### PR TITLE
Fix datetime parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ dtoa = "0.4.1"
 itoa = "0.3.1"
 encoding = "0.2"
 image = { version = "0.20.0", optional = true }
-chrono = { version = "0.3.0", optional = true }
+chrono = { version = "0.4.3", optional = true }
 log = "0.4.6"
 rayon = "1.0"
 nom = { version = "5.0.0-alpha2", optional = true }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -5,8 +5,6 @@ use chrono::prelude::*;
 use time::strptime;
 use time::{strftime, Tm};
 
-const TIME_FMT_DECODE_STR: &str = "%Y%m%d%H%M%S%z";
-
 #[cfg(feature = "chrono_time")]
 impl From<DateTime<Local>> for Object {
 	fn from(date: DateTime<Local>) -> Self {
@@ -29,8 +27,8 @@ fn convert_utc_offset(bytes: &mut [u8]) {
 }
 
 #[cfg(feature = "chrono_time")]
-impl From<DateTime<UTC>> for Object {
-	fn from(date: DateTime<UTC>) -> Self {
+impl From<DateTime<Utc>> for Object {
+	fn from(date: DateTime<Utc>) -> Self {
 		Object::string_literal(date.format("D:%Y%m%d%H%M%SZ").to_string())
 	}
 }
@@ -65,6 +63,8 @@ impl Object {
 
 	#[cfg(feature = "chrono_time")]
 	pub fn as_datetime(&self) -> Option<DateTime<Local>> {
+	#[cfg(feature = "chrono_time")]
+		const TIME_FMT_DECODE_STR: &str = "%Y%m%d%H%M%S%#z";
 		let text = self.datetime_string()?;
 		DateTime::parse_from_str(&text, TIME_FMT_DECODE_STR).map(|date| date.with_timezone(&Local)).ok()
 	}
@@ -75,6 +75,7 @@ impl Object {
 	/// however, be calculated manually
 	#[cfg(not(feature = "chrono_time"))]
 	pub fn as_datetime(&self) -> Option<Tm> {
+		const TIME_FMT_DECODE_STR: &str = "%Y%m%d%H%M%S%z";
 		let text = self.datetime_string()?;
 		strptime(&text, TIME_FMT_DECODE_STR).ok()
 	}
@@ -92,7 +93,7 @@ fn parse_datetime_local() {
 #[cfg(feature = "chrono_time")]
 #[test]
 fn parse_datetime_utc() {
-	let time = UTC::now().with_nanosecond(0).unwrap();
+	let time = Utc::now().with_nanosecond(0).unwrap();
 	let text: Object = time.into();
 	let time2 = text.as_datetime();
 	assert_eq!(time2, Some(time.with_timezone(&Local)));

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -66,7 +66,7 @@ impl Object {
 	#[cfg(feature = "chrono_time")]
 	pub fn as_datetime(&self) -> Option<DateTime<Local>> {
 		let text = self.datetime_string()?;
-		Local.datetime_from_str(&text, TIME_FMT_DECODE_STR).ok()
+		DateTime::parse_from_str(&text, TIME_FMT_DECODE_STR).map(|date| date.with_timezone(&Local)).ok()
 	}
 
 	/// WARNING: `tm_wday` (weekday), `tm_yday` (day index in year), `tm_isdst`
@@ -82,11 +82,20 @@ impl Object {
 
 #[cfg(feature = "chrono_time")]
 #[test]
-fn parse_datetime() {
+fn parse_datetime_local() {
 	let time = Local::now().with_nanosecond(0).unwrap();
 	let text: Object = time.into();
 	let time2 = text.as_datetime();
 	assert_eq!(time2, Some(time));
+}
+
+#[cfg(feature = "chrono_time")]
+#[test]
+fn parse_datetime_utc() {
+	let time = UTC::now().with_nanosecond(0).unwrap();
+	let text: Object = time.into();
+	let time2 = text.as_datetime();
+	assert_eq!(time2, Some(time.with_timezone(&Local)));
 }
 
 #[cfg(not(feature = "chrono_time"))]


### PR DESCRIPTION
This fixes the timezone handling issue described in #88 

Note that the other issue (handling of incomplete date strings) is not addressed by this change. I would still suggest that this is merged. Addressing the other issue will most likely be a larger effort and it would be nice to get this fixed first.