### PR TITLE
Added optional allows_compression for Stream object

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -8,11 +8,18 @@ pub type ObjectId = (u32, u16);
 #[derive(Debug, Clone)]
 pub struct Dictionary(LinkedHashMap<String, Object>);
 
-/// Stream Object.
+/// Stream object
+/// Warning - all streams must be indirect objects, while 
+/// the stream dictionary may be a direct object
 #[derive(Debug, Clone)]
 pub struct Stream {
+    /// Associated stream dictionary
 	pub dict: Dictionary,
+    /// Contents of the stream in bytes
 	pub content: Vec<u8>,
+    /// Can the stream be compressed by the `Document::compress()` function?
+    /// Font streams may not be compressed, for example
+    pub allows_compression: bool,
 }
 
 /// Basic PDF object types defined in an enum.
@@ -241,8 +248,17 @@ impl Stream {
 		Stream {
 			dict: dict,
 			content: content,
+            allows_compression: true,
 		}
 	}
+
+    /// Default is that the stream may be compressed. On font streams, 
+    /// set this to false, otherwise the font will be corrupt
+    #[inline]
+    pub fn with_compression(mut self, allows_compression: bool) -> Stream {
+        self.allows_compression = allows_compression;
+        self
+    }
 
 	pub fn filter(&self) -> Option<String> {
 		if let Some(filter) = self.dict.get("Filter") {

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -19,7 +19,11 @@ impl Document {
 	pub fn compress(&mut self) {
 		for (_, object) in self.objects.iter_mut() {
 			match *object {
-				Object::Stream(ref mut stream) => stream.compress(),
+				Object::Stream(ref mut stream) => {
+                    if stream.allows_compression {
+                        stream.compress()
+                    }
+                },
 				_ => ()
 			}
 		}


### PR DESCRIPTION
For some reason, some streams in a PDF may not be compressed, while others do - such as font streams. If you compress a stream that contains an embedded font, Adobe Reader will tell you that the font is "corrupt" while other readers don't even give any error message. The text will still be selectable, but it won't show (which led me to [this](https://stackoverflow.com/questions/42754574/pdf-doesnt-show-characters-even-though-font-is-embedded-and-tounicode-is-prese)).

The problem is caused by the `Document::compress()` method ([link](https://docs.rs/lopdf/0.9.0/lopdf/struct.Document.html#method.compress)). It simply compresses every stream. Which is good for things like images, ICC profiles, etc., but embedded fonts may not be compressed (for whatever reason).

This change may break current code IF the code did not create the stream via the `Stream::new()` function. 