### PR TITLE
Use itoa and dtoa to improve writing performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ pom = "1.0.1"
 chrono = "0.3.0"
 flate2 = "0.2.14"
 linked-hash-map = "0.3.0"
+dtoa = "0.4.1"
+itoa = "0.3.1"
 
 [badges]
 travis-ci = { repository = "J-F-Liu/lopdf" }

--- a/benches/datetime.rs
+++ b/benches/datetime.rs
@@ -17,3 +17,39 @@ fn create_and_parse_datetime(b: &mut Bencher) {
 		assert_eq!(time2, Some(time));
 	});
 }
+
+// new (with itoa):       4,660 ns/iter (+/- 121)
+// old (with formatting): 4,899 ns/iter (+/- 3,581)
+#[bench]
+fn bench_integer_write(b: &mut test::Bencher) {
+    b.iter(||{
+        let mut buf = ::std::io::Cursor::new(Vec::<u8>::new());
+        let mut doc = lopdf::Document::new();
+        doc.add_object(Object::Integer(5));
+        doc.save_to(&mut buf).unwrap();
+    })
+}
+
+// new (with dtoa):       4,801 ns/iter (+/- 183)
+// old (with formatting): 5,007 ns/iter (+/- 211)
+#[bench]
+fn bench_floating_point_write(b: &mut test::Bencher) {
+    b.iter(||{
+        let mut buf = ::std::io::Cursor::new(Vec::<u8>::new());
+        let mut doc = lopdf::Document::new();
+        doc.add_object(Object::Real(5.0));
+        doc.save_to(&mut buf).unwrap();
+    })
+}
+
+// new (with true / false): 4,547 ns/iter (+/- 70)
+// old (with formatting):   4,598 ns/iter (+/- 194)
+#[bench]
+fn bench_boolean_write(b: &mut test::Bencher) {
+    b.iter(||{
+        let mut buf = ::std::io::Cursor::new(Vec::<u8>::new());
+        let mut doc = lopdf::Document::new();
+        doc.add_object(Object::Boolean(false));
+        doc.save_to(&mut buf).unwrap();
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ extern crate pom;
 extern crate chrono;
 extern crate flate2;
 extern crate linked_hash_map;
+extern crate dtoa;
+extern crate itoa;
 
 mod object;
 mod datetime;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -21,7 +21,7 @@ impl Document {
 	pub fn save_to<W: Write + Seek>(&mut self, target: &mut W) -> Result <()> {
 		self.save_internal(target)
 	}
-	
+
 	fn save_internal<W: Write + Seek>(&mut self, target: &mut W) -> Result<()> {
 		let mut xref = Xref::new(self.max_id + 1);
 		target.write_all(format!("%PDF-{}\n", self.version).as_bytes())?;
@@ -117,12 +117,15 @@ impl Writer {
 	}
 
 	pub fn write_object<'a>(file: &mut Write, object: &'a Object) -> Result<()> {
+        use dtoa;
+        use itoa;
+
 		match *object {
 			Null => file.write_all(b"null"),
-			Boolean(ref value) => file.write_all(format!("{}", value).as_bytes()),
-			Integer(ref value) => file.write_all(format!("{}", value).as_bytes()),
-			Real(ref value) => file.write_all(format!("{}", value).as_bytes()),
-			Name(ref name) => Writer::write_name(file, name),
+			Boolean(ref value) => if *value { file.write_all(b"true") } else { file.write_all(b"false") },
+            Integer(ref value) => { let _ = itoa::write(file, *value); Ok(()) },
+            Real(ref value) => { let _ = dtoa::write(file, *value); Ok(()) },
+            Name(ref name) => Writer::write_name(file, name),
 			String(ref text, ref format) => Writer::write_string(file, text, format),
 			Array(ref array) => Writer::write_array(file, array),
 			Object::Dictionary(ref dict) => Writer::write_dictionary(file, dict),


### PR DESCRIPTION
This commit is only performance-related.

On my flamegraph for my current application, I noticed that `lopdf::writer::write_object` uses almost 80% of it's time only formatting numbers, because of the default Rust formatter. Since I have PDFs with lots of data points (i.e. thousands of floating point numbers), this function alone used roughly 0.82% of the time on the flame graph and spends most of its time only formatting numbers:

![lopdf_flame](https://user-images.githubusercontent.com/12084016/29490829-a439ffb6-8548-11e7-86ac-bbfeb83b7345.png)

So I asked others what an optimized way of doing this would be. The answer was to either use the `write!()` macro instead of `format!()` or to use the `itoa` and `dtoa` crates. Since the latter seem to be faster, I chose them.

Result: The CPU time is down to 0.02%. This might be due to bad measurement on my part, but I think it's logical that if you don't have to continouusly call the formatting function just to write a number, the function will be faster:

![lopdf_new](https://user-images.githubusercontent.com/12084016/29490854-7aaae362-8549-11e7-8437-49cb9ad3d6b1.png)

If you can, please release a new version after the merge so I can update `printpdf` to use that and update the dependencies.