### PR TITLE
Derive Clone for lopdf::Document

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -4,7 +4,7 @@ use super::{Object, ObjectId, Dictionary};
 use byref::ByRef;
 
 /// PDF document.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Document {
 	/// The version of the PDF specification to which the file conforms.
 	pub version: String,

--- a/src/xref.rs
+++ b/src/xref.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::io::{Cursor, Read};
 use super::{Dictionary, Stream};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Xref {
 	/// Entries for indirect object.
 	pub entries: BTreeMap<u32, XrefEntry>,


### PR DESCRIPTION
I need this so I can clone a `printpdf::PdfDocument` when needed. This enables me to save one document to multiple files.

If you merge this, please also publish a new version on crates.io so I can let printpdf depend on that version.