### PR TITLE
Escape fix

### DIFF
--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -124,18 +124,16 @@ fn name(input: &[u8]) -> NomResult<Vec<u8>> {
 }
 
 fn escape_sequence(input: &[u8]) -> NomResult<Option<u8>> {
-	tag(b"\\")(input).and_then(|(i, _)| {
-		alt((
-			map(oct_char, Some),
-			map(eol, |_| None),
-			map(tag(b"n"), |_| Some(b'\n')),
-			map(tag(b"r"), |_| Some(b'\r')),
-			map(tag(b"t"), |_| Some(b'\t')),
-			map(tag(b"b"), |_| Some(b'\x08')),
-			map(tag(b"f"), |_| Some(b'\x0C')),
-			map(take(1usize), |c: &[u8]| Some(c[0])),
-		))(i)
-	})
+	preceded(tag(b"\\"), alt((
+		map(oct_char, Some),
+		map(eol, |_| None),
+		map(tag(b"n"), |_| Some(b'\n')),
+		map(tag(b"r"), |_| Some(b'\r')),
+		map(tag(b"t"), |_| Some(b'\t')),
+		map(tag(b"b"), |_| Some(b'\x08')),
+		map(tag(b"f"), |_| Some(b'\x0C')),
+		map(take(1usize), |c: &[u8]| Some(c[0])),
+	)))(input)
 }
 
 enum ILS<'a> {

--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -128,17 +128,12 @@ fn escape_sequence(input: &[u8]) -> NomResult<Option<u8>> {
 		alt((
 			map(oct_char, Some),
 			map(eol, |_| None),
-			map(|i| map_opt(take(1usize), |c: &[u8]| {
-				match c[0] {
-					b'n' => Some(b'\n'),
-					b'r' => Some(b'\r'),
-					b't' => Some(b'\t'),
-					b'b' => Some(b'\x08'),
-					b'f' => Some(b'\x0C'),
-					_ => Some(c[0]),
-				}
-			})(i), Some),
-
+			map(tag(b"n"), |_| Some(b'\n')),
+			map(tag(b"r"), |_| Some(b'\r')),
+			map(tag(b"t"), |_| Some(b'\t')),
+			map(tag(b"b"), |_| Some(b'\x08')),
+			map(tag(b"f"), |_| Some(b'\x0C')),
+			map(take(1usize), |c: &[u8]| Some(c[0])),
 		))(i)
 	})
 }

--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -126,21 +126,19 @@ fn name(input: &[u8]) -> NomResult<Vec<u8>> {
 fn escape_sequence(input: &[u8]) -> NomResult<Option<u8>> {
 	tag(b"\\")(input).and_then(|(i, _)| {
 		alt((
+			map(oct_char, Some),
+			map(eol, |_| None),
 			map(|i| map_opt(take(1usize), |c: &[u8]| {
 				match c[0] {
-					b'(' | b')' => Some(c[0]),
 					b'n' => Some(b'\n'),
 					b'r' => Some(b'\r'),
 					b't' => Some(b'\t'),
 					b'b' => Some(b'\x08'),
 					b'f' => Some(b'\x0C'),
-					b'\\' => Some(b'\\'),
 					_ => Some(c[0]),
 				}
 			})(i), Some),
 
-			map(oct_char, Some),
-			map(eol, |_| None),
 		))(i)
 	})
 }

--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -135,7 +135,7 @@ fn escape_sequence(input: &[u8]) -> NomResult<Option<u8>> {
 					b'b' => Some(b'\x08'),
 					b'f' => Some(b'\x0C'),
 					b'\\' => Some(b'\\'),
-					_ => None,
+					_ => Some(c[0]),
 				}
 			})(i), Some),
 


### PR DESCRIPTION
Cleaner code overall and fixes the case of a backslash followed by a non-special character.