### PR TITLE
LZW decompression support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ chrono = { version = "0.3.0", optional = true }
 log = "0.4.6"
 rayon = "1.0"
 nom = { version = "5.0.0-alpha2", optional = true }
+lzw = "0.10"
 
 [features]
 default = ["chrono_time"]


### PR DESCRIPTION
For implementing the functionality requested in issue #30.

The CMAP in the issue decodes to:
"/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n/CMapType 2 def\n/CMapName/R99 def\n1 begincodespacerange\n<00><ff>\nendcodespacerange\n1 beginbfrange\n<20><20><0020>\nendbfrange\nendcmap\nCMapName currentdict /CMap defineresource pop\nend end\n"

As decimal bytes:
`[47, 67, 73, 68, 73, 110, 105, 116, 32, 47, 80, 114, 111, 99, 83, 101, 116, 32, 102, 105, 110, 100, 114, 101, 115, 111, 117, 114, 99, 101, 32, 98, 101, 103, 105, 110, 10, 49, 50, 32, 100, 105, 99, 116, 32, 98, 101, 103, 105, 110, 10, 98, 101, 103, 105, 110, 99, 109, 97, 112, 10, 47, 67, 77, 97, 112, 84, 121, 112, 101, 32, 50, 32, 100, 101, 102, 10, 47, 67, 77, 97, 112, 78, 97, 109, 101, 47, 82, 57, 57, 32, 100, 101, 102, 10, 49, 32, 98, 101, 103, 105, 110, 99, 111, 100, 101, 115, 112, 97, 99, 101, 114, 97, 110, 103, 101, 10, 60, 48, 48, 62, 60, 102, 102, 62, 10, 101, 110, 100, 99, 111, 100, 101, 115, 112, 97, 99, 101, 114, 97, 110, 103, 101, 10, 49, 32, 98, 101, 103, 105, 110, 98, 102, 114, 97, 110, 103, 101, 10, 60, 50, 48, 62, 60, 50, 48, 62, 60, 48, 48, 50, 48, 62, 10, 101, 110, 100, 98, 102, 114, 97, 110, 103, 101, 10, 101, 110, 100, 99, 109, 97, 112, 10, 67, 77, 97, 112, 78, 97, 109, 101, 32, 99, 117, 114, 114, 101, 110, 116, 100, 105, 99, 116, 32, 47, 67, 77, 97, 112, 32, 100, 101, 102, 105, 110, 101, 114, 101, 115, 111, 117, 114, 99, 101, 32, 112, 111, 112, 10, 101, 110, 100, 32, 101, 110, 100, 10]`