### PR TITLE
Genericize Content to allow AsRef<[Operation]>

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -1,4 +1,4 @@
-use super::content::Content;
+use super::content::{Content, Operation};
 use super::encodings::{self, bytes_to_string, string_to_bytes};
 use super::{Dictionary, Object, ObjectId};
 use crate::xref::Xref;
@@ -175,7 +175,7 @@ impl Document {
 	}
 
 	/// Get decoded page content;
-	pub fn get_and_decode_page_content(&self, page_id: ObjectId) -> Result<Content> {
+	pub fn get_and_decode_page_content(&self, page_id: ObjectId) -> Result<Content<Vec<Operation>>> {
 		let content_data = self.get_page_content(page_id)?;
 		Content::decode(&content_data)
 	}

--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -398,11 +398,11 @@ fn operation(input: &[u8]) -> NomResult<Operation> {
 		|(operands, operator)| Operation { operator, operands })(input)
 }
 
-fn _content(input: &[u8]) -> NomResult<Content> {
+fn _content(input: &[u8]) -> NomResult<Content<Vec<Operation>>> {
 	preceded(content_space, map(many0(operation), |operations| Content { operations }))(input)
 }
 
-pub fn content(input: &[u8]) -> Option<Content> {
+pub fn content(input: &[u8]) -> Option<Content<Vec<Operation>>> {
 	strip_nom(_content(input))
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -253,7 +253,7 @@ fn operation<'a>() -> Parser<'a, u8, Operation> {
 	operation.map(|(operands, operator)| Operation { operator, operands })
 }
 
-pub fn content(input: &[u8]) -> Option<Content> {
+pub fn content(input: &[u8]) -> Option<Content<Vec<Operation>>> {
 	(content_space() * operation().repeat(0..).map(|operations| Content { operations })).parse(input).ok()
 }
 


### PR DESCRIPTION
This was just `Vec<Operation>` before, which may be the most common use-case and is also required for parsing, since allocation is necessary.
When creating a document allocating a `Vec` per `Content` may not be necessary though, so for that use-case allowing any `AsRef<[Operation]>`, like just a slice, is convenient.

Example:
```
let content = Content {
	operations: /* note the missing vec!*/[
		Operation::new("BT", vec![]),
		Operation::new("Tf", vec!["F1".into(), 48.into()]),
		Operation::new("Td", vec![100.into(), 600.into()]),
		Operation::new("Tj", vec![Object::string_literal("Hello World!")]),
		Operation::new("ET", vec![]),
	],
};
```

The operands for `Operation` still require `Vec`. If the `Operation` struct were to be replaced with an enum as suggested in #109 (with an additional `Custom { operation: AsRef<str>, operands: AsRef<[Object]> }`) that would become unnecessary though. If you like the idea I'd be happy to make a PR for that as well.