### PR TITLE
Move bracket depth checking into parsers.

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -63,28 +63,12 @@ pub struct Reader<'a> {
 	document: Document,
 }
 
-const MAX_BRACKET: usize = 100;
+/// Maximum allowed embedding of literal strings.
+pub const MAX_BRACKET: usize = 100;
 
 impl <'a> Reader<'a> {
 	/// Read whole document.
 	fn read(mut self) -> Result<Document> {
-		fn max_bracket_depth(b: &[u8]) -> usize {
-			let mut cd = 0;
-			let mut md = 0;
-			for b in b.iter() {
-				if *b == b'(' {
-					cd += 1;
-					md = cd.max(md);
-				} else if *b == b')' && cd > 0 {
-					cd -= 1;
-				}
-			}
-			md
-		}
-		if max_bracket_depth(&self.buffer) > MAX_BRACKET {
-			return Err(Error::BracketLimit);
-		}
-
 		// The document structure can be expressed in PEG as:
 		//   document <- header indirect_object* xref trailer xref_start
 		let version = parser::header(&self.buffer).ok_or(Error::Header)?;


### PR DESCRIPTION
Improves #97, this way the checking also applies to filtered (compressed) data.

base64 encoded sample pdf:
```
JVBERi0xLjUKMSAwIG9iajw8L1R5cGUvUGFnZXMvS2lkc1s1IDAgUl0vQ291bnQgMS9SZXNvdXJj
ZXMgMyAwIFIvTWVkaWFCb3hbMCAwIDU5NSA4NDJdPj5lbmRvYmoKMiAwIG9iajw8L1R5cGUvRm9u
dC9TdWJ0eXBlL1R5cGUxL0Jhc2VGb250L0NvdXJpZXI+PmVuZG9iagozIDAgb2JqPDwvRm9udDw8
L0YxIDIgMCBSPj4+PmVuZG9iago1IDAgb2JqPDwvVHlwZS9QYWdlL1BhcmVudCAxIDAgUi9Db250
ZW50c1s0IDAgUl0+PmVuZG9iago2IDAgb2JqPDwvVHlwZS9DYXRhbG9nL1BhZ2VzIDEgMCBSPj5l
bmRvYmoKNCAwIG9iajw8L0xlbmd0aCAgIDg0IC9GaWx0ZXIvRmxhdGVEZWNvZGU+PnN0cmVhbQp4
2u3DsQmDUBAA0P6muHRJFYUQUgcSHODABdRCPgjuX+gSdu/B+1Y8/32+PllL9F2X73NNcQcAAAAA
LjfMrW05bnubbg8AAAAA4HJZa/wqDnT6OQplbmRzdHJlYW0gZW5kb2JqCnhyZWYKMCA3CjAwMDAw
MDAwMDAgNjU1MzUgZiAKMDAwMDAwMDAwOSAwMDAwMCBuIAowMDAwMDAwMDk2IDAwMDAwIG4gCjAw
MDAwMDAxNTUgMDAwMDAgbiAKMDAwMDAwMDI5MSAwMDAwMCBuIAowMDAwMDAwMTkxIDAwMDAwIG4g
CjAwMDAwMDAyNDggMDAwMDAgbiAKdHJhaWxlcgo8PC9Sb290IDYgMCBSL1NpemUgNz4+CnN0YXJ0
eHJlZgo0NDIKJSVFT0YK

```