### PR TITLE
Use Read / Write for files to allow arbitrary PDF sources

### DIFF
--- a/src/creator.rs
+++ b/src/creator.rs
@@ -81,6 +81,5 @@ fn create_document() {
 	doc.trailer.set("Info", Reference(info_id));
 	doc.compress();
 
-	let mut file = ::std::fs::File::create("test_1_create.pdf").unwrap();
-	doc.save(&mut file).unwrap();
+	doc.save("test_1_create.pdf").unwrap();
 }

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -82,4 +82,16 @@ fn create_document() {
 	doc.compress();
 
 	doc.save("test_1_create.pdf").unwrap();
+
+	// test load_from() and save_to()
+	use std::fs::File;
+	use std::io::Cursor;
+
+	let in_file = File::open("test_1_create.pdf").unwrap();
+	let mut in_doc = Document::load_from(in_file).unwrap();
+
+	let out_buf = Vec::<u8>::new();
+	let mut memory_cursor = Cursor::new(out_buf);
+	in_doc.save_to(&mut memory_cursor).unwrap();
+	assert!(!memory_cursor.get_ref().is_empty());
 }

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -80,5 +80,7 @@ fn create_document() {
 	doc.trailer.set("Root", Reference(catalog_id));
 	doc.trailer.set("Info", Reference(info_id));
 	doc.compress();
-	doc.save("test_1_create.pdf").unwrap();
+
+	let mut file = ::std::fs::File::create("test_1_create.pdf").unwrap();
+	doc.save(&mut file).unwrap();
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -27,6 +27,7 @@ pub struct Document {
 }
 
 impl Document {
+
 	/// Create new PDF document.
 	pub fn new() -> Document {
 		Document {
@@ -37,6 +38,13 @@ impl Document {
 			streams: BTreeMap::new(),
 			max_id: 0,
 		}
+	}
+
+	/// Create new PDF document.
+	pub fn with_version<S: Into<String>>(version: S) -> Document {
+		let mut document = Self::new();
+		document.version = version.into();
+		document
 	}
 
 	/// Get object by object id, will recursively dereference a referenced object.

--- a/src/document.rs
+++ b/src/document.rs
@@ -5,6 +5,7 @@ use object_stream::ObjectStream;
 use byref::ByRef;
 
 /// PDF document.
+#[derive(Debug)]
 pub struct Document {
 	/// The version of the PDF specification to which the file conforms.
 	pub version: String,

--- a/src/object_stream.rs
+++ b/src/object_stream.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use super::{Object, ObjectId, Stream};
 use super::parser;
 
+#[derive(Debug)]
 pub struct ObjectStream {
 	pub objects: Vec<(ObjectId, Object)>,
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,8 +1,6 @@
 use pom::{Input, DataInput};
 use std::cmp;
-use std::fs::File;
 use std::io::{Result, Read, Error, ErrorKind};
-use std::path::Path;
 
 use super::{Document, Object, ObjectId};
 use super::parser;
@@ -10,11 +8,12 @@ use xref::XrefEntry;
 use object_stream::ObjectStream;
 
 impl Document {
+
 	/// Load PDF document from specified file path.
-	pub fn load<P: AsRef<Path>>(path: P) -> Result<Document> {
-		let mut file = File::open(path)?;
-		let mut buffer = Vec::with_capacity(file.metadata()?.len() as usize);
-		file.read_to_end(&mut buffer)?;
+	pub fn load<R: Read>(mut source: R) -> Result<Document> {
+
+		let mut buffer = Vec::new();
+		source.read_to_end(&mut buffer)?;
 
 		let mut reader = Reader {
 			buffer: buffer,
@@ -160,7 +159,11 @@ impl Reader {
 
 #[test]
 fn load_document() {
-	let mut doc = Document::load("assets/example.pdf").unwrap();
+
+	use std::fs::File;
+	let file = File::open("assets/example.pdf").unwrap();
+	let mut doc = Document::load(file).unwrap();
 	assert_eq!(doc.version, "1.5");
-	doc.save("test_2_load.pdf").unwrap();
+	let mut file = File::create("test_2_load.pdf").unwrap();
+	doc.save(&mut file).unwrap();
 }

--- a/src/xref.rs
+++ b/src/xref.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::io::{Cursor, Read};
 use super::{Dictionary, Stream};
 
+#[derive(Debug)]
 pub struct Xref {
 	/// Entries for indirect object.
 	pub entries: BTreeMap<u32, XrefEntry>,

--- a/tests/modify.rs
+++ b/tests/modify.rs
@@ -2,11 +2,9 @@ extern crate lopdf;
 
 use lopdf::{Document, Object, StringFormat};
 use std::io::Result;
-use std::fs::File;
 
 fn modify_text() -> Result<Document> {
-	let file = File::open("assets/example.pdf").unwrap();
-	let mut doc = Document::load(file)?;
+	let mut doc = Document::load("assets/example.pdf")?;
 	doc.version = "1.4".to_string();
 	if let Some(content_stream) = doc.objects.get_mut(&(4, 0)) {
 		match *content_stream {
@@ -21,8 +19,7 @@ fn modify_text() -> Result<Document> {
 		}
 	}
 
-	let mut file = File::create("test_3_modify.pdf")?;
-	doc.save(&mut file)?;
+	doc.save("test_3_modify.pdf")?;
 	Ok(doc)
 }
 

--- a/tests/modify.rs
+++ b/tests/modify.rs
@@ -2,9 +2,11 @@ extern crate lopdf;
 
 use lopdf::{Document, Object, StringFormat};
 use std::io::Result;
+use std::fs::File;
 
 fn modify_text() -> Result<Document> {
-	let mut doc = Document::load("assets/example.pdf")?;
+	let file = File::open("assets/example.pdf").unwrap();
+	let mut doc = Document::load(file)?;
 	doc.version = "1.4".to_string();
 	if let Some(content_stream) = doc.objects.get_mut(&(4, 0)) {
 		match *content_stream {
@@ -18,7 +20,9 @@ fn modify_text() -> Result<Document> {
 			_ => ()
 		}
 	}
-	doc.save("test_3_modify.pdf")?;
+
+	let mut file = File::create("test_3_modify.pdf")?;
+	doc.save(&mut file)?;
 	Ok(doc)
 }
 


### PR DESCRIPTION
I've refactored the API for saving and loading a bit, adding `save_to()` and `load_from()` to allow reading / writing PDF from arbitrary sources, not only files. This does not break the current API `save()` and `load()` still work.

I also added Debug for `lopdf::Document`, because the unwrap function needs this.