### PR TITLE
Make chrono crate optional (use `time` directly)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
 language: rust
 
+cache: cargo
+
 rust:
   - stable
   - beta
   - nightly
+
+script:
+  - cargo clean
+  - cargo check --verbose --no-default-features
+  - cargo check --verbose --features="chrono_time"
+  - cargo test --verbose
+  - cargo test --verbose --examples
+
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,17 @@ description = "A Rust library for PDF document manipulation."
 
 [dependencies]
 pom = "1.1.0"
-chrono = "0.3.0"
+time = "0.1.40"
 flate2 = "0.2.14"
 linked-hash-map = "0.3.0"
 dtoa = "0.4.1"
 itoa = "0.3.1"
 encoding = "0.2"
+chrono = { version = "0.3.0", optional = true }
+
+[features]
+default = ["chrono_time"]
+chrono_time = ["chrono"]
 
 [badges]
 travis-ci = { repository = "J-F-Liu/lopdf" }

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -66,13 +66,13 @@ impl Document {
 fn create_document() {
 	use super::Stream;
 	use super::content::*;
-	use chrono::prelude::Local;
+	use time::now;
 
 	let mut doc = Document::with_version("1.5");
 	let info_id = doc.add_object(dictionary! {
 		"Title" => Object::string_literal("Create PDF document example"),
 		"Creator" => Object::string_literal("https://crates.io/crates/lopdf"),
-		"CreationDate" => Local::now(),
+		"CreationDate" => now(),
 	});
 	let pages_id = doc.new_object_id();
 	let font_id = doc.add_object(dictionary! {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,44 +1,112 @@
+#[cfg(feature = "chrono_time")]
 use chrono::prelude::*;
+#[cfg(not(feature = "chrono_time"))]
+use time::strptime;
+use time::{Tm, strftime};
 use super::Object;
 
+const TIME_FMT_DECODE_STR: &str = "%Y%m%d%H%M%S%z";
+
+#[cfg(feature = "chrono_time")]
 impl From<DateTime<Local>> for Object {
 	fn from(date: DateTime<Local>) -> Self {
-		let mut bytes = date.format("D:%Y%m%d%H%M%S%:z'").to_string().into_bytes();
-		let mut index = bytes.len();
-		while let Some(last) = bytes[..index].last_mut() {
-			if *last == b':' {
-				*last = b'\'';
-				break;
-			}
-			index -= 1;
-		}
-		Object::string_literal(bytes)
+		let mut timezone_str = date.format("D:%Y%m%d%H%M%S%:z'").to_string().into_bytes();
+		convert_utc_offset(&mut timezone_str);
+		Object::string_literal(timezone_str)
 	}
 }
 
+// Find the last `:` and turn it into an `'` to account for PDF weirdness
+fn convert_utc_offset(bytes: &mut [u8]) {
+	let mut index = bytes.len();
+	while let Some(last) = bytes[..index].last_mut() {
+		if *last == b':' {
+			*last = b'\'';
+			break;
+		}
+		index -= 1;
+	}
+}
+
+#[cfg(feature = "chrono_time")]
 impl From<DateTime<UTC>> for Object {
 	fn from(date: DateTime<UTC>) -> Self {
 		Object::string_literal(date.format("D:%Y%m%d%H%M%SZ").to_string())
 	}
 }
 
-impl Object {
-	pub fn as_datetime(&self) -> Option<DateTime<Local>> {
-		match *self {
-			Object::String(ref bytes, _) => {
-				let text = String::from_utf8(
-					bytes.iter().filter(|b| ![b'D', b':', b'\''].contains(b)).map(|b|*b).collect()
-				).unwrap();
-				Local.datetime_from_str(&text, "%Y%m%d%H%M%S%z").ok()
-			},
-			_ => None
-		}
+impl From<Tm> for Object {
+	fn from(date: Tm) -> Self {
+		// can only fail if the TIME_FMT_ENCODE_STR would be invalid
+		Object::string_literal(if date.tm_utcoff != 0 {
+			// D:%Y%m%d%H%M%S:%z'
+			//
+			// UTC offset in the form +HHMM or -HHMM (empty string if the the object is naive).
+			let timezone = strftime("%z", &date).unwrap();
+			let timezone_str_start = strftime("%Y%m%d%H%M%S", &date).unwrap();
+
+			let mut timezone_str = format!("D:{}:{}'", timezone_str_start, timezone).into_bytes();
+			convert_utc_offset(&mut timezone_str);
+			timezone_str
+		} else {
+			format!("D:{}", strftime("%Y%m%d%H%M%SZ", &date).unwrap()).into_bytes()
+		})
 	}
 }
 
+impl Object {
+
+	// Parses the `D`, `:` and `\` out of a `Object::String` to parse the date time
+	fn datetime_string(&self) -> Option<String> {
+		if let Object::String(ref bytes, _) = self {
+			String::from_utf8(bytes.iter().filter(|b| {
+				![b'D', b':', b'\''].contains(b)
+			}).map(|b|*b).collect()).ok()
+		} else {
+			None
+		}
+	}
+
+	#[cfg(feature = "chrono_time")]
+	pub fn as_datetime(&self) -> Option<DateTime<Local>> {
+		let text = self.datetime_string()?;
+		Local.datetime_from_str(&text, TIME_FMT_DECODE_STR).ok()
+	}
+
+	/// WARNING: `tm_wday` (weekday), `tm_yday` (day index in year), `tm_isdst`
+	/// (daylight saving time) and `tm_nsec` (nanoseconds of the date from 1970)
+	/// are set to 0 since they aren't available in the PDF time format. They could,
+	/// however, be calculated manually
+	#[cfg(not(feature = "chrono_time"))]
+	pub fn as_datetime(&self) -> Option<Tm> {
+		let text = self.datetime_string()?;
+		strptime(&text, TIME_FMT_DECODE_STR).ok()
+	}
+}
+
+#[cfg(feature = "chrono_time")]
 #[test]
 fn parse_datetime() {
 	let time = Local::now().with_nanosecond(0).unwrap();
+	let text: Object = time.into();
+	let time2 = text.as_datetime();
+	assert_eq!(time2, Some(time));
+}
+
+#[cfg(not(feature = "chrono_time"))]
+#[test]
+fn parse_datetime() {
+
+	// Tm-based: Ignore tm_wday, tm_yday, tm_isdst and tm_nsec
+	// - not important in the date parsing
+	let time = Tm {
+		tm_wday: 0,
+		tm_yday: 0,
+		tm_isdst: 0,
+		tm_nsec: 0,
+		.. ::time::now()
+	};
+
 	let text: Object = time.into();
 	let time2 = text.as_datetime();
 	assert_eq!(time2, Some(time));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "chrono_time")]
 extern crate chrono;
 extern crate dtoa;
 extern crate encoding;
@@ -5,6 +6,7 @@ extern crate flate2;
 extern crate itoa;
 extern crate linked_hash_map;
 extern crate pom;
+extern crate time;
 
 #[macro_use]
 mod object;

--- a/src/xobject.rs
+++ b/src/xobject.rs
@@ -1,6 +1,6 @@
 use super::content::*;
 use super::Object::*;
-use super::{Dictionary, Document, Object, Stream};
+use super::{Dictionary, Document, Stream};
 
 pub fn form(boundingbox: Vec<f64>, matrix: Vec<f64>, content: Vec<u8>) -> Stream {
 	let mut dict = Dictionary::new();


### PR DESCRIPTION
The chrono crate is currently only used for providing a few impls for parsing PDF date objects. However, `chrono` is a pretty heavy dependency if it is only used for printing the date. The `time` crate (which `chrono` itself depends on anyways) is more than enough to do that job (and if it's absolutely necessary to parse date formats, this can also be done with external libraries, there is no need for `lopdf` to depend on `chrono`). `chrono`, however, brings in num-traits, num-*, etc. - very generics-heavy crates that aren't strictly needed for `lopdf` to work.

Compile time of lopdf:

- `chrono` on:  19.87s
- `chrono` off: 15.57s

By default this feature is **on**, to not break any code, being backwards-compatible. However, since in theory someone could have `default-features = false` in his Cargo.toml, this is still a "breaking change" in terms of semver.

The only drawback is that with time parsing, the weekday and year day isn't preserved / calculated (`strptime` doesn't auto-calculate those fields). But for crates that don't need this behaviour, this can be a significant improvement in terms of compile time.

This PR brings the dependency count from 30 to 19 dependencies (11 dependencies removed). If this is merged, I'd be happy if a new version would be released.