### PR TITLE
add `get_object_mut`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lopdf"
-version = "0.14.1"
+version = "0.14.2"
 authors = ["Junfeng Liu <china.liujunfeng@gmail.com>"]
 homepage = "https://github.com/J-F-Liu/lopdf"
 documentation = "https://docs.rs/crate/lopdf/"

--- a/src/document.rs
+++ b/src/document.rs
@@ -54,6 +54,21 @@ impl Document {
 		return None;
 	}
 
+	/// Get mutable reference to object by object id, will recursively dereference a referenced object.
+	pub fn get_object_mut(&mut self, id: ObjectId) -> Option<&mut Object> {
+		unsafe {
+			let s = self as *mut Self;
+			if let Some(object) = (*s).objects.get_mut(&id) {
+				if let Some(id) = object.as_reference() {
+					return (*s).get_object_mut(id);
+				} else {
+					return Some(object);
+				}
+			}
+			None
+		}
+	}
+
 	/// Traverse objects from trailer recursively, return all referenced object IDs.
 	pub fn traverse_objects<A: Fn(&mut Object) -> ()>(&mut self, action: A) -> Vec<ObjectId> {
 		fn traverse_array<A: Fn(&mut Object) -> ()>(array: &mut Vec<Object>, action: &A, refs: &mut Vec<ObjectId>) {


### PR DESCRIPTION
Adding `get_object_mut` to `Document` so we can have the recursive dereferencing of the object which we do not have using the `objects` property directly.

I had to make a raw pointer to the `Document` so that we can have multiple mutable references in the function. It should not make any problem as we don't mutate the struct inside this function.

We could probably write it without any `unsafe` when NLL is stable.