### PR TITLE
Ununwrap: replace panics by error handling

### DIFF
--- a/examples/add_barcode.rs
+++ b/examples/add_barcode.rs
@@ -79,7 +79,7 @@ fn main() {
 			vec![mm2pt, 0.0, 0.0, mm2pt, 12.44 * mm2pt, 842.0 - 14.53 * mm2pt],
 			operations.as_bytes().to_vec(),
 		);
-		doc.insert_form_object(page_id, barcode);
+		doc.insert_form_object(page_id, barcode).unwrap();
 	}
 	doc.save(output_file).unwrap();
 }

--- a/src/content.rs
+++ b/src/content.rs
@@ -1,6 +1,7 @@
 use super::parser;
 use super::{Object, Stream};
-use std::io::{self, Write};
+use std::io::Write;
+use crate::{Error, Result};
 use crate::writer::Writer;
 
 #[derive(Debug, Clone)]
@@ -25,7 +26,7 @@ pub struct Content {
 
 impl Content {
 	/// Encode content operations.
-	pub fn encode(&self) -> io::Result<Vec<u8>> {
+	pub fn encode(&self) -> Result<Vec<u8>> {
 		let mut buffer = Vec::new();
 		for operation in &self.operations {
 			for operand in &operation.operands {
@@ -39,14 +40,14 @@ impl Content {
 	}
 
 	/// Decode content operations.
-	pub fn decode(data: &[u8]) -> Option<Content> {
-		parser::content(data)
+	pub fn decode(data: &[u8]) -> Result<Content> {
+		parser::content(data).ok_or(Error::ContentDecode)
 	}
 }
 
 impl Stream {
 	/// Decode content after decoding all stream filters.
-	pub fn decode_content(&self) -> Option<Content> {
+	pub fn decode_content(&self) -> Result<Content> {
 		Content::decode(&self.content)
 	}
 }

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -23,7 +23,7 @@ impl Document {
 	}
 
 	fn get_or_create_resources_mut(&mut self, page_id: ObjectId) -> Option<&mut Object> {
-		let page = self.get_object_mut(page_id).and_then(Object::as_dict_mut).unwrap();
+		let page = self.get_object_mut(page_id).and_then(Object::as_dict_mut)?;
 		if page.has(b"Resources") {
 			if let Some(_res_id) = page.get(b"Resources").and_then(Object::as_reference) {
 				// self.get_object_mut(res_id)
@@ -40,7 +40,7 @@ impl Document {
 	pub fn get_or_create_resources(&mut self, page_id: ObjectId) -> Option<&mut Object> {
 		let mut resources_id = None;
 		{
-			let page = self.get_object(page_id).and_then(Object::as_dict).unwrap();
+			let page = self.get_object(page_id).and_then(Object::as_dict)?;
 			if page.has(b"Resources") {
 				resources_id = page.get(b"Resources").and_then(Object::as_reference);
 			}

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -1,4 +1,5 @@
-use super::{Dictionary, Document, Object, ObjectId};
+use crate::{Error, Result};
+use crate::{Dictionary, Document, Object, ObjectId};
 
 impl Document {
 	/// Create new PDF document with version.
@@ -51,24 +52,26 @@ impl Document {
 		}
 	}
 
-	pub fn add_xobject<N: Into<Vec<u8>>>(&mut self, page_id: ObjectId, xobject_name: N, xobject_id: ObjectId) {
+	pub fn add_xobject<N: Into<Vec<u8>>>(&mut self, page_id: ObjectId, xobject_name: N, xobject_id: ObjectId) -> Result<()> {
 		if let Some(resources) = self.get_or_create_resources(page_id).and_then(Object::as_dict_mut) {
 			if !resources.has(b"XObject") {
 				resources.set("XObject", Dictionary::new());
 			}
-			let xobjects = resources.get_mut(b"XObject").and_then(Object::as_dict_mut).unwrap();
+			let xobjects = resources.get_mut(b"XObject").and_then(Object::as_dict_mut).ok_or(Error::TypeError)?;
 			xobjects.set(xobject_name, Object::Reference(xobject_id));
 		}
+		Ok(())
 	}
 
-	pub fn add_graphics_state<N: Into<Vec<u8>>>(&mut self, page_id: ObjectId, gs_name: N, gs_id: ObjectId) {
+	pub fn add_graphics_state<N: Into<Vec<u8>>>(&mut self, page_id: ObjectId, gs_name: N, gs_id: ObjectId) -> Result<()> {
 		if let Some(resources) = self.get_or_create_resources(page_id).and_then(Object::as_dict_mut) {
 			if !resources.has(b"ExtGState") {
 				resources.set("ExtGState", Dictionary::new());
 			}
-			let states = resources.get_mut(b"ExtGState").and_then(Object::as_dict_mut).unwrap();
+			let states = resources.get_mut(b"ExtGState").and_then(Object::as_dict_mut).ok_or(Error::TypeError)?;
 			states.set(gs_name, Object::Reference(gs_id));
 		}
+		Ok(())
 	}
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -175,7 +175,7 @@ impl Document {
 		for object_id in content_streams {
 			if let Some(content_stream) = self.get_object(object_id) {
 				if let Object::Stream(ref stream) = *content_stream {
-					if let Some(data) = stream.decompressed_content() {
+					if let Ok(data) = stream.decompressed_content() {
 						content.write_all(&data)?;
 					} else {
 						content.write_all(&stream.content)?;

--- a/src/document.rs
+++ b/src/document.rs
@@ -7,7 +7,7 @@ use encoding::all::UTF_16BE;
 use encoding::types::{DecoderTrap, EncoderTrap, Encoding};
 use log::info;
 use std::collections::BTreeMap;
-use std::io::{self, Write};
+use std::io::Write;
 use std::str;
 
 /// PDF document.
@@ -169,7 +169,7 @@ impl Document {
 	}
 
 	/// Get content of a page.
-	pub fn get_page_content(&self, page_id: ObjectId) -> io::Result<Vec<u8>> {
+	pub fn get_page_content(&self, page_id: ObjectId) -> Result<Vec<u8>> {
 		let mut content = Vec::new();
 		let content_streams = self.get_page_contents(page_id);
 		for object_id in content_streams {

--- a/src/document.rs
+++ b/src/document.rs
@@ -2,6 +2,7 @@ use super::content::Content;
 use super::encodings::{self, bytes_to_string, string_to_bytes};
 use super::{Dictionary, Object, ObjectId};
 use crate::xref::Xref;
+use crate::Result;
 use encoding::all::UTF_16BE;
 use encoding::types::{DecoderTrap, EncoderTrap, Encoding};
 use log::info;
@@ -186,9 +187,9 @@ impl Document {
 	}
 
 	/// Get decoded page content;
-	pub fn get_and_decode_page_content(&self, page_id: ObjectId) -> Content {
-		let content_data = self.get_page_content(page_id).unwrap();
-		Content::decode(&content_data).unwrap()
+	pub fn get_and_decode_page_content(&self, page_id: ObjectId) -> Result<Content> {
+		let content_data = self.get_page_content(page_id)?;
+		Content::decode(&content_data)
 	}
 
 	/// Get resources used by a page.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,8 @@
+#[derive(Debug)]
+pub enum Error {
+	IO(std::io::Error),
+	InvalidTrailer,
+	InvalidXref,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,25 @@
 #[derive(Debug)]
 pub enum Error {
 	IO(std::io::Error),
-	InvalidTrailer,
-	InvalidXref,
+	Header,
+	Trailer,
+	Xref(XrefError),
+	Offset(usize),
+	Parse {offset: usize},
+}
+
+#[derive(Debug)]
+pub enum XrefError {
+	Parse,
+	Start,
+	PrevStart,
+	StreamStart,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+impl From<std::io::Error> for Error {
+	fn from(err: std::io::Error) -> Error {
+		Error::IO(err)
+	}
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ pub enum Error {
 	Xref(XrefError),
 	Offset(usize),
 	Parse {offset: usize},
+	ContentDecode,
 }
 
 impl fmt::Display for Error {
@@ -19,6 +20,7 @@ impl fmt::Display for Error {
 			Error::Xref(e) => write!(f, "Invalid cross-reference table ({})", e),
 			Error::Offset(o) => write!(f, "Invalid file offset: {}", o),
 			Error::Parse{offset, ..} => write!(f, "Invalid object at byte {}", offset),
+			Error::ContentDecode => write!(f, "Could not decode content"),
 		}
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,9 @@ pub enum Error {
 	Offset(usize),
 	Parse {offset: usize},
 	ContentDecode,
+	TypeError,
+	ObjectNotFound,
+	PageNumberNotFound(u32),
 }
 
 impl fmt::Display for Error {
@@ -21,6 +24,9 @@ impl fmt::Display for Error {
 			Error::Offset(o) => write!(f, "Invalid file offset: {}", o),
 			Error::Parse{offset, ..} => write!(f, "Invalid object at byte {}", offset),
 			Error::ContentDecode => write!(f, "Could not decode content"),
+			Error::TypeError => write!(f, "An object does not have the expected type"),
+			Error::ObjectNotFound => write!(f, "A required object was not found"),
+			Error::PageNumberNotFound(p) => write!(f, "Page number {} could not be found", p),
 		}
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
 	TypeError,
 	ObjectNotFound,
 	PageNumberNotFound(u32),
+	#[cfg(feature = "embed_image")]
+	Image(image::ImageError),
 }
 
 impl fmt::Display for Error {
@@ -27,6 +29,8 @@ impl fmt::Display for Error {
 			Error::TypeError => write!(f, "An object does not have the expected type"),
 			Error::ObjectNotFound => write!(f, "A required object was not found"),
 			Error::PageNumberNotFound(p) => write!(f, "Page number {} could not be found", p),
+			#[cfg(feature = "embed_image")]
+			Error::Image(e) => e.fmt(f),
 		}
     }
 }
@@ -59,5 +63,12 @@ pub type Result<T> = std::result::Result<T, Error>;
 impl From<std::io::Error> for Error {
 	fn from(err: std::io::Error) -> Error {
 		Error::IO(err)
+	}
+}
+
+#[cfg(feature = "embed_image")]
+impl From<image::ImageError> for Error {
+	fn from(err: image::ImageError) -> Error {
+		Error::Image(err)
 	}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[derive(Debug)]
 pub enum Error {
 	IO(std::io::Error),
@@ -8,6 +10,21 @@ pub enum Error {
 	Parse {offset: usize},
 }
 
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match self {
+			Error::IO(e) => e.fmt(f),
+			Error::Header => write!(f, "Invalid file header"),
+			Error::Trailer => write!(f, "Invalid file trailer"),
+			Error::Xref(e) => write!(f, "Invalid cross-reference table ({})", e),
+			Error::Offset(o) => write!(f, "Invalid file offset: {}", o),
+			Error::Parse{offset, ..} => write!(f, "Invalid object at byte {}", offset),
+		}
+    }
+}
+
+impl std::error::Error for Error {}
+
 #[derive(Debug)]
 pub enum XrefError {
 	Parse,
@@ -15,6 +32,19 @@ pub enum XrefError {
 	PrevStart,
 	StreamStart,
 }
+
+impl fmt::Display for XrefError {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match self {
+			XrefError::Parse => write!(f, "could not parse xref"),
+			XrefError::Start => write!(f, "invalid start value"),
+			XrefError::PrevStart => write!(f, "invalid start value in Prev field"),
+			XrefError::StreamStart => write!(f, "invalid stream start value"),
+		}
+    }
+}
+
+impl std::error::Error for XrefError {}
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,6 @@ mod processor;
 mod reader;
 mod writer;
 pub mod xobject;
+
+mod error;
+pub use error::{Error, Result};

--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -284,10 +284,10 @@ fn object<'a>(input: &'a [u8], reader: &Reader) -> NomResult<'a, Object> {
 	terminated(alt((|input| stream(input, reader), _direct_objects)), space)(input)
 }
 
-pub fn indirect_object<'a>(input: &'a [u8], file_offset: usize, reader: &Reader) -> crate::Result<(ObjectId, Object)> {
-	let (_, (id, mut object)) = _indirect_object(&input[file_offset..], reader).map_err(|_| Error::Parse{ offset: file_offset })?;
+pub fn indirect_object<'a>(input: &'a [u8], offset: usize, reader: &Reader) -> crate::Result<(ObjectId, Object)> {
+	let (_, (id, mut object)) = _indirect_object(&input[offset..], reader).map_err(|_| Error::Parse{ offset })?;
 
-	offset_stream(&mut object, file_offset);
+	offset_stream(&mut object, offset);
 
 	Ok((id, object))
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -199,9 +199,9 @@ pub fn xref_and_trailer(input: &[u8], reader: &Reader) -> Result<(Xref, Dictiona
 }
 
 fn _xref_and_trailer(reader: &Reader) -> Parser<u8, (Xref, Dictionary)> {
-	(xref() + trailer()).map(|(mut xref, trailer)| {
-		xref.size = trailer.get(b"Size").and_then(Object::as_i64).expect("Size is absent in trailer.") as u32;
-		(xref, trailer)
+	(xref() + trailer()).convert(|(mut xref, trailer)| -> Result<_> {
+		xref.size = trailer.get(b"Size").and_then(Object::as_i64).ok_or(Error::Trailer)? as u32;
+		Ok((xref, trailer))
 	}) | _indirect_object(reader).convert(|(_, obj)| match obj {
 		Object::Stream(stream) => decode_xref_stream(stream),
 		_ => Err(Error::Xref(XrefError::Parse)),

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -25,7 +25,8 @@ impl Document {
 		for object in self.objects.values_mut() {
 			if let Object::Stream(ref mut stream) = *object {
 				if stream.allows_compression {
-					stream.compress()
+					// Ignore any error and continue to compress other streams.
+					let _ = stream.compress();
 				}
 			}
 		}
@@ -195,7 +196,8 @@ impl Document {
 		if let Some(content_stream) = self.objects.get_mut(&stream_id) {
 			if let Object::Stream(ref mut stream) = *content_stream {
 				stream.set_plain_content(content);
-				stream.compress();
+				// Ignore any compression error.
+				let _ = stream.compress();
 			}
 		}
 	}
@@ -262,7 +264,7 @@ impl Document {
 		if let Some(stream_obj) = self.get_object(stream_id) {
 			if let Object::Stream(ref stream) = *stream_obj {
 				if decompress {
-					if let Some(data) = stream.decompressed_content() {
+					if let Ok(data) = stream.decompressed_content() {
 						file.write_all(&data)?;
 					} else {
 						file.write_all(&stream.content)?;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -147,7 +147,7 @@ impl Reader {
 	}
 
 	fn get_stream_length(&self, object_id: ObjectId) -> Option<i64> {
-		let object = self.document.get_object(object_id).unwrap();
+		let object = self.document.get_object(object_id)?;
 		match object {
 			Object::Stream(ref stream) => stream.dict.get(b"Length").and_then(|value| {
 				if let Some(id) = value.as_reference() {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,7 +1,7 @@
 use log::{error, warn};
 use std::cmp;
 use std::fs::File;
-use std::io::{Error, ErrorKind, Read, Result};
+use std::io::Read;
 use std::path::Path;
 use std::sync::Mutex;
 
@@ -11,6 +11,8 @@ use super::parser;
 use super::{Document, Object, ObjectId};
 use crate::object_stream::ObjectStream;
 use crate::xref::XrefEntry;
+use crate::{Error, Result};
+use crate::error::XrefError;
 
 impl Document {
 	/// Load PDF document from specified file path.
@@ -51,25 +53,23 @@ impl Reader {
 	fn read(&mut self) -> Result<()> {
 		// The document structure can be expressed in PEG as:
 		//   document <- header indirect_object* xref trailer xref_start
-		let version = parser::header(&self.buffer).ok_or_else(|| Error::new(ErrorKind::InvalidData, "Not a valid PDF file (header)."))?;
+		let version = parser::header(&self.buffer).ok_or(Error::Header)?;
 
 		let xref_start = Self::get_xref_start(&self.buffer)?;
 		if xref_start > self.buffer.len() {
-			return Err(Error::new(ErrorKind::InvalidData, "Not a valid PDF file (xref_start)"));
+			return Err(Error::Xref(XrefError::Start));
 		}
 
-		let (mut xref, mut trailer) = parser::xref_and_trailer(&self.buffer[xref_start..], self)
-			.map_err(|err| Error::new(ErrorKind::InvalidData, format!("Not a valid PDF file (xref_and_trailer).\n{:?}", err)))?;
+		let (mut xref, mut trailer) = parser::xref_and_trailer(&self.buffer[xref_start..], self)?;
 
 		// Read previous Xrefs of linearized or incremental updated document.
 		let mut prev_xref_start = trailer.remove(b"Prev");
 		while let Some(prev) = prev_xref_start.and_then(|offset| offset.as_i64()) {
 			let prev = prev as usize;
 			if prev > self.buffer.len() {
-				return Err(Error::new(ErrorKind::InvalidData, "Not a valid PDF file (prev_xref_start)"));
+				return Err(Error::Xref(XrefError::PrevStart));
 			}
-			let (prev_xref, mut prev_trailer) = parser::xref_and_trailer(&self.buffer[prev..], &self)
-				.map_err(|err| Error::new(ErrorKind::InvalidData, format!("Not a valid PDF file (prev xref_and_trailer).\n{:?}", err)))?;
+			let (prev_xref, mut prev_trailer) = parser::xref_and_trailer(&self.buffer[prev..], &self)?;
 			xref.extend(prev_xref);
 
 			// Read xref stream in hybrid-reference file
@@ -77,10 +77,9 @@ impl Reader {
 			if let Some(prev) = prev_xref_stream_start.and_then(|offset| offset.as_i64()) {
 				let prev = prev as usize;
 				if prev > self.buffer.len() {
-					return Err(Error::new(ErrorKind::InvalidData, "Not a valid PDF file (prev_xref_stream_start)"));
+					return Err(Error::Xref(XrefError::StreamStart));
 				}
-				let (prev_xref, _) = parser::xref_and_trailer(&self.buffer[prev..], &self)
-					.map_err(|_| Error::new(ErrorKind::InvalidData, "Not a valid PDF file (prev xref_and_trailer)."))?;
+				let (prev_xref, _) = parser::xref_and_trailer(&self.buffer[prev..], &self)?;
 				xref.extend(prev_xref);
 			}
 
@@ -188,24 +187,24 @@ impl Reader {
 
 	fn read_object(&self, offset: usize) -> Result<(ObjectId, Object)> {
 		if offset > self.buffer.len() {
-			return Err(Error::new(ErrorKind::InvalidData, format!("Not a valid PDF file (read at offset {})", offset)));
+			return Err(Error::Offset(offset));
 		}
+
 		parser::indirect_object(&self.buffer, offset, self)
-			.map_err(|err| Error::new(ErrorKind::InvalidData, format!("Not a valid PDF file (read object at {}).\n{:?}", offset, err)))
 	}
 
 	fn get_xref_start(buffer: &[u8]) -> Result<usize> {
 		let seek_pos = buffer.len() - cmp::min(buffer.len(), 512);
 		Self::search_substring(buffer, b"%%EOF", seek_pos)
 			.and_then(|eof_pos| Self::search_substring(buffer, b"startxref", eof_pos - 25))
-			.ok_or_else(|| Error::new(ErrorKind::InvalidData, "Not a valid PDF file (xref_start)."))
+			.ok_or(Error::Xref(XrefError::Start))
 			.and_then(|xref_pos| if xref_pos <= buffer.len() {
 				match parser::xref_start(&buffer[xref_pos..]) {
 					Some(startxref) => Ok(startxref as usize),
-					None => Err(Error::new(ErrorKind::InvalidData, "Not a valid PDF file (xref_start).")),
+					None => Err(Error::Xref(XrefError::Start)),
 				}
 			} else {
-				Err(Error::new(ErrorKind::InvalidData, "Not a valid PDF file (xref_pos)"))
+				Err(Error::Xref(XrefError::Start))
 			})
 	}
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -24,7 +24,7 @@ impl Document {
 	fn save_internal<W: Write>(&mut self, target: &mut W) -> Result<()> {
 		let mut target = CountingWrite { inner: target, bytes_written: 0 };
 		let mut xref = Xref::new(self.max_id + 1);
-		write!(target, "%PDF-{}\n", self.version)?;
+		writeln!(target, "%PDF-{}", self.version)?;
 
 		for (&(id, generation), object) in &self.objects {
 			if object.type_name().map(|name| ["ObjStm", "XRef", "Linearized"].contains(&name)) != Some(true) {
@@ -76,10 +76,9 @@ impl Writer {
 	}
 
 	fn write_xref(file: &mut dyn Write, xref: &Xref) -> Result<()> {
-		file.write_all(b"xref\n")?;
-		write!(file, "0 {}\n", xref.size)?;
+		writeln!(file, "xref\n0 {}", xref.size)?;
 
-		let mut write_xref_entry = |offset: u32, generation: u16, kind: char| write!(file, "{:>010} {:>05} {} \n", offset, generation, kind);
+		let mut write_xref_entry = |offset: u32, generation: u16, kind: char| writeln!(file, "{:>010} {:>05} {} ", offset, generation, kind);
 		write_xref_entry(0, 65535, 'f')?;
 
 		let mut obj_id = 1;
@@ -101,7 +100,7 @@ impl Writer {
 		xref.insert(id, XrefEntry::Normal { offset, generation });
 		write!(file, "{} {} obj{}", id, generation, if Writer::need_separator(object) { " " } else { "" })?;
 		Writer::write_object(file, object)?;
-		write!(file, "{}endobj\n", if Writer::need_end_separator(object) { " " } else { "" })?;
+		writeln!(file, "{}endobj", if Writer::need_end_separator(object) { " " } else { "" })?;
 		Ok(())
 	}
 

--- a/src/xobject.rs
+++ b/src/xobject.rs
@@ -80,11 +80,10 @@ impl Document {
 			.push(Operation::new("cm", vec![size.0.into(), 0.into(), 0.into(), size.1.into(), position.0.into(), position.1.into()]));
 		content.operations.push(Operation::new("Do", vec![Name(img_name.as_bytes().to_vec())]));
 		content.operations.push(Operation::new("Q", vec![]));
-		let modified_contnet = content.encode().unwrap();
+		let modified_content = content.encode()?;
 		self.add_xobject(page_id, img_name, img_id);
-		self.change_page_content(page_id, modified_contnet);
 
-		Ok(())
+		self.change_page_content(page_id, modified_content)
 	}
 
 	pub fn insert_form_object(&mut self, page_id: ObjectId, form_obj: Stream) -> Result<()> {
@@ -97,11 +96,10 @@ impl Document {
 		// content.operations.push(Operation::new("q", vec![]));
 		content.operations.push(Operation::new("Do", vec![Name(form_name.as_bytes().to_vec())]));
 		// content.operations.push(Operation::new("Q", vec![]));
-		let modified_contnet = content.encode().unwrap();
+		let modified_content = content.encode()?;
 		self.add_xobject(page_id, form_name, form_id);
-		self.change_page_content(page_id, modified_contnet);
 
-		Ok(())
+		self.change_page_content(page_id, modified_content)
 	}
 }
 

--- a/src/xobject.rs
+++ b/src/xobject.rs
@@ -83,7 +83,7 @@ impl Document {
 		content.operations.push(Operation::new("Do", vec![Name(img_name.as_bytes().to_vec())]));
 		content.operations.push(Operation::new("Q", vec![]));
 		let modified_content = content.encode()?;
-		self.add_xobject(page_id, img_name, img_id);
+		self.add_xobject(page_id, img_name, img_id)?;
 
 		self.change_page_content(page_id, modified_content)
 	}
@@ -99,7 +99,7 @@ impl Document {
 		content.operations.push(Operation::new("Do", vec![Name(form_name.as_bytes().to_vec())]));
 		// content.operations.push(Operation::new("Q", vec![]));
 		let modified_content = content.encode()?;
-		self.add_xobject(page_id, form_name, form_id);
+		self.add_xobject(page_id, form_name, form_id)?;
 
 		self.change_page_content(page_id, modified_content)
 	}

--- a/src/xref.rs
+++ b/src/xref.rs
@@ -2,6 +2,8 @@ use super::{Dictionary, Stream};
 use std::collections::BTreeMap;
 use std::io::{Cursor, Read};
 
+use crate::{Error, Result};
+
 #[derive(Debug, Clone)]
 pub struct Xref {
 	/// Entries for indirect object.
@@ -67,11 +69,11 @@ impl XrefEntry {
 	}
 }
 
-pub fn decode_xref_stream(mut stream: Stream) -> (Xref, Dictionary) {
+pub fn decode_xref_stream(mut stream: Stream) -> Result<(Xref, Dictionary)> {
 	stream.decompress();
 	let mut dict = stream.dict;
 	let mut reader = Cursor::new(stream.content);
-	let size = dict.get(b"Size").and_then(Object::as_i64).expect("Size is absent in trailer.");
+	let size = dict.get(b"Size").and_then(Object::as_i64).ok_or(Error::InvalidTrailer)?;
 	let mut xref = Xref::new(size as u32);
 	{
 		let section_indice = dict
@@ -83,7 +85,7 @@ pub fn decode_xref_stream(mut stream: Stream) -> (Xref, Dictionary) {
 			.get(b"W")
 			.and_then(Object::as_array)
 			.map(|array| array.iter().map(|n| n.as_i64().unwrap() as usize).collect())
-			.expect("W is absent in trailer.");
+			.ok_or(Error::InvalidTrailer)?;
 		let mut bytes1 = vec![0_u8; field_widths[0]];
 		let mut bytes2 = vec![0_u8; field_widths[1]];
 		let mut bytes3 = vec![0_u8; field_widths[2]];
@@ -126,7 +128,7 @@ pub fn decode_xref_stream(mut stream: Stream) -> (Xref, Dictionary) {
 	dict.remove(b"Length");
 	dict.remove(b"W");
 	dict.remove(b"Index");
-	(xref, dict)
+	Ok((xref, dict))
 }
 
 fn read_big_endian_interger(reader: &mut Cursor<Vec<u8>>, buffer: &mut [u8]) -> u32 {

--- a/src/xref.rs
+++ b/src/xref.rs
@@ -73,7 +73,7 @@ pub fn decode_xref_stream(mut stream: Stream) -> Result<(Xref, Dictionary)> {
 	stream.decompress();
 	let mut dict = stream.dict;
 	let mut reader = Cursor::new(stream.content);
-	let size = dict.get(b"Size").and_then(Object::as_i64).ok_or(Error::InvalidTrailer)?;
+	let size = dict.get(b"Size").and_then(Object::as_i64).ok_or(Error::Trailer)?;
 	let mut xref = Xref::new(size as u32);
 	{
 		let section_indice = dict
@@ -85,7 +85,7 @@ pub fn decode_xref_stream(mut stream: Stream) -> Result<(Xref, Dictionary)> {
 			.get(b"W")
 			.and_then(Object::as_array)
 			.map(|array| array.iter().map(|n| n.as_i64().unwrap() as usize).collect())
-			.ok_or(Error::InvalidTrailer)?;
+			.ok_or(Error::Trailer)?;
 		let mut bytes1 = vec![0_u8; field_widths[0]];
 		let mut bytes2 = vec![0_u8; field_widths[1]];
 		let mut bytes3 = vec![0_u8; field_widths[2]];

--- a/src/xref.rs
+++ b/src/xref.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use std::io::{Cursor, Read};
 
 use crate::{Error, Result};
+use crate::error::XrefError;
 
 #[derive(Debug, Clone)]
 pub struct Xref {
@@ -73,39 +74,42 @@ pub fn decode_xref_stream(mut stream: Stream) -> Result<(Xref, Dictionary)> {
 	stream.decompress();
 	let mut dict = stream.dict;
 	let mut reader = Cursor::new(stream.content);
-	let size = dict.get(b"Size").and_then(Object::as_i64).ok_or(Error::Trailer)?;
+	let size = dict.get(b"Size").and_then(Object::as_i64).ok_or(Error::Xref(XrefError::Parse))?;
 	let mut xref = Xref::new(size as u32);
 	{
 		let section_indice = dict
 			.get(b"Index")
-			.and_then(Object::as_array)
-			.map(|array| array.iter().map(|n| n.as_i64().unwrap()).collect())
+			.and_then(parse_integer_array)
 			.unwrap_or_else(|| vec![0, size]);
-		let field_widths: Vec<usize> = dict
+		let field_widths = dict
 			.get(b"W")
-			.and_then(Object::as_array)
-			.map(|array| array.iter().map(|n| n.as_i64().unwrap() as usize).collect())
-			.ok_or(Error::Trailer)?;
-		let mut bytes1 = vec![0_u8; field_widths[0]];
-		let mut bytes2 = vec![0_u8; field_widths[1]];
-		let mut bytes3 = vec![0_u8; field_widths[2]];
+			.and_then(parse_integer_array)
+			.ok_or(Error::Xref(XrefError::Parse))?;
+
+		if field_widths.len() < 3 {
+			return Err(Error::Xref(XrefError::Parse));
+		}
+
+		let mut bytes1 = vec![0_u8; field_widths[0] as usize];
+		let mut bytes2 = vec![0_u8; field_widths[1] as usize];
+		let mut bytes3 = vec![0_u8; field_widths[2] as usize];
 
 		for i in 0..section_indice.len() / 2 {
 			let start = section_indice[2 * i];
 			let count = section_indice[2 * i + 1];
 
 			for j in 0..count {
-				let entry_type = if !bytes1.is_empty() { read_big_endian_interger(&mut reader, bytes1.as_mut_slice()) } else { 1 };
+				let entry_type = if !bytes1.is_empty() { read_big_endian_integer(&mut reader, bytes1.as_mut_slice())? } else { 1 };
 				match entry_type {
 					0 => {
 						//free object
-						read_big_endian_interger(&mut reader, bytes2.as_mut_slice());
-						read_big_endian_interger(&mut reader, bytes3.as_mut_slice());
+						read_big_endian_integer(&mut reader, bytes2.as_mut_slice())?;
+						read_big_endian_integer(&mut reader, bytes3.as_mut_slice())?;
 					}
 					1 => {
 						//normal object
-						let offset = read_big_endian_interger(&mut reader, bytes2.as_mut_slice());
-						let generation = if !bytes3.is_empty() { read_big_endian_interger(&mut reader, bytes3.as_mut_slice()) } else { 0 } as u16;
+						let offset = read_big_endian_integer(&mut reader, bytes2.as_mut_slice())?;
+						let generation = if !bytes3.is_empty() { read_big_endian_integer(&mut reader, bytes3.as_mut_slice())? } else { 0 } as u16;
 						xref.insert(
 							(start + j) as u32,
 							XrefEntry::Normal {
@@ -116,8 +120,8 @@ pub fn decode_xref_stream(mut stream: Stream) -> Result<(Xref, Dictionary)> {
 					}
 					2 => {
 						//compressed object
-						let container = read_big_endian_interger(&mut reader, bytes2.as_mut_slice());
-						let index = read_big_endian_interger(&mut reader, bytes3.as_mut_slice()) as u16;
+						let container = read_big_endian_integer(&mut reader, bytes2.as_mut_slice())?;
+						let index = read_big_endian_integer(&mut reader, bytes3.as_mut_slice())? as u16;
 						xref.insert((start + j) as u32, XrefEntry::Compressed { container, index });
 					}
 					_ => {}
@@ -131,11 +135,22 @@ pub fn decode_xref_stream(mut stream: Stream) -> Result<(Xref, Dictionary)> {
 	Ok((xref, dict))
 }
 
-fn read_big_endian_interger(reader: &mut Cursor<Vec<u8>>, buffer: &mut [u8]) -> u32 {
-	reader.read_exact(buffer).unwrap();
+fn read_big_endian_integer(reader: &mut Cursor<Vec<u8>>, buffer: &mut [u8]) -> Result<u32> {
+	reader.read_exact(buffer)?;
 	let mut value = 0;
 	for &mut byte in buffer {
 		value = (value << 8) + u32::from(byte);
 	}
-	value
+	Ok(value)
+}
+
+fn parse_integer_array(array: &Object) -> Option<Vec<i64>> {
+	let array = array.as_array()?;
+	let mut out = Vec::with_capacity(array.len());
+
+	for n in array {
+		out.push(n.as_i64()?);
+	}
+
+	Some(out)
 }

--- a/tests/modify.rs
+++ b/tests/modify.rs
@@ -25,7 +25,7 @@ fn test_modify() {
 
 fn replace_text() -> Result<Document> {
 	let mut doc = Document::load("assets/example.pdf")?;
-	doc.replace_text(1, "Hello World!", "Modified text!");
+	doc.replace_text(1, "Hello World!", "Modified text!")?;
 	doc.save("test_4_replace.pdf")?;
 
 	let doc = Document::load("test_4_replace.pdf")?;
@@ -34,7 +34,7 @@ fn replace_text() -> Result<Document> {
 
 #[test]
 fn test_replace() {
-	assert_eq!(replace_text().unwrap().extract_text(&[1]), "Modified text!\n");
+	assert_eq!(replace_text().unwrap().extract_text(&[1]).unwrap(), "Modified text!\n");
 }
 
 #[test]

--- a/tests/modify.rs
+++ b/tests/modify.rs
@@ -1,5 +1,4 @@
-use lopdf::{Document, Object};
-use std::io::Result;
+use lopdf::{Document, Object, Result};
 
 fn modify_text() -> Result<Document> {
 	let mut doc = Document::load("assets/example.pdf")?;


### PR DESCRIPTION
This patch should reduce lopdf panics on practically all invalid documents.

I am not sure of the design as this is the first time I make an Error enum. Please review carefully.

I might make another patch that replaces some Options by explicit results to add precise error signaling everywhere in the future to complete this work.