### PR TITLE
Nom 5 parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ script:
   - cargo clean
   - cargo check --verbose --no-default-features
   - cargo check --verbose --features="chrono_time"
+  - cargo check --verbose --features="nom_parser"
   - cargo test --verbose
+  - cargo test --verbose --features="nom_parser"
   - cargo test --verbose --examples
 
 matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,13 @@ image = { version = "0.20.0", optional = true }
 chrono = { version = "0.3.0", optional = true }
 log = "0.4.6"
 rayon = "1.0"
+nom = { version = "5.0.0-alpha2", optional = true }
 
 [features]
 default = ["chrono_time"]
 chrono_time = ["chrono"]
 embed_image = ["image"]
+nom_parser = ["nom"]
 
 [badges]
 travis-ci = { repository = "J-F-Liu/lopdf" }

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,0 +1,16 @@
+#![feature(test)]
+use std::fs::File;
+use std::io::{Cursor, Read};
+
+extern crate test;
+use lopdf::Document;
+
+#[bench]
+fn bench_load(b: &mut test::test::Bencher) {
+	let mut buffer = Vec::new();
+	File::open("assets/example.pdf").unwrap().read_to_end(&mut buffer).unwrap();
+
+	b.iter(|| {
+		Document::load_from(Cursor::new(&buffer)).unwrap();
+	})
+}

--- a/src/content.rs
+++ b/src/content.rs
@@ -1,6 +1,5 @@
 use super::parser;
 use super::{Object, Stream};
-use pom::Result;
 use std::io::{self, Write};
 use crate::writer::Writer;
 
@@ -40,14 +39,14 @@ impl Content {
 	}
 
 	/// Decode content operations.
-	pub fn decode(data: &[u8]) -> Result<Content> {
-		parser::content().parse(data)
+	pub fn decode(data: &[u8]) -> Option<Content> {
+		parser::content(data)
 	}
 }
 
 impl Stream {
 	/// Decode content after decoding all stream filters.
-	pub fn decode_content(&self) -> Result<Content> {
+	pub fn decode_content(&self) -> Option<Content> {
 		Content::decode(&self.content)
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod content;
 mod creator;
 mod encodings;
 mod filters;
+#[cfg_attr(feature = "nom_parser", path = "nom_parser.rs")]
 mod parser;
 mod processor;
 mod reader;

--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -10,7 +10,7 @@ use nom::branch::alt;
 use nom::error::{ParseError, ErrorKind};
 use nom::multi::{many0, many0_count, fold_many0, fold_many1};
 use nom::combinator::{opt, map, map_res, map_opt};
-use nom::character::complete::one_of;
+use nom::character::complete::{digit0, digit1, one_of};
 use nom::sequence::{delimited, pair, preceded, terminated, tuple, separated_pair};
 
 // Change this to something else that implements ParseError to get a
@@ -70,7 +70,7 @@ fn space(input: &[u8]) -> NomResult<()> {
 fn integer(input: &[u8]) -> NomResult<i64> {
 	opt(one_of("+-"))(input)
 		.and_then(|(i, sign)| {
-			map_res(take_while1(|c: u8| c.is_ascii_digit()),
+			map_res(digit1,
 					|m: &[u8]| {
 						let len = sign.map(|_| 1).unwrap_or(0) + m.len();
 						i64::from_str(str::from_utf8(&input[..len]).unwrap())
@@ -80,11 +80,11 @@ fn integer(input: &[u8]) -> NomResult<i64> {
 
 fn real(input: &[u8]) -> NomResult<f64> {
 	let (i, _) = pair(opt(one_of("+-")), alt((
-		map(tuple((take_while1(|c: u8| c.is_ascii_digit()),
+		map(tuple((digit1,
 				   tag(b"."),
-				   take_while(|c: u8| c.is_ascii_digit()))),
+				   digit0)),
 			|_| ()),
-		map(pair(tag(b"."), take_while1(|c: u8| c.is_ascii_digit())),
+		map(pair(tag(b"."), digit1),
 			|_| ())
 	)))(input)?;
 
@@ -235,8 +235,7 @@ fn stream<'a>(input: &'a [u8], reader: &Reader) -> NomResult<'a, Object> {
 }
 
 fn unsigned_int<I: FromStr>(input: &[u8]) -> NomResult<I> {
-	map_res(take_while1(|c: u8| c.is_ascii_digit()),
-			|digits| I::from_str(str::from_utf8(digits).unwrap()))(input)
+	map_res(digit1,	|digits| I::from_str(str::from_utf8(digits).unwrap()))(input)
 }
 
 fn object_id(input: &[u8]) -> NomResult<ObjectId> {

--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -69,14 +69,10 @@ fn space(input: &[u8]) -> NomResult<()> {
 }
 
 fn integer(input: &[u8]) -> NomResult<i64> {
-	opt(one_of("+-"))(input)
-		.and_then(|(i, sign)| {
-			map_res(digit1,
-					|m: &[u8]| {
-						let len = sign.map(|_| 1).unwrap_or(0) + m.len();
-						i64::from_str(str::from_utf8(&input[..len]).unwrap())
-					})(i)
-		})
+	let (i, _) = pair(opt(one_of("+-")), digit1)(input)?;
+
+	let int_input = &input[..input.len()-i.len()];
+	convert_result(i64::from_str(str::from_utf8(int_input).unwrap()), i, ErrorKind::Digit)
 }
 
 fn real(input: &[u8]) -> NomResult<f64> {

--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -1,0 +1,285 @@
+use super::{Dictionary, Object, ObjectId, Stream, StringFormat};
+use crate::content::*;
+use crate::reader::Reader;
+use crate::xref::*;
+use pom::char_class::{alpha, hex_digit, multispace, oct_digit};
+use pom::parser::*;
+use std::str::{self, FromStr};
+
+fn eol<'a>() -> Parser<'a, u8, u8> {
+	(sym(b'\r') * sym(b'\n')) | sym(b'\n') | sym(b'\r')
+}
+
+fn comment<'a>() -> Parser<'a, u8, ()> {
+	sym(b'%') * none_of(b"\r\n").repeat(0..) * eol().discard()
+}
+
+fn white_space<'a>() -> Parser<'a, u8, ()> {
+	one_of(b" \t\n\r\0\x0C").repeat(0..).discard()
+}
+
+fn space<'a>() -> Parser<'a, u8, ()> {
+	(one_of(b" \t\n\r\0\x0C").repeat(1..).discard() | comment()).repeat(0..).discard()
+}
+
+fn integer<'a>() -> Parser<'a, u8, i64> {
+	let number = one_of(b"+-").opt() + one_of(b"0123456789").repeat(1..);
+	number.collect().convert(str::from_utf8).convert(|s| i64::from_str(&s))
+}
+
+fn real<'a>() -> Parser<'a, u8, f64> {
+	let number = one_of(b"+-").opt() + ((one_of(b"0123456789").repeat(1..) * sym(b'.') - one_of(b"0123456789").repeat(0..)) | (sym(b'.') - one_of(b"0123456789").repeat(1..)));
+	number.collect().convert(str::from_utf8).convert(|s| f64::from_str(&s))
+}
+
+fn hex_char<'a>() -> Parser<'a, u8, u8> {
+	let number = is_a(hex_digit).repeat(2);
+	number.collect().convert(|v| u8::from_str_radix(str::from_utf8(v).unwrap(), 16))
+}
+
+fn oct_char<'a>() -> Parser<'a, u8, u8> {
+	let number = is_a(oct_digit).repeat(1..4);
+	number.collect().convert(|v| u8::from_str_radix(str::from_utf8(v).unwrap(), 8))
+}
+
+fn name<'a>() -> Parser<'a, u8, Vec<u8>> {
+	sym(b'/') * (none_of(b" \t\n\r\x0C()<>[]{}/%#") | (sym(b'#') * hex_char())).repeat(0..)
+}
+
+fn escape_sequence<'a>() -> Parser<'a, u8, Vec<u8>> {
+	sym(b'\\')
+		* (sym(b'\\').map(|_| vec![b'\\'])
+			| sym(b'(').map(|_| vec![b'('])
+			| sym(b')').map(|_| vec![b')'])
+			| sym(b'n').map(|_| vec![b'\n'])
+			| sym(b'r').map(|_| vec![b'\r'])
+			| sym(b't').map(|_| vec![b'\t'])
+			| sym(b'b').map(|_| vec![b'\x08'])
+			| sym(b'f').map(|_| vec![b'\x0C'])
+			| oct_char().map(|c| vec![c])
+			| eol().map(|_| vec![])
+			| empty().map(|_| vec![]))
+}
+
+fn nested_literal_string<'a>() -> Parser<'a, u8, Vec<u8>> {
+	sym(b'(')
+		* (none_of(b"\\()").repeat(1..) | escape_sequence() | call(nested_literal_string)).repeat(0..).map(|segments| {
+			let mut bytes = segments.into_iter().fold(vec![b'('], |mut bytes, mut segment| {
+				bytes.append(&mut segment);
+				bytes
+			});
+			bytes.push(b')');
+			bytes
+		}) - sym(b')')
+}
+
+fn literal_string<'a>() -> Parser<'a, u8, Vec<u8>> {
+	sym(b'(')
+		* (none_of(b"\\()").repeat(1..) | escape_sequence() | nested_literal_string())
+			.repeat(0..)
+			.map(|segments| segments.concat())
+		- sym(b')')
+}
+
+fn hexadecimal_string<'a>() -> Parser<'a, u8, Vec<u8>> {
+	sym(b'<') * (white_space() * hex_char()).repeat(0..) - (white_space() * sym(b'>'))
+}
+
+fn array<'a>() -> Parser<'a, u8, Vec<Object>> {
+	sym(b'[') * space() * call(direct_object).repeat(0..) - sym(b']')
+}
+
+fn dictionary<'a>() -> Parser<'a, u8, Dictionary> {
+	let entry = name() - space() + call(direct_object);
+	let entries = seq(b"<<") * space() * entry.repeat(0..) - seq(b">>");
+	entries.map(|entries| {
+		entries.into_iter().fold(Dictionary::new(), |mut dict: Dictionary, (key, value)| {
+			dict.set(key, value);
+			dict
+		})
+	})
+}
+
+fn stream(reader: &Reader) -> Parser<u8, Stream> {
+	(dictionary() - space() - seq(b"stream") - eol())
+		>> move |dict: Dictionary| {
+			if let Some(length) = dict.get(b"Length").and_then(|value| {
+				if let Some(id) = value.as_reference() {
+					return reader.get_object(id).and_then(|value| value.as_i64());
+				}
+				value.as_i64()
+			}) {
+				let stream = take(length as usize) - eol().opt() - seq(b"endstream").expect("endstream");
+				stream.map(move |data| Stream::new(dict.clone(), data.to_vec()))
+			} else {
+				empty().pos().map(move |pos| Stream::with_position(dict.clone(), pos))
+			}
+		}
+}
+
+fn object_id<'a>() -> Parser<'a, u8, ObjectId> {
+	let id = one_of(b"0123456789").repeat(1..).convert(|v| u32::from_str(&str::from_utf8(&v).unwrap()));
+	let gen = one_of(b"0123456789").repeat(1..).convert(|v| u16::from_str(&str::from_utf8(&v).unwrap()));
+	id - space() + gen - space()
+}
+
+pub fn direct_object<'a>() -> Parser<'a, u8, Object> {
+	(seq(b"null").map(|_| Object::Null)
+		| seq(b"true").map(|_| Object::Boolean(true))
+		| seq(b"false").map(|_| Object::Boolean(false))
+		| (object_id().map(Object::Reference) - sym(b'R'))
+		| real().map(Object::Real)
+		| integer().map(Object::Integer)
+		| name().map(Object::Name)
+		| literal_string().map(Object::string_literal)
+		| hexadecimal_string().map(|bytes| Object::String(bytes, StringFormat::Hexadecimal))
+		| array().map(Object::Array)
+		| dictionary().map(Object::Dictionary))
+		- space()
+}
+
+fn object(reader: &Reader) -> Parser<u8, Object> {
+	(seq(b"null").map(|_| Object::Null)
+		| seq(b"true").map(|_| Object::Boolean(true))
+		| seq(b"false").map(|_| Object::Boolean(false))
+		| (object_id().map(Object::Reference) - sym(b'R'))
+		| real().map(Object::Real)
+		| integer().map(Object::Integer)
+		| name().map(Object::Name)
+		| literal_string().map(Object::string_literal)
+		| hexadecimal_string().map(|bytes| Object::String(bytes, StringFormat::Hexadecimal))
+		| array().map(Object::Array)
+		| stream(reader).map(Object::Stream)
+		| dictionary().map(Object::Dictionary))
+		- space()
+}
+
+pub fn indirect_object(reader: &Reader) -> Parser<u8, (ObjectId, Object)> {
+	object_id() - seq(b"obj") - space() + object(reader) - space() - seq(b"endobj").opt() - space()
+}
+
+pub fn header<'a>() -> Parser<'a, u8, String> {
+	seq(b"%PDF-") * none_of(b"\r\n").repeat(0..).convert(String::from_utf8) - eol() - comment().repeat(0..)
+}
+
+fn xref<'a>() -> Parser<'a, u8, Xref> {
+	let xref_entry = integer().map(|i| i as u32) - sym(b' ') + integer().map(|i| i as u16) - sym(b' ') + one_of(b"nf").map(|k| k == b'n') - take(2);
+	let xref_section = integer().map(|i| i as usize) - sym(b' ') + integer() - sym(b' ').opt() - eol() + xref_entry.repeat(0..);
+	let xref = seq(b"xref") * eol() * xref_section.repeat(1..) - space();
+	xref.map(|sections| {
+		sections
+			.into_iter()
+			.fold(Xref::new(0), |mut xref: Xref, ((start, _count), entries): _| {
+				for (index, ((offset, generation), is_normal)) in entries.into_iter().enumerate() {
+					if is_normal {
+						xref.insert((start + index) as u32, XrefEntry::Normal { offset, generation });
+					}
+				}
+				xref
+			})
+	})
+}
+
+fn trailer<'a>() -> Parser<'a, u8, Dictionary> {
+	seq(b"trailer") * space() * dictionary() - space()
+}
+
+pub fn xref_and_trailer(reader: &Reader) -> Parser<u8, (Xref, Dictionary)> {
+	(xref() + trailer()).map(|(mut xref, trailer)| {
+		xref.size = trailer.get(b"Size").and_then(Object::as_i64).expect("Size is absent in trailer.") as u32;
+		(xref, trailer)
+	}) | indirect_object(reader).convert(|(_, obj)| match obj {
+		Object::Stream(stream) => Ok(decode_xref_stream(stream)),
+		_ => Err("Xref is not a stream object."),
+	})
+}
+
+pub fn xref_start<'a>() -> Parser<'a, u8, i64> {
+	seq(b"startxref") * eol() * integer() - eol() - seq(b"%%EOF") - space()
+}
+
+// The following code create parser to parse content stream.
+
+fn content_space<'a>() -> Parser<'a, u8, ()> {
+	is_a(multispace).repeat(0..).discard()
+}
+
+fn operator<'a>() -> Parser<'a, u8, String> {
+	(is_a(alpha) | one_of(b"*'\"")).repeat(1..).convert(String::from_utf8)
+}
+
+fn operand<'a>() -> Parser<'a, u8, Object> {
+	(seq(b"null").map(|_| Object::Null)
+		| seq(b"true").map(|_| Object::Boolean(true))
+		| seq(b"false").map(|_| Object::Boolean(false))
+		| real().map(Object::Real)
+		| integer().map(Object::Integer)
+		| name().map(Object::Name)
+		| literal_string().map(Object::string_literal)
+		| hexadecimal_string().map(|bytes| Object::String(bytes, StringFormat::Hexadecimal))
+		| array().map(Object::Array)
+		| dictionary().map(Object::Dictionary))
+		- content_space()
+}
+
+fn operation<'a>() -> Parser<'a, u8, Operation> {
+	let operation = operand().repeat(0..) + operator() - content_space();
+	operation.map(|(operands, operator)| Operation { operator, operands })
+}
+
+pub fn content<'a>() -> Parser<'a, u8, Content> {
+	content_space() * operation().repeat(0..).map(|operations| Content { operations })
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_real_number() {
+		let r0 = real().parse(b"0.12");
+		assert_eq!(r0, Ok(0.12));
+		let r1 = real().parse(b"-.12");
+		assert_eq!(r1, Ok(-0.12));
+		let r2 = real().parse(b"10.");
+		assert_eq!(r2, Ok(10.0));
+	}
+
+	#[test]
+	fn parse_string() {
+		assert_eq!(literal_string().parse(b"()"), Ok(b"".to_vec()));
+		assert_eq!(literal_string().parse(b"(text())"), Ok(b"text()".to_vec()));
+		assert_eq!(literal_string().parse(b"(text\r\n\\\\(nested\\t\\b\\f))"), Ok(b"text\r\n\\(nested\t\x08\x0C)".to_vec()));
+		assert_eq!(literal_string().parse(b"(text\\0\\53\\053\\0053)"), Ok(b"text\0++\x053".to_vec()));
+		assert_eq!(literal_string().parse(b"(text line\\\n())"), Ok(b"text line()".to_vec()));
+		assert_eq!(name().parse(b"/ABC#5f"), Ok(b"ABC\x5F".to_vec()));
+	}
+
+	#[test]
+	fn parse_name() {
+		let text = b"/#cb#ce#cc#e5";
+		let name = name().parse(text);
+		println!("{:?}", name);
+		assert_eq!(name.is_ok(), true);
+	}
+
+	#[test]
+	/// Run `cargo test -- --nocapture` to see output
+	fn parse_content() {
+		let stream = b"
+2 J
+BT
+/F1 12 Tf
+0 Tc
+0 Tw
+72.5 712 TD
+[(Unencoded streams can be read easily) 65 (,) ] TJ
+0 -14 TD
+[(b) 20 (ut generally tak) 10 (e more space than \\311)] TJ
+T* (encoded streams.) Tj
+		";
+		let content = content().parse(stream);
+		println!("{:?}", content);
+		assert_eq!(content.is_ok(), true);
+	}
+}

--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -10,6 +10,7 @@ use nom::branch::alt;
 use nom::error::{ParseError, ErrorKind};
 use nom::multi::{many0, many0_count, fold_many0, fold_many1};
 use nom::combinator::{opt, map, map_res, map_opt};
+use nom::character::{is_hex_digit, is_oct_digit};
 use nom::character::complete::{digit0, digit1, one_of};
 use nom::sequence::{delimited, pair, preceded, terminated, tuple, separated_pair};
 
@@ -93,13 +94,13 @@ fn real(input: &[u8]) -> NomResult<f64> {
 }
 
 fn hex_char(input: &[u8]) -> NomResult<u8> {
-	map_res(take_while_m_n(2, 2, |c: u8| c.is_ascii_hexdigit()),
+	map_res(take_while_m_n(2, 2, is_hex_digit),
 			|x| u8::from_str_radix(str::from_utf8(x).unwrap(), 16)
 	)(input)
 }
 
 fn oct_char(input: &[u8]) -> NomResult<u8> {
-	map_res(take_while_m_n(1, 3, |c: u8| b"01234567".contains(&c)),
+	map_res(take_while_m_n(1, 3, is_oct_digit),
 			// Spec requires us to ignore any overflow.
 			|x| u16::from_str_radix(str::from_utf8(x).unwrap(), 8).map(|o| o as u8)
 	)(input)

--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -325,7 +325,7 @@ pub fn xref_and_trailer(input: &[u8], reader: &Reader) -> Result<(Xref, Dictiona
 					Ok((xref, trailer))
 				}),
 
-		map(move |i| _indirect_object(i, reader),
+		map(|i| _indirect_object(i, reader),
 				|(_, obj)| match obj {
 					Object::Stream(stream) => Ok(decode_xref_stream(stream)),
 					_ => Err("Xref is not a stream object.")

--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -99,7 +99,7 @@ fn hex_char(input: &[u8]) -> NomResult<u8> {
 }
 
 fn oct_char(input: &[u8]) -> NomResult<u8> {
-	map_res(take_while_m_n(1, 3, |c: u8| c.is_ascii_hexdigit()),
+	map_res(take_while_m_n(1, 3, |c: u8| b"01234567".contains(&c)),
 			// Spec requires us to ignore any overflow.
 			|x| u16::from_str_radix(str::from_utf8(x).unwrap(), 8).map(|o| o as u8)
 	)(input)

--- a/src/object_stream.rs
+++ b/src/object_stream.rs
@@ -31,7 +31,7 @@ impl ObjectStream {
 			let id = chunk[0]?;
 			let offset = first_offset + chunk[1]? as usize;
 
-			let object = parser::direct_object().parse(&stream.content[offset..]).ok()?;
+			let object = parser::direct_object(&stream.content[offset..])?;
 
 			Some(((id, 0), object))
 		}).collect();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -86,11 +86,11 @@ fn hexadecimal_string<'a>() -> Parser<'a, u8, Vec<u8>> {
 }
 
 fn array<'a>() -> Parser<'a, u8, Vec<Object>> {
-	sym(b'[') * space() * call(direct_object).repeat(0..) - sym(b']')
+	sym(b'[') * space() * call(_direct_object).repeat(0..) - sym(b']')
 }
 
 fn dictionary<'a>() -> Parser<'a, u8, Dictionary> {
-	let entry = name() - space() + call(direct_object);
+	let entry = name() - space() + call(_direct_object);
 	let entries = seq(b"<<") * space() * entry.repeat(0..) - seq(b">>");
 	entries.map(|entries| {
 		entries.into_iter().fold(Dictionary::new(), |mut dict: Dictionary, (key, value)| {
@@ -123,7 +123,11 @@ fn object_id<'a>() -> Parser<'a, u8, ObjectId> {
 	id - space() + gen - space()
 }
 
-pub fn direct_object<'a>() -> Parser<'a, u8, Object> {
+pub fn direct_object(input: &[u8]) -> Option<Object> {
+	_direct_object().parse(input).ok()
+}
+
+fn _direct_object<'a>() -> Parser<'a, u8, Object> {
 	(seq(b"null").map(|_| Object::Null)
 		| seq(b"true").map(|_| Object::Boolean(true))
 		| seq(b"false").map(|_| Object::Boolean(false))
@@ -154,12 +158,16 @@ fn object(reader: &Reader) -> Parser<u8, Object> {
 		- space()
 }
 
-pub fn indirect_object(reader: &Reader) -> Parser<u8, (ObjectId, Object)> {
+pub fn indirect_object(input: &[u8], reader: &Reader) -> Option<(ObjectId, Object)> {
+	_indirect_object(reader).parse(input).ok()
+}
+
+fn _indirect_object(reader: &Reader) -> Parser<u8, (ObjectId, Object)> {
 	object_id() - seq(b"obj") - space() + object(reader) - space() - seq(b"endobj").opt() - space()
 }
 
-pub fn header<'a>() -> Parser<'a, u8, String> {
-	seq(b"%PDF-") * none_of(b"\r\n").repeat(0..).convert(String::from_utf8) - eol() - comment().repeat(0..)
+pub fn header(input: &[u8]) -> Option<String> {
+	(seq(b"%PDF-") * none_of(b"\r\n").repeat(0..).convert(String::from_utf8) - eol() - comment().repeat(0..)).parse(input).ok()
 }
 
 fn xref<'a>() -> Parser<'a, u8, Xref> {
@@ -184,18 +192,22 @@ fn trailer<'a>() -> Parser<'a, u8, Dictionary> {
 	seq(b"trailer") * space() * dictionary() - space()
 }
 
-pub fn xref_and_trailer(reader: &Reader) -> Parser<u8, (Xref, Dictionary)> {
+pub fn xref_and_trailer(input: &[u8], reader: &Reader) -> Result<(Xref, Dictionary), pom::Error> {
+	_xref_and_trailer(reader).parse(input)
+}
+
+fn _xref_and_trailer(reader: &Reader) -> Parser<u8, (Xref, Dictionary)> {
 	(xref() + trailer()).map(|(mut xref, trailer)| {
 		xref.size = trailer.get(b"Size").and_then(Object::as_i64).expect("Size is absent in trailer.") as u32;
 		(xref, trailer)
-	}) | indirect_object(reader).convert(|(_, obj)| match obj {
+	}) | _indirect_object(reader).convert(|(_, obj)| match obj {
 		Object::Stream(stream) => Ok(decode_xref_stream(stream)),
 		_ => Err("Xref is not a stream object."),
 	})
 }
 
-pub fn xref_start<'a>() -> Parser<'a, u8, i64> {
-	seq(b"startxref") * eol() * integer() - eol() - seq(b"%%EOF") - space()
+pub fn xref_start(input: &[u8]) -> Option<i64> {
+	(seq(b"startxref") * eol() * integer() - eol() - seq(b"%%EOF") - space()).parse(input).ok()
 }
 
 // The following code create parser to parse content stream.
@@ -227,8 +239,8 @@ fn operation<'a>() -> Parser<'a, u8, Operation> {
 	operation.map(|(operands, operator)| Operation { operator, operands })
 }
 
-pub fn content<'a>() -> Parser<'a, u8, Content> {
-	content_space() * operation().repeat(0..).map(|operations| Content { operations })
+pub fn content(input: &[u8]) -> Option<Content> {
+	(content_space() * operation().repeat(0..).map(|operations| Content { operations })).parse(input).ok()
 }
 
 #[cfg(test)]
@@ -278,8 +290,8 @@ BT
 [(b) 20 (ut generally tak) 10 (e more space than \\311)] TJ
 T* (encoded streams.) Tj
 		";
-		let content = content().parse(stream);
+		let content = content(stream);
 		println!("{:?}", content);
-		assert_eq!(content.is_ok(), true);
+		assert!(content.is_some());
 	}
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -51,15 +51,14 @@ impl Reader {
 	fn read(&mut self) -> Result<()> {
 		// The document structure can be expressed in PEG as:
 		//   document <- header indirect_object* xref trailer xref_start
-		let version = parser::header().parse(&self.buffer).map_err(|_| Error::new(ErrorKind::InvalidData, "Not a valid PDF file (header)."))?;
+		let version = parser::header(&self.buffer).ok_or_else(|| Error::new(ErrorKind::InvalidData, "Not a valid PDF file (header)."))?;
 
 		let xref_start = Self::get_xref_start(&self.buffer)?;
 		if xref_start > self.buffer.len() {
 			return Err(Error::new(ErrorKind::InvalidData, format!("Not a valid PDF file (xref_start)")));
 		}
 
-		let (mut xref, mut trailer) = parser::xref_and_trailer(&self)
-			.parse(&self.buffer[xref_start..])
+		let (mut xref, mut trailer) = parser::xref_and_trailer(&self.buffer[xref_start..], self)
 			.map_err(|err| Error::new(ErrorKind::InvalidData, format!("Not a valid PDF file (xref_and_trailer).\n{:?}", err)))?;
 
 		// Read previous Xrefs of linearized or incremental updated document.
@@ -69,8 +68,7 @@ impl Reader {
 			if prev > self.buffer.len() {
 				return Err(Error::new(ErrorKind::InvalidData, format!("Not a valid PDF file (prev_xref_start)")));
 			}
-			let (prev_xref, mut prev_trailer) = parser::xref_and_trailer(&self)
-				.parse(&self.buffer[prev..])
+			let (prev_xref, mut prev_trailer) = parser::xref_and_trailer(&self.buffer[prev..], &self)
 				.map_err(|err| Error::new(ErrorKind::InvalidData, format!("Not a valid PDF file (prev xref_and_trailer).\n{:?}", err)))?;
 			xref.extend(prev_xref);
 
@@ -81,8 +79,7 @@ impl Reader {
 				if prev > self.buffer.len() {
 					return Err(Error::new(ErrorKind::InvalidData, format!("Not a valid PDF file (prev_xref_stream_start)")));
 				}
-				let (prev_xref, _) = parser::xref_and_trailer(&self)
-					.parse(&self.buffer[prev..])
+				let (prev_xref, _) = parser::xref_and_trailer(&self.buffer[prev..], &self)
 					.map_err(|_| Error::new(ErrorKind::InvalidData, "Not a valid PDF file (prev xref_and_trailer)."))?;
 				xref.extend(prev_xref);
 			}
@@ -193,9 +190,8 @@ impl Reader {
 		if offset > self.buffer.len() {
 			return Err(Error::new(ErrorKind::InvalidData, format!("Not a valid PDF file (read at offset {})", offset)));
 		}
-		let (id, mut object) = parser::indirect_object(self)
-			.parse(&self.buffer[offset..])
-			.map_err(|err| Error::new(ErrorKind::InvalidData, format!("Not a valid PDF file (read object at {}).\n{:?}", offset, err)))?;
+		let (id, mut object) = parser::indirect_object(&self.buffer[offset..], self)
+			.ok_or_else(|| Error::new(ErrorKind::InvalidData, format!("Not a valid PDF file (read object at {}).", offset)))?;
 
 		// Parser is invoked relative to offset, add it back here.
 		if let Object::Stream(ref mut stream) = object {
@@ -211,9 +207,9 @@ impl Reader {
 			.and_then(|eof_pos| Self::search_substring(buffer, b"startxref", eof_pos - 25))
 			.ok_or_else(|| Error::new(ErrorKind::InvalidData, "Not a valid PDF file (xref_start)."))
 			.and_then(|xref_pos| if xref_pos <= buffer.len() {
-				match parser::xref_start().parse(&buffer[xref_pos..]) {
-					Ok(startxref) => Ok(startxref as usize),
-					Err(_) => Err(Error::new(ErrorKind::InvalidData, "Not a valid PDF file (xref_start).")),
+				match parser::xref_start(&buffer[xref_pos..]) {
+					Some(startxref) => Ok(startxref as usize),
+					None => Err(Error::new(ErrorKind::InvalidData, "Not a valid PDF file (xref_start).")),
 				}
 			} else {
 				Err(Error::new(ErrorKind::InvalidData, "Not a valid PDF file (xref_pos)"))


### PR DESCRIPTION
As promised, here is the nom 5 parser with the following features:

 - No macros used.
 - 20 to 30 times faster than the pom parser on most documents.
 - Optional, enabled via the nom_parser feature.

I have also included a micro benchmark:
```
$ cargo bench --bench parse
test bench_load ... bench:     801,357 ns/iter (+/- 114,452)
```

```
$ cargo bench --bench parse --features nom_parser
test bench_load ... bench:      34,705 ns/iter (+/- 8,359)
```

Looking forward to your comments,
Jonathan