### PR TITLE
Make sure Stream.start_position is relative to the whole file.

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -366,6 +366,10 @@ impl Stream {
 		}
 	}
 
+	pub fn offset_position(&mut self, file_offset: usize) {
+		self.start_position = self.start_position.and_then(|sp| sp.checked_add(file_offset))
+	}
+
 	/// Default is that the stream may be compressed. On font streams,
 	/// set this to false, otherwise the font will be corrupt
 	#[inline]


### PR DESCRIPTION
I noticed this while writing the nom parser.

This is to make sure this code works in reader.rs: 
```rust
if let Some(start) = stream.start_position {
    let end = start + length as usize;
    stream.set_content(self.buffer[start..end].to_vec());
}
```