### PR TITLE
Remove the Seek bound on Document::save_to

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lopdf"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Junfeng Liu <china.liujunfeng@gmail.com>"]
 homepage = "https://github.com/J-F-Liu/lopdf"
 documentation = "https://docs.rs/crate/lopdf/"


### PR DESCRIPTION
It was only used to obtain the current position, which this library can count itself. This enables saving to `&mut Vec<u8>`. This also fixed incorrect offsets if the target did not start empty.