### PR TITLE
Allow loading a document from a memory slice.

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -65,12 +65,16 @@ impl Document {
 	pub fn prune_objects(&mut self) -> Vec<ObjectId> {
 		let mut ids = vec![];
 		let refs = self.traverse_objects(|_| {});
-		for id in self.objects.keys().cloned().collect::<Vec<ObjectId>>() {
-			if !refs.contains(&id) {
-				self.objects.remove(&id);
-				ids.push(id);
+		for id in self.objects.keys() {
+			if !refs.contains(id) {
+				ids.push(*id);
 			}
 		}
+
+		for id in &ids {
+			self.objects.remove(id);
+		}
+
 		ids
 	}
 
@@ -107,12 +111,16 @@ impl Document {
 	/// Delete zero length stream objects.
 	pub fn delete_zero_length_streams(&mut self) -> Vec<ObjectId> {
 		let mut ids = vec![];
-		for id in self.objects.keys().cloned().collect::<Vec<ObjectId>>() {
-			if self.objects.get(&id).and_then(|o| Object::as_stream(o).ok()).map(|stream| stream.content.is_empty()).unwrap_or(false) {
-				self.delete_object(id);
-				ids.push(id);
+		for id in self.objects.keys() {
+			if self.objects.get(id).and_then(|o| Object::as_stream(o).ok()).map(|stream| stream.content.is_empty()).unwrap_or(false) {
+				ids.push(*id);
 			}
 		}
+
+		for id in &ids {
+			self.delete_object(*id);
+		}
+
 		ids
 	}
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -20,18 +20,18 @@ impl Document {
 	#[inline]
 	pub fn load<P: AsRef<Path>>(path: P) -> Result<Document> {
 		let file = File::open(path)?;
-		let buffer = Vec::with_capacity(file.metadata()?.len() as usize);
-		Self::load_internal(file, buffer)
+		let capacity = Some(file.metadata()?.len() as usize);
+		Self::load_internal(file, capacity)
 	}
 
 	/// Load a PDF document from an arbitrary source.
 	#[inline]
 	pub fn load_from<R: Read>(source: R) -> Result<Document> {
-		let buffer = Vec::<u8>::new();
-		Self::load_internal(source, buffer)
+		Self::load_internal(source, None)
 	}
 
-	fn load_internal<R: Read>(mut source: R, mut buffer: Vec<u8>) -> Result<Document> {
+	fn load_internal<R: Read>(mut source: R, capacity: Option<usize>) -> Result<Document> {
+		let mut buffer = capacity.map(Vec::with_capacity).unwrap_or_else(Vec::new);
 		source.read_to_end(&mut buffer)?;
 
 		let mut reader = Reader {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -15,7 +15,7 @@ use crate::{Error, Result};
 use crate::error::XrefError;
 
 impl Document {
-	/// Load PDF document from specified file path.
+	/// Load a PDF document from a specified file path.
 	#[inline]
 	pub fn load<P: AsRef<Path>>(path: P) -> Result<Document> {
 		let file = File::open(path)?;
@@ -23,7 +23,7 @@ impl Document {
 		Self::load_internal(file, buffer)
 	}
 
-	/// Load PDF document from arbitrary source
+	/// Load a PDF document from an arbitrary source.
 	#[inline]
 	pub fn load_from<R: Read>(source: R) -> Result<Document> {
 		let buffer = Vec::<u8>::new();
@@ -34,21 +34,31 @@ impl Document {
 		source.read_to_end(&mut buffer)?;
 
 		let mut reader = Reader {
-			buffer,
+			buffer: &buffer,
 			document: Document::new(),
 		};
 
 		reader.read()?;
 		Ok(reader.document)
 	}
+
+	/// Load a PDF document from a memory slice.
+	pub fn load_mem(buffer: &[u8]) -> Result<Document> {
+		let mut reader = Reader {
+			buffer,
+			document: Document::new(),
+		};
+		reader.read()?;
+		Ok(reader.document)
+	}
 }
 
-pub struct Reader {
-	buffer: Vec<u8>,
+pub struct Reader<'a> {
+	buffer: &'a [u8],
 	document: Document,
 }
 
-impl Reader {
+impl <'a> Reader<'a> {
 	/// Read whole document.
 	fn read(&mut self) -> Result<()> {
 		// The document structure can be expressed in PEG as:

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,5 +1,6 @@
 use log::{error, warn};
 use std::cmp;
+use std::convert::TryInto;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -44,8 +45,16 @@ impl Document {
 
 	/// Load a PDF document from a memory slice.
 	pub fn load_mem(buffer: &[u8]) -> Result<Document> {
+		buffer.try_into()
+	}
+}
+
+impl TryInto<Document> for &[u8] {
+	type Error = Error;
+
+	fn try_into(self) -> Result<Document> {
 		let mut reader = Reader {
-			buffer,
+			buffer: self,
 			document: Document::new(),
 		};
 		reader.read()?;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -34,12 +34,10 @@ impl Document {
 		let mut buffer = capacity.map(Vec::with_capacity).unwrap_or_else(Vec::new);
 		source.read_to_end(&mut buffer)?;
 
-		let reader = Reader {
+		Reader {
 			buffer: &buffer,
 			document: Document::new(),
-		};
-
-		reader.read()
+		}.read()
 	}
 
 	/// Load a PDF document from a memory slice.
@@ -52,11 +50,10 @@ impl TryInto<Document> for &[u8] {
 	type Error = Error;
 
 	fn try_into(self) -> Result<Document> {
-		let reader = Reader {
+		Reader {
 			buffer: self,
 			document: Document::new(),
-		};
-		reader.read()
+		}.read()
 	}
 }
 


### PR DESCRIPTION
Avoids having to go through a Readable object and a buffer copy.