### PR TITLE
Changed document.get_object() to search in objects, not in XRef table

### DIFF
--- a/tests/modify.rs
+++ b/tests/modify.rs
@@ -31,8 +31,16 @@ fn test_modify() {
 
 #[test]
 fn test_get_object() {
+	use lopdf::Dictionary as LoDictionary;
+	use lopdf::Stream as LoStream;
+	use self::Object;
+
 	let mut doc = Document::new();
 	let id = doc.add_object(Object::String("test".as_bytes().to_vec(), StringFormat::Literal));
+	let id2 = doc.add_object(Object::Stream(LoStream::new(LoDictionary::new(), "stream".as_bytes().to_vec())));
+
 	println!("{:?}", id);
+	println!("{:?}", id2);
 	assert!(doc.get_object(id).is_some());
+	assert!(doc.get_object(id2).is_some());
 }

--- a/tests/modify.rs
+++ b/tests/modify.rs
@@ -28,3 +28,11 @@ fn modify_text() -> Result<Document> {
 fn test_modify() {
 	assert_eq!(modify_text().is_ok(), true);
 }
+
+#[test]
+fn test_get_object() {
+	let mut doc = Document::new();
+	let id = doc.add_object(Object::String("test".as_bytes().to_vec(), StringFormat::Literal));
+	println!("{:?}", id);
+	assert!(doc.get_object(id).is_some());
+}


### PR DESCRIPTION
I don't know why, but for some reason, the Document::get_object() was searching in the XRef table. So if I added an object, then wanted to get it again, the function couldn't find it (since it was added to the objects, not to the xref table).

For some reason it seems that `Document.streams` and `Document.reference_table` aren't used, but I'm not sure about that. If you add an object (even a stream), it gets dumped into the objects. If you want to make a function that specifically searches the XRef table, I'd rather call it `get_xref` or something like that.

An alternative way would be to add every object to the `reference_table`, but what's the point of that?