### PR TITLE
limit recursion to the number of objects

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -296,8 +296,14 @@ impl Iterator for PageTreeIter<'_> {
 	type Item = ObjectId;
 
 	fn next(&mut self) -> Option<Self::Item> {
+		let mut objcount = self.doc.objects.len();
 		loop {
 			while let Some((kid, new_kids)) = self.kids.and_then(|k| k.split_first()) {
+				if objcount == 0 {
+					return None;
+				}
+				objcount -= 1;
+				
 				self.kids = Some(new_kids);
 
 				if let Ok(kid_id) = kid.as_reference() {


### PR DESCRIPTION
a self referential pdf causes infinity loop.

```pdf
%PDF-1.5

1 0 obj
  << /Type /Catalog
     /Pages 2 0 R
  >>
endobj

2 0 obj
  << /Type /Pages
     /Kids [2 0 R]
  >>
endobj

xref
1 3
0000000000 65535 f 
0000000010 00000 n 
0000000069 00000 n 
trailer
  <<  /Root 1 0 R
      /Size 5
  >>
startxref
127
%%EOF


```