### PR TITLE
Merge document PDF logic with some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,45 +19,265 @@ use lopdf::content::{Content, Operation};
 let mut doc = Document::with_version("1.5");
 let pages_id = doc.new_object_id();
 let font_id = doc.add_object(dictionary! {
-	"Type" => "Font",
-	"Subtype" => "Type1",
-	"BaseFont" => "Courier",
+    "Type" => "Font",
+    "Subtype" => "Type1",
+    "BaseFont" => "Courier",
 });
 let resources_id = doc.add_object(dictionary! {
-	"Font" => dictionary! {
-		"F1" => font_id,
-	},
+    "Font" => dictionary! {
+        "F1" => font_id,
+    },
 });
 let content = Content {
-	operations: vec![
-		Operation::new("BT", vec![]),
-		Operation::new("Tf", vec!["F1".into(), 48.into()]),
-		Operation::new("Td", vec![100.into(), 600.into()]),
-		Operation::new("Tj", vec![Object::string_literal("Hello World!")]),
-		Operation::new("ET", vec![]),
-	],
+    operations: vec![
+        Operation::new("BT", vec![]),
+        Operation::new("Tf", vec!["F1".into(), 48.into()]),
+        Operation::new("Td", vec![100.into(), 600.into()]),
+        Operation::new("Tj", vec![Object::string_literal("Hello World!")]),
+        Operation::new("ET", vec![]),
+    ],
 };
 let content_id = doc.add_object(Stream::new(dictionary! {}, content.encode().unwrap()));
 let page_id = doc.add_object(dictionary! {
-	"Type" => "Page",
-	"Parent" => pages_id,
-	"Contents" => content_id,
+    "Type" => "Page",
+    "Parent" => pages_id,
+    "Contents" => content_id,
 });
 let pages = dictionary! {
-	"Type" => "Pages",
-	"Kids" => vec![page_id.into()],
-	"Count" => 1,
-	"Resources" => resources_id,
-	"MediaBox" => vec![0.into(), 0.into(), 595.into(), 842.into()],
+    "Type" => "Pages",
+    "Kids" => vec![page_id.into()],
+    "Count" => 1,
+    "Resources" => resources_id,
+    "MediaBox" => vec![0.into(), 0.into(), 595.into(), 842.into()],
 };
 doc.objects.insert(pages_id, Object::Dictionary(pages));
 let catalog_id = doc.add_object(dictionary! {
-	"Type" => "Catalog",
-	"Pages" => pages_id,
+    "Type" => "Catalog",
+    "Pages" => pages_id,
 });
 doc.trailer.set("Root", catalog_id);
 doc.compress();
 doc.save("example.pdf").unwrap();
+```
+
+* Merge PDF documents
+
+```rust
+#[macro_use]
+extern crate lopdf;
+
+use std::collections::BTreeMap;
+
+use lopdf::content::{Content, Operation};
+use lopdf::{Document, Object, ObjectId, Stream};
+
+pub fn generate_fake_document() -> Document {
+    let mut doc = Document::with_version("1.5");
+    let pages_id = doc.new_object_id();
+    let font_id = doc.add_object(dictionary! {
+        "Type" => "Font",
+        "Subtype" => "Type1",
+        "BaseFont" => "Courier",
+    });
+    let resources_id = doc.add_object(dictionary! {
+        "Font" => dictionary! {
+            "F1" => font_id,
+        },
+    });
+    let content = Content {
+        operations: vec![
+            Operation::new("BT", vec![]),
+            Operation::new("Tf", vec!["F1".into(), 48.into()]),
+            Operation::new("Td", vec![100.into(), 600.into()]),
+            Operation::new("Tj", vec![Object::string_literal("Hello World!")]),
+            Operation::new("ET", vec![]),
+        ],
+    };
+    let content_id = doc.add_object(Stream::new(dictionary! {}, content.encode().unwrap()));
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Parent" => pages_id,
+        "Contents" => content_id,
+        "Resources" => resources_id,
+        "MediaBox" => vec![0.into(), 0.into(), 595.into(), 842.into()],
+    });
+    let pages = dictionary! {
+        "Type" => "Pages",
+        "Kids" => vec![page_id.into()],
+        "Count" => 1,
+    };
+    doc.objects.insert(pages_id, Object::Dictionary(pages));
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => pages_id,
+    });
+    doc.trailer.set("Root", catalog_id);
+
+    doc
+}
+
+fn main() {
+    // Generate a stack of Documents to merge
+    let documents = vec![
+        generate_fake_document(),
+        generate_fake_document(),
+        generate_fake_document(),
+        generate_fake_document(),
+    ];
+
+    // Define a starting max_id (will be used as start index for object_ids)
+    let mut max_id = 1;
+
+    // Collect all Documents Objects grouped by a map
+    let mut documents_pages = BTreeMap::new();
+    let mut documents_objects = BTreeMap::new();
+
+    for mut document in documents {
+        document.renumber_objects_with(max_id);
+
+        max_id = document.max_id + 1;
+
+        documents_pages.extend(
+            document
+                    .get_pages()
+                    .into_iter()
+                    .map(|(_, object_id)| {
+                        (
+                            object_id,
+                            document.get_object(object_id).unwrap().to_owned(),
+                        )
+                    })
+                    .collect::<BTreeMap<ObjectId, Object>>(),
+        );
+        documents_objects.extend(document.objects);
+    }
+
+    // Initialize a new empty document
+    let mut document = Document::with_version("1.5");
+
+    // Catalog and Pages are mandatory
+    let mut catalog_object: Option<(ObjectId, Object)> = None;
+    let mut pages_object: Option<(ObjectId, Object)> = None;
+
+    // Process all objects except "Page" type
+    for (object_id, object) in documents_objects.iter() {
+        // We have to ignore "Page" (as are processed later), "Outlines" and "Outline" objects
+        // All other objects should be collected and inserted into the main Document
+        match object.type_name().unwrap_or("") {
+            "Catalog" => {
+                // Collect a first "Catalog" object and use it for the future "Pages"
+                catalog_object = Some((
+                    if let Some((id, _)) = catalog_object {
+                        id
+                    } else {
+                        *object_id
+                    },
+                    object.clone(),
+                ));
+            }
+            "Pages" => {
+                // Collect and update a first "Pages" object and use it for the future "Catalog"
+                // We have also to merge all dictionaries of the old and the new "Pages" object
+                if let Ok(dictionary) = object.as_dict() {
+                    let mut dictionary = dictionary.clone();
+                    if let Some((_, ref object)) = pages_object {
+                        if let Ok(old_dictionary) = object.as_dict() {
+                            dictionary.extend(old_dictionary);
+                        }
+                    }
+
+                    pages_object = Some((
+                        if let Some((id, _)) = pages_object {
+                            id
+                        } else {
+                            *object_id
+                        },
+                        Object::Dictionary(dictionary),
+                    ));
+                }
+            }
+            "Page" => {}     // Ignored, processed later and separately
+            "Outlines" => {} // Ignored, not supported yet
+            "Outline" => {}  // Ignored, not supported yet
+            _ => {
+                document.objects.insert(*object_id, object.clone());
+            }
+        }
+    }
+
+    // If no "Pages" found abort
+    if pages_object.is_none() {
+        println!("Pages root not found.");
+
+        return;
+    }
+
+    // Iter over all "Page" and collect with the parent "Pages" created before
+    for (object_id, object) in documents_pages.iter() {
+        if let Ok(dictionary) = object.as_dict() {
+            let mut dictionary = dictionary.clone();
+            dictionary.set("Parent", pages_object.as_ref().unwrap().0);
+
+            document
+                    .objects
+                    .insert(*object_id, Object::Dictionary(dictionary));
+        }
+    }
+
+    // If no "Catalog" found abort
+    if catalog_object.is_none() {
+        println!("Catalog root not found.");
+
+        return;
+    }
+
+    let catalog_object = catalog_object.unwrap();
+    let pages_object = pages_object.unwrap();
+
+    // Build a new "Pages" with updated fields
+    if let Ok(dictionary) = pages_object.1.as_dict() {
+        let mut dictionary = dictionary.clone();
+
+        // Set new pages count
+        dictionary.set("Count", documents_pages.len() as u32);
+
+        // Set new "Kids" list (collected from documents pages) for "Pages"
+        dictionary.set(
+            "Kids",
+            documents_pages
+                    .into_iter()
+                    .map(|(object_id, _)| Object::Reference(object_id))
+                    .collect::<Vec<_>>(),
+        );
+
+        document
+                .objects
+                .insert(pages_object.0, Object::Dictionary(dictionary));
+    }
+
+    // Build a new "Catalog" with updated fields
+    if let Ok(dictionary) = catalog_object.1.as_dict() {
+        let mut dictionary = dictionary.clone();
+        dictionary.set("Pages", pages_object.0);
+        dictionary.remove(b"Outlines"); // Outlines not supported in merged PDFs
+
+        document
+                .objects
+                .insert(catalog_object.0, Object::Dictionary(dictionary));
+    }
+
+    document.trailer.set("Root", catalog_object.0);
+
+    // Update the max internal ID as wasn't updated before due to direct objects insertion
+    document.max_id = document.objects.len() as u32;
+
+    // Reorder all new Document objects
+    document.renumber_objects();
+    document.compress();
+
+    // Save the merged PDF
+    document.save("merged.pdf").unwrap();
+}
 ```
 
 * Modify PDF document
@@ -73,8 +293,8 @@ doc.save("modified.pdf")?;
 
 * Why keeping everything in memory as high-level objects until finally serializing the entire document?
 
-	Normally a PDF document won't be very large, ranging form tens of KB to hundreds of MB. Memory size is not a bottle neck for today's computer.
-	By keep the whole document in memory, stream length can be pre-calculated, no need to use a reference object for the Length entry,
-	the resulting PDF file is smaller for distribution and faster for PDF consumers to process.
+    Normally a PDF document won't be very large, ranging form tens of KB to hundreds of MB. Memory size is not a bottle neck for today's computer.
+    By keep the whole document in memory, stream length can be pre-calculated, no need to use a reference object for the Length entry,
+    the resulting PDF file is smaller for distribution and faster for PDF consumers to process.
 
-	Producing is a one-time effort, while consuming is many more.
+    Producing is a one-time effort, while consuming is many more.

--- a/examples/merge.rs
+++ b/examples/merge.rs
@@ -149,18 +149,13 @@ fn main() {
 
     // Iter over all "Page" and collect with the parent "Pages" created before
     for (object_id, object) in documents_pages.iter() {
-        match object.type_name().unwrap_or("") {
-            "Page" => {
-                if let Ok(dictionary) = object.as_dict() {
-                    let mut dictionary = dictionary.clone();
-                    dictionary.set("Parent", pages_object.as_ref().unwrap().0);
+        if let Ok(dictionary) = object.as_dict() {
+            let mut dictionary = dictionary.clone();
+            dictionary.set("Parent", pages_object.as_ref().unwrap().0);
 
-                    document
-                        .objects
-                        .insert(*object_id, Object::Dictionary(dictionary));
-                }
-            }
-            _ => {}
+            document
+                .objects
+                .insert(*object_id, Object::Dictionary(dictionary));
         }
     }
 

--- a/examples/merge.rs
+++ b/examples/merge.rs
@@ -1,0 +1,201 @@
+#[macro_use]
+extern crate lopdf;
+
+use lopdf::content::{Content, Operation};
+use lopdf::{Document, Object, ObjectId, Stream};
+
+pub fn generate_fake_document() -> Document {
+    let mut doc = Document::with_version("1.5");
+    let pages_id = doc.new_object_id();
+    let font_id = doc.add_object(dictionary! {
+        "Type" => "Font",
+        "Subtype" => "Type1",
+        "BaseFont" => "Courier",
+    });
+    let resources_id = doc.add_object(dictionary! {
+        "Font" => dictionary! {
+            "F1" => font_id,
+        },
+    });
+    let content = Content {
+        operations: vec![
+            Operation::new("BT", vec![]),
+            Operation::new("Tf", vec!["F1".into(), 48.into()]),
+            Operation::new("Td", vec![100.into(), 600.into()]),
+            Operation::new("Tj", vec![Object::string_literal("Hello World!")]),
+            Operation::new("ET", vec![]),
+        ],
+    };
+    let content_id = doc.add_object(Stream::new(dictionary! {}, content.encode().unwrap()));
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Parent" => pages_id,
+        "Contents" => content_id,
+        "Resources" => resources_id,
+        "MediaBox" => vec![0.into(), 0.into(), 595.into(), 842.into()],
+    });
+    let pages = dictionary! {
+        "Type" => "Pages",
+        "Kids" => vec![page_id.into()],
+        "Count" => 1,
+    };
+    doc.objects.insert(pages_id, Object::Dictionary(pages));
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => pages_id,
+    });
+    doc.trailer.set("Root", catalog_id);
+
+    doc
+}
+
+fn main() {
+    // Generate a stack of Documents to merge
+    let documents = vec![
+        generate_fake_document(),
+        generate_fake_document(),
+        generate_fake_document(),
+        generate_fake_document(),
+    ];
+
+    // Define a starting max_id (will be used as start index for object_ids)
+    let mut max_id = 1;
+
+    // Collect all Documents Objects grouped by a map
+    let mut documents_objects = Vec::new();
+    for mut document in documents {
+        document.renumber_objects_with(max_id);
+
+        max_id = document.max_id + 1;
+
+        documents_objects.push(document.objects);
+    }
+
+    // Initialize a new empty document
+    let mut document = Document::with_version("1.5");
+
+    // Catalog and Pages are mandatory
+    let mut catalog_object: Option<(ObjectId, Object)> = None;
+    let mut pages_object: Option<(ObjectId, Object)> = None;
+
+    // Iter on all Documents Objects collected before
+    let mut pages: Vec<ObjectId> = Vec::new();
+    for document_objects in documents_objects {
+        // Process all objects except "Page" type
+        for (object_id, object) in document_objects.iter() {
+            // We have to ignore "Page" (as are processed later), "Outlines" and "Outline" objects
+            // All other objects should be collected and inserted into the main Document
+            match object.type_name().unwrap_or("") {
+                "Catalog" => {
+                    // Collect a first "Catalog" object and use it for the future "Pages"
+                    catalog_object = Some((
+                        if let Some((id, _)) = catalog_object {
+                            id
+                        } else {
+                            *object_id
+                        },
+                        object.clone(),
+                    ));
+                }
+                "Pages" => {
+                    // Collect and update a first "Pages" object and use it for the future "Catalog"
+                    // We have also to merge all dictionaries of the old and the new "Pages" object
+                    if let Ok(dictionary) = object.as_dict() {
+                        let mut dictionary = dictionary.clone();
+                        if let Some((_, ref object)) = pages_object {
+                            if let Ok(old_dictionary) = object.as_dict() {
+                                dictionary.extend(old_dictionary);
+                            }
+                        }
+
+                        pages_object = Some((
+                            if let Some((id, _)) = pages_object {
+                                id
+                            } else {
+                                *object_id
+                            },
+                            Object::Dictionary(dictionary),
+                        ));
+                    }
+                }
+                "Page" => {}     // Ignored, processed later and separately
+                "Outlines" => {} // Ignored, not supported yet
+                "Outline" => {}  // Ignored, not supported yet
+                _ => {
+                    document.objects.insert(*object_id, object.clone());
+                }
+            }
+        }
+
+        // If no "Pages" found abort
+        if pages_object.is_none() {
+            println!("Pages root not found.");
+
+            return;
+        }
+
+        // Iter over all "Page" and collect with the parent "Pages" created before
+        for (object_id, object) in document_objects.into_iter() {
+            match object.type_name().unwrap_or("") {
+                "Page" => {
+                    if let Ok(dictionary) = object.as_dict() {
+                        let mut dictionary = dictionary.clone();
+                        dictionary.set("Parent", pages_object.as_ref().unwrap().0);
+
+                        document
+                            .objects
+                            .insert(object_id, Object::Dictionary(dictionary));
+
+                        pages.push(object_id);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // If no "Catalog" found abort
+    if catalog_object.is_none() {
+        println!("Catalog root not found.");
+
+        return;
+    }
+
+    let catalog_object = catalog_object.unwrap();
+    let pages_object = pages_object.unwrap();
+
+    // Build a new "Pages" with updated fields
+    if let Ok(dictionary) = pages_object.1.as_dict() {
+        let count = pages.len();
+
+        let mut dictionary = dictionary.clone();
+        dictionary.set("Count", count as u32);
+
+        document
+            .objects
+            .insert(pages_object.0, Object::Dictionary(dictionary));
+    }
+
+    // Build a new "Catalog" with updated fields
+    if let Ok(dictionary) = catalog_object.1.as_dict() {
+        let mut dictionary = dictionary.clone();
+        dictionary.set("Pages", pages_object.0);
+        dictionary.remove(b"Outlines"); // Outlines not supported in merged PDFs
+
+        document
+            .objects
+            .insert(catalog_object.0, Object::Dictionary(dictionary));
+    }
+
+    document.trailer.set("Root", catalog_object.0);
+
+    // Update the max internal ID as wasn't updated before due to direct objects insertion
+    document.max_id = document.objects.len() as u32;
+
+    // Reorder all new Document objects
+    document.renumber_objects();
+    document.compress();
+
+    // Save the merged PDF
+    document.save("merged.pdf").unwrap();
+}

--- a/src/object.rs
+++ b/src/object.rs
@@ -331,6 +331,10 @@ impl Dictionary {
 			.and_then(Object::as_name_str)
 			.unwrap_or("StandardEncoding")
 	}
+
+	pub fn extend(&mut self, other: &Dictionary) {
+		self.0.extend(other.to_owned().0)
+	}
 }
 
 #[macro_export]

--- a/src/object.rs
+++ b/src/object.rs
@@ -16,55 +16,55 @@ pub struct Dictionary(LinkedHashMap<Vec<u8>, Object>);
 /// the stream dictionary may be a direct object
 #[derive(Debug, Clone)]
 pub struct Stream {
-	/// Associated stream dictionary
-	pub dict: Dictionary,
-	/// Contents of the stream in bytes
-	pub content: Vec<u8>,
-	/// Can the stream be compressed by the `Document::compress()` function?
-	/// Font streams may not be compressed, for example
-	pub allows_compression: bool,
-	/// Stream data's position in PDF file.
-	pub start_position: Option<usize>,
+    /// Associated stream dictionary
+    pub dict: Dictionary,
+    /// Contents of the stream in bytes
+    pub content: Vec<u8>,
+    /// Can the stream be compressed by the `Document::compress()` function?
+    /// Font streams may not be compressed, for example
+    pub allows_compression: bool,
+    /// Stream data's position in PDF file.
+    pub start_position: Option<usize>,
 }
 
 /// Basic PDF object types defined in an enum.
 #[derive(Clone)]
 pub enum Object {
-	Null,
-	Boolean(bool),
-	Integer(i64),
-	Real(f64),
-	Name(Vec<u8>),
-	String(Vec<u8>, StringFormat),
-	Array(Vec<Object>),
-	Dictionary(Dictionary),
-	Stream(Stream),
-	Reference(ObjectId),
+    Null,
+    Boolean(bool),
+    Integer(i64),
+    Real(f64),
+    Name(Vec<u8>),
+    String(Vec<u8>, StringFormat),
+    Array(Vec<Object>),
+    Dictionary(Dictionary),
+    Stream(Stream),
+    Reference(ObjectId),
 }
 
 /// String objects can be written in two formats.
 #[derive(Debug, Clone)]
 pub enum StringFormat {
-	Literal,
-	Hexadecimal,
+    Literal,
+    Hexadecimal,
 }
 
 impl Default for StringFormat {
-	fn default() -> StringFormat {
-		StringFormat::Literal
-	}
+    fn default() -> StringFormat {
+        StringFormat::Literal
+    }
 }
 
 impl From<bool> for Object {
-	fn from(value: bool) -> Self {
-		Object::Boolean(value)
-	}
+    fn from(value: bool) -> Self {
+        Object::Boolean(value)
+    }
 }
 
 impl From<i64> for Object {
-	fn from(number: i64) -> Self {
-		Object::Integer(number)
-	}
+    fn from(number: i64) -> Self {
+        Object::Integer(number)
+    }
 }
 
 macro_rules! from_smaller_ints {
@@ -80,261 +80,356 @@ macro_rules! from_smaller_ints {
 }
 
 from_smaller_ints! {
-	i8 i16 i32
-	u8 u16 u32
+    i8 i16 i32
+    u8 u16 u32
 }
 
 impl From<f64> for Object {
-	fn from(number: f64) -> Self {
-		Object::Real(number)
-	}
+    fn from(number: f64) -> Self {
+        Object::Real(number)
+    }
 }
 
 impl From<f32> for Object {
-	fn from(number: f32) -> Self {
-		Object::Real(f64::from(number))
-	}
+    fn from(number: f32) -> Self {
+        Object::Real(f64::from(number))
+    }
 }
 
 impl From<String> for Object {
-	fn from(name: String) -> Self {
-		Object::Name(name.into_bytes())
-	}
+    fn from(name: String) -> Self {
+        Object::Name(name.into_bytes())
+    }
 }
 
 impl<'a> From<&'a str> for Object {
-	fn from(name: &'a str) -> Self {
-		Object::Name(name.as_bytes().to_vec())
-	}
+    fn from(name: &'a str) -> Self {
+        Object::Name(name.as_bytes().to_vec())
+    }
 }
 
 impl From<Vec<Object>> for Object {
-	fn from(array: Vec<Object>) -> Self {
-		Object::Array(array)
-	}
+    fn from(array: Vec<Object>) -> Self {
+        Object::Array(array)
+    }
 }
 
 impl From<Dictionary> for Object {
-	fn from(dcit: Dictionary) -> Self {
-		Object::Dictionary(dcit)
-	}
+    fn from(dcit: Dictionary) -> Self {
+        Object::Dictionary(dcit)
+    }
 }
 
 impl From<Stream> for Object {
-	fn from(stream: Stream) -> Self {
-		Object::Stream(stream)
-	}
+    fn from(stream: Stream) -> Self {
+        Object::Stream(stream)
+    }
 }
 
 impl From<ObjectId> for Object {
-	fn from(id: ObjectId) -> Self {
-		Object::Reference(id)
-	}
+    fn from(id: ObjectId) -> Self {
+        Object::Reference(id)
+    }
 }
 
 impl Object {
-	pub fn string_literal<S: Into<Vec<u8>>>(s: S) -> Self {
-		Object::String(s.into(), StringFormat::Literal)
-	}
+    pub fn string_literal<S: Into<Vec<u8>>>(s: S) -> Self {
+        Object::String(s.into(), StringFormat::Literal)
+    }
 
-	pub fn is_null(&self) -> bool {
-		match *self {
-			Object::Null => true,
-			_ => false,
-		}
-	}
+    pub fn is_null(&self) -> bool {
+        match *self {
+            Object::Null => true,
+            _ => false,
+        }
+    }
 
-	pub fn as_i64(&self) -> Result<i64> {
-		match *self {
-			Object::Integer(ref value) => Ok(*value),
-			_ => Err(Error::Type),
-		}
-	}
+    pub fn as_i64(&self) -> Result<i64> {
+        match *self {
+            Object::Integer(ref value) => Ok(*value),
+            _ => Err(Error::Type),
+        }
+    }
 
-	pub fn as_f64(&self) -> Result<f64> {
-		match *self {
-			Object::Real(ref value) => Ok(*value),
-			_ => Err(Error::Type),
-		}
-	}
+    pub fn as_f64(&self) -> Result<f64> {
+        match *self {
+            Object::Real(ref value) => Ok(*value),
+            _ => Err(Error::Type),
+        }
+    }
 
-	pub fn as_name(&self) -> Result<&[u8]> {
-		match *self {
-			Object::Name(ref name) => Ok(name),
-			_ => Err(Error::Type),
-		}
-	}
+    pub fn as_name(&self) -> Result<&[u8]> {
+        match *self {
+            Object::Name(ref name) => Ok(name),
+            _ => Err(Error::Type),
+        }
+    }
 
-	pub fn as_name_str(&self) -> Result<&str> {
-		Ok(str::from_utf8(self.as_name()?)?)
-	}
+    pub fn as_name_str(&self) -> Result<&str> {
+        Ok(str::from_utf8(self.as_name()?)?)
+    }
 
-	pub fn as_str(&self) -> Result<&[u8]> {
-		match self {
-			Object::String(string, _) => Ok(string),
-			_ => Err(Error::Type)
-		}
-	}
+    pub fn as_str(&self) -> Result<&[u8]> {
+        match self {
+            Object::String(string, _) => Ok(string),
+            _ => Err(Error::Type),
+        }
+    }
 
-	pub fn as_str_mut(&mut self) -> Result<&mut Vec<u8>> {
-		match self {
-			Object::String(string, _) => Ok(string),
-			_ => Err(Error::Type)
-		}
-	}
+    pub fn as_str_mut(&mut self) -> Result<&mut Vec<u8>> {
+        match self {
+            Object::String(string, _) => Ok(string),
+            _ => Err(Error::Type),
+        }
+    }
 
-	pub fn as_reference(&self) -> Result<ObjectId> {
-		match *self {
-			Object::Reference(ref id) => Ok(*id),
-			_ => Err(Error::Type),
-		}
-	}
+    pub fn as_reference(&self) -> Result<ObjectId> {
+        match *self {
+            Object::Reference(ref id) => Ok(*id),
+            _ => Err(Error::Type),
+        }
+    }
 
-	pub fn as_array(&self) -> Result<&Vec<Object>> {
-		match *self {
-			Object::Array(ref arr) => Ok(arr),
-			_ => Err(Error::Type),
-		}
-	}
+    pub fn as_array(&self) -> Result<&Vec<Object>> {
+        match *self {
+            Object::Array(ref arr) => Ok(arr),
+            _ => Err(Error::Type),
+        }
+    }
 
-	pub fn as_array_mut(&mut self) -> Result<&mut Vec<Object>> {
-		match *self {
-			Object::Array(ref mut arr) => Ok(arr),
-			_ => Err(Error::Type),
-		}
-	}
+    pub fn as_array_mut(&mut self) -> Result<&mut Vec<Object>> {
+        match *self {
+            Object::Array(ref mut arr) => Ok(arr),
+            _ => Err(Error::Type),
+        }
+    }
 
-	pub fn as_dict(&self) -> Result<&Dictionary> {
-		match *self {
-			Object::Dictionary(ref dict) => Ok(dict),
-			_ => Err(Error::Type),
-		}
-	}
+    pub fn as_dict(&self) -> Result<&Dictionary> {
+        match *self {
+            Object::Dictionary(ref dict) => Ok(dict),
+            _ => Err(Error::Type),
+        }
+    }
 
-	pub fn as_dict_mut(&mut self) -> Result<&mut Dictionary> {
-		match *self {
-			Object::Dictionary(ref mut dict) => Ok(dict),
-			_ => Err(Error::Type),
-		}
-	}
+    pub fn as_dict_mut(&mut self) -> Result<&mut Dictionary> {
+        match *self {
+            Object::Dictionary(ref mut dict) => Ok(dict),
+            _ => Err(Error::Type),
+        }
+    }
 
-	pub fn as_stream(&self) -> Result<&Stream> {
-		match *self {
-			Object::Stream(ref stream) => Ok(stream),
-			_ => Err(Error::Type),
-		}
-	}
+    pub fn as_stream(&self) -> Result<&Stream> {
+        match *self {
+            Object::Stream(ref stream) => Ok(stream),
+            _ => Err(Error::Type),
+        }
+    }
 
-	pub fn as_stream_mut(&mut self) -> Result<&mut Stream> {
-		match *self {
-			Object::Stream(ref mut stream) => Ok(stream),
-			_ => Err(Error::Type),
-		}
-	}
+    pub fn as_stream_mut(&mut self) -> Result<&mut Stream> {
+        match *self {
+            Object::Stream(ref mut stream) => Ok(stream),
+            _ => Err(Error::Type),
+        }
+    }
 
-	pub fn type_name(&self) -> Result<&str> {
-		match *self {
-			Object::Dictionary(ref dict) => dict.type_name(),
-			Object::Stream(ref stream) => stream.dict.type_name(),
-			_ => Err(Error::Type),
-		}
-	}
+    pub fn type_name(&self) -> Result<&str> {
+        match *self {
+            Object::Dictionary(ref dict) => dict.type_name(),
+            Object::Stream(ref stream) => stream.dict.type_name(),
+            _ => Err(Error::Type),
+        }
+    }
 }
 
 impl fmt::Debug for Object {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		match *self {
-			Object::Null => f.write_str("null"),
-			Object::Boolean(ref value) => {
-				if *value {
-					f.write_str("true")
-				} else {
-					f.write_str("false")
-				}
-			}
-			Object::Integer(ref value) => write!(f, "{}", *value),
-			Object::Real(ref value) => write!(f, "{}", *value),
-			Object::Name(ref name) => write!(f, "/{}", String::from_utf8_lossy(name)),
-			Object::String(ref text, _) => write!(f, "({})", String::from_utf8_lossy(text)),
-			Object::Array(ref array) => {
-				let items = array.iter().map(|item| format!("{:?}", item)).collect::<Vec<String>>();
-				write!(f, "[{}]", items.join(" "))
-			}
-			Object::Dictionary(ref dict) => write!(f, "{:?}", dict),
-			Object::Stream(ref stream) => write!(f, "{:?}stream...endstream", stream.dict),
-			Object::Reference(ref id) => write!(f, "{} {} R", id.0, id.1),
-		}
-	}
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Object::Null => f.write_str("null"),
+            Object::Boolean(ref value) => {
+                if *value {
+                    f.write_str("true")
+                } else {
+                    f.write_str("false")
+                }
+            }
+            Object::Integer(ref value) => write!(f, "{}", *value),
+            Object::Real(ref value) => write!(f, "{}", *value),
+            Object::Name(ref name) => write!(f, "/{}", String::from_utf8_lossy(name)),
+            Object::String(ref text, _) => write!(f, "({})", String::from_utf8_lossy(text)),
+            Object::Array(ref array) => {
+                let items = array
+                    .iter()
+                    .map(|item| format!("{:?}", item))
+                    .collect::<Vec<String>>();
+                write!(f, "[{}]", items.join(" "))
+            }
+            Object::Dictionary(ref dict) => write!(f, "{:?}", dict),
+            Object::Stream(ref stream) => write!(f, "{:?}stream...endstream", stream.dict),
+            Object::Reference(ref id) => write!(f, "{} {} R", id.0, id.1),
+        }
+    }
 }
 
 impl Dictionary {
-	pub fn new() -> Dictionary {
-		Dictionary(LinkedHashMap::new())
-	}
+    pub fn new() -> Dictionary {
+        Dictionary(LinkedHashMap::new())
+    }
 
-	pub fn has(&self, key: &[u8]) -> bool {
-		self.0.contains_key(key)
-	}
+    pub fn has(&self, key: &[u8]) -> bool {
+        self.0.contains_key(key)
+    }
 
-	pub fn get(&self, key: &[u8]) -> Result<&Object> {
-		self.0.get(key).ok_or(Error::DictKey)
-	}
+    pub fn get(&self, key: &[u8]) -> Result<&Object> {
+        self.0.get(key).ok_or(Error::DictKey)
+    }
 
-	/// Extract object from dictionary, dereferencing the object if it
-	/// is a reference.
-	pub fn get_deref<'a>(&'a self, key: &[u8], doc: &'a Document) -> Result<&'a Object> {
-		doc.dereference(self.get(key)?).map(|(_, object)| object)
-	}
+    /// Extract object from dictionary, dereferencing the object if it
+    /// is a reference.
+    pub fn get_deref<'a>(&'a self, key: &[u8], doc: &'a Document) -> Result<&'a Object> {
+        doc.dereference(self.get(key)?).map(|(_, object)| object)
+    }
 
-	pub fn get_mut(&mut self, key: &[u8]) -> Result<&mut Object> {
-		self.0.get_mut(key).ok_or(Error::DictKey)
-	}
+    pub fn get_mut(&mut self, key: &[u8]) -> Result<&mut Object> {
+        self.0.get_mut(key).ok_or(Error::DictKey)
+    }
 
-	pub fn set<K, V>(&mut self, key: K, value: V)
-	where
-		K: Into<Vec<u8>>,
-		V: Into<Object>,
-	{
-		self.0.insert(key.into(), value.into());
-	}
+    pub fn set<K, V>(&mut self, key: K, value: V)
+    where
+        K: Into<Vec<u8>>,
+        V: Into<Object>,
+    {
+        self.0.insert(key.into(), value.into());
+    }
 
-	pub fn len(&self) -> usize {
-		self.0.len()
-	}
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 
-	pub fn is_empty(&self) -> bool {
-		self.0.len() == 0
-	}
+    pub fn is_empty(&self) -> bool {
+        self.0.len() == 0
+    }
 
-	pub fn remove(&mut self, key: &[u8]) -> Option<Object> {
-		self.0.remove(key)
-	}
+    pub fn remove(&mut self, key: &[u8]) -> Option<Object> {
+        self.0.remove(key)
+    }
 
-	pub fn type_name(&self) -> Result<&str> {
-		self.get(b"Type").and_then(Object::as_name_str).or_else(|_| self.get(b"Linearized").and(Ok("Linearized")))
-	}
+    pub fn type_name(&self) -> Result<&str> {
+        self.get(b"Type")
+            .and_then(Object::as_name_str)
+            .or_else(|_| self.get(b"Linearized").and(Ok("Linearized")))
+    }
 
-	pub fn type_is(&self, type_name: &[u8]) -> bool {
-		self.get(b"Type").and_then(Object::as_name).ok() == Some(type_name)
-	}
+    pub fn type_is(&self, type_name: &[u8]) -> bool {
+        self.get(b"Type").and_then(Object::as_name).ok() == Some(type_name)
+    }
 
-	pub fn iter(&self) -> Iter<'_, Vec<u8>, Object> {
-		self.0.iter()
-	}
+    pub fn iter(&self) -> Iter<'_, Vec<u8>, Object> {
+        self.0.iter()
+    }
 
-	pub fn iter_mut(&mut self) -> IterMut<'_, Vec<u8>, Object> {
-		self.0.iter_mut()
-	}
+    pub fn iter_mut(&mut self) -> IterMut<'_, Vec<u8>, Object> {
+        self.0.iter_mut()
+    }
 
-	pub fn get_font_encoding(&self) -> &str {
-		self.get(b"Encoding")
-			.and_then(Object::as_name_str)
-			.unwrap_or("StandardEncoding")
-	}
+    pub fn get_font_encoding(&self) -> &str {
+        self.get(b"Encoding")
+            .and_then(Object::as_name_str)
+            .unwrap_or("StandardEncoding")
+    }
 
-	pub fn extend(&mut self, other: &Dictionary) {
-		self.0.extend(other.to_owned().0)
-	}
+    pub fn extend(&mut self, other: &Dictionary) {
+        let keep_both_objects = |new_dict: &mut LinkedHashMap<Vec<u8>, Object>,
+                                 key: &Vec<u8>,
+                                 value: &Object,
+                                 old_value: &Object| {
+            let mut final_array = Vec::new();
+            match value {
+                Object::Array(array) => {
+                    final_array.push(old_value.to_owned());
+                    final_array.extend(array.to_owned());
+                }
+                _ => {
+                    final_array.push(value.to_owned());
+                    final_array.push(old_value.to_owned());
+                }
+            }
+
+            new_dict.insert(key.to_owned(), Object::Array(final_array));
+        };
+
+        let mut new_dict = LinkedHashMap::new();
+        for (key, value) in other.0.iter() {
+            if let Some(old_value) = self.0.get(key) {
+                match old_value {
+                    Object::Dictionary(old_dict) => match value {
+                        Object::Dictionary(dict) => {
+                            let mut replaced_dict = old_dict.to_owned();
+                            replaced_dict.extend(dict);
+
+                            new_dict.insert(key.to_owned(), Object::Dictionary(replaced_dict));
+                        }
+                        _ => keep_both_objects(&mut new_dict, key, value, old_value),
+                    },
+                    Object::Array(old_array) => match value {
+                        Object::Array(array) => {
+                            let mut replaced_array = old_array.to_owned();
+                            replaced_array.extend(array.to_owned());
+
+                            new_dict.insert(key.to_owned(), Object::Array(replaced_array));
+                        }
+                        _ => keep_both_objects(&mut new_dict, key, value, old_value),
+                    },
+                    Object::Integer(old_id) => match value {
+                        Object::Integer(id) => {
+                            let mut array = Vec::new();
+                            array.push(Object::Integer(*old_id));
+                            array.push(Object::Integer(*id));
+
+                            new_dict.insert(key.to_owned(), Object::Array(array));
+                        }
+                        _ => keep_both_objects(&mut new_dict, key, value, old_value),
+                    },
+                    Object::Real(old_id) => match value {
+                        Object::Real(id) => {
+                            let mut array = Vec::new();
+                            array.push(Object::Real(*old_id));
+                            array.push(Object::Real(*id));
+
+                            new_dict.insert(key.to_owned(), Object::Array(array));
+                        }
+                        _ => keep_both_objects(&mut new_dict, key, value, old_value),
+                    },
+                    Object::String(old_ids, old_format) => match value {
+                        Object::String(ids, format) => {
+                            let mut array = Vec::new();
+                            array.push(Object::String(old_ids.to_owned(), old_format.to_owned()));
+                            array.push(Object::String(ids.to_owned(), format.to_owned()));
+
+                            new_dict.insert(key.to_owned(), Object::Array(array));
+                        }
+                        _ => keep_both_objects(&mut new_dict, key, value, old_value),
+                    },
+                    Object::Reference(old_object_id) => match value {
+                        Object::Reference(object_id) => {
+                            let mut array = Vec::new();
+                            array.push(Object::Reference(*old_object_id));
+                            array.push(Object::Reference(*object_id));
+
+                            new_dict.insert(key.to_owned(), Object::Array(array));
+                        }
+                        _ => keep_both_objects(&mut new_dict, key, value, old_value),
+                    },
+                    _ => {
+                        new_dict.insert(key.to_owned(), old_value.to_owned());
+                    }
+                }
+            } else {
+                new_dict.insert(key.to_owned(), value.to_owned());
+            }
+        }
+
+        self.0 = new_dict;
+    }
 }
 
 #[macro_export]
@@ -355,215 +450,245 @@ macro_rules! dictionary {
 }
 
 impl fmt::Debug for Dictionary {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		let entries = self.into_iter().map(|(key, value)| format!("/{} {:?}", String::from_utf8_lossy(key), value)).collect::<Vec<String>>();
-		write!(f, "<<{}>>", entries.concat())
-	}
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let entries = self
+            .into_iter()
+            .map(|(key, value)| format!("/{} {:?}", String::from_utf8_lossy(key), value))
+            .collect::<Vec<String>>();
+        write!(f, "<<{}>>", entries.concat())
+    }
 }
 
 impl<'a> IntoIterator for &'a Dictionary {
-	type Item = (&'a Vec<u8>, &'a Object);
-	type IntoIter = linked_hash_map::Iter<'a, Vec<u8>, Object>;
+    type Item = (&'a Vec<u8>, &'a Object);
+    type IntoIter = linked_hash_map::Iter<'a, Vec<u8>, Object>;
 
-	fn into_iter(self) -> Self::IntoIter {
-		self.0.iter()
-	}
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
 }
 
 use std::iter::FromIterator;
 impl<K: Into<Vec<u8>>> FromIterator<(K, Object)> for Dictionary {
-	fn from_iter<I: IntoIterator<Item = (K, Object)>>(iter: I) -> Self {
-		let mut dict = Dictionary::new();
-		for (k, v) in iter {
-			dict.set(k, v);
-		}
-		dict
-	}
+    fn from_iter<I: IntoIterator<Item = (K, Object)>>(iter: I) -> Self {
+        let mut dict = Dictionary::new();
+        for (k, v) in iter {
+            dict.set(k, v);
+        }
+        dict
+    }
 }
 
 impl Stream {
-	pub fn new(mut dict: Dictionary, content: Vec<u8>) -> Stream {
-		dict.set("Length", content.len() as i64);
-		Stream {
-			dict,
-			content,
-			allows_compression: true,
-			start_position: None,
-		}
-	}
+    pub fn new(mut dict: Dictionary, content: Vec<u8>) -> Stream {
+        dict.set("Length", content.len() as i64);
+        Stream {
+            dict,
+            content,
+            allows_compression: true,
+            start_position: None,
+        }
+    }
 
-	pub fn with_position(dict: Dictionary, position: usize) -> Stream {
-		Stream {
-			dict,
-			content: vec![],
-			allows_compression: true,
-			start_position: Some(position),
-		}
-	}
+    pub fn with_position(dict: Dictionary, position: usize) -> Stream {
+        Stream {
+            dict,
+            content: vec![],
+            allows_compression: true,
+            start_position: Some(position),
+        }
+    }
 
-	/// Default is that the stream may be compressed. On font streams,
-	/// set this to false, otherwise the font will be corrupt
-	#[inline]
-	pub fn with_compression(mut self, allows_compression: bool) -> Stream {
-		self.allows_compression = allows_compression;
-		self
-	}
+    /// Default is that the stream may be compressed. On font streams,
+    /// set this to false, otherwise the font will be corrupt
+    #[inline]
+    pub fn with_compression(mut self, allows_compression: bool) -> Stream {
+        self.allows_compression = allows_compression;
+        self
+    }
 
-	// Return first filter
-	pub fn filter(&self) -> Result<String> {
-		self.filters().and_then(|f| f.into_iter().nth(0).ok_or(Error::ObjectNotFound))
-	}
+    // Return first filter
+    pub fn filter(&self) -> Result<String> {
+        self.filters()
+            .and_then(|f| f.into_iter().nth(0).ok_or(Error::ObjectNotFound))
+    }
 
-	pub fn filters(&self) -> Result<Vec<String>> {
-		let filter = self.dict.get(b"Filter")?;
+    pub fn filters(&self) -> Result<Vec<String>> {
+        let filter = self.dict.get(b"Filter")?;
 
-		if let Ok(name) = filter.as_name_str() {
-			Ok(vec![name.into()])
-		} else if let Ok(names) = filter.as_array() {
-			let out_names: Vec<_> = names.iter().filter_map(|n| Object::as_name_str(n).ok()).map(Into::into).collect();
+        if let Ok(name) = filter.as_name_str() {
+            Ok(vec![name.into()])
+        } else if let Ok(names) = filter.as_array() {
+            let out_names: Vec<_> = names
+                .iter()
+                .filter_map(|n| Object::as_name_str(n).ok())
+                .map(Into::into)
+                .collect();
 
-			// It is an error if a single conversion fails.
-			if out_names.len() == names.len() {
-				Ok(out_names)
-			} else {
-				Err(Error::Type)
-			}
-		} else {
-			Err(Error::Type)
-		}
-	}
+            // It is an error if a single conversion fails.
+            if out_names.len() == names.len() {
+                Ok(out_names)
+            } else {
+                Err(Error::Type)
+            }
+        } else {
+            Err(Error::Type)
+        }
+    }
 
-	pub fn set_content(&mut self, content: Vec<u8>) {
-		self.content = content;
-		self.dict.set("Length", self.content.len() as i64);
-	}
+    pub fn set_content(&mut self, content: Vec<u8>) {
+        self.content = content;
+        self.dict.set("Length", self.content.len() as i64);
+    }
 
-	pub fn set_plain_content(&mut self, content: Vec<u8>) {
-		self.dict.remove(b"DecodeParms");
-		self.dict.remove(b"Filter");
-		self.dict.set("Length", content.len() as i64);
-		self.content = content;
-	}
+    pub fn set_plain_content(&mut self, content: Vec<u8>) {
+        self.dict.remove(b"DecodeParms");
+        self.dict.remove(b"Filter");
+        self.dict.set("Length", content.len() as i64);
+        self.content = content;
+    }
 
-	pub fn compress(&mut self) -> Result<()> {
-		use flate2::write::ZlibEncoder;
-		use flate2::Compression;
-		use std::io::prelude::*;
+    pub fn compress(&mut self) -> Result<()> {
+        use flate2::write::ZlibEncoder;
+        use flate2::Compression;
+        use std::io::prelude::*;
 
-		if self.dict.get(b"Filter").is_err() {
-			let mut encoder = ZlibEncoder::new(Vec::new(), Compression::best());
-			encoder.write_all(self.content.as_slice())?;
-			let compressed = encoder.finish()?;
-			if compressed.len() + 19 < self.content.len() {
-				self.dict.set("Filter", "FlateDecode");
-				self.set_content(compressed);
-			}
-		}
-		Ok(())
-	}
+        if self.dict.get(b"Filter").is_err() {
+            let mut encoder = ZlibEncoder::new(Vec::new(), Compression::best());
+            encoder.write_all(self.content.as_slice())?;
+            let compressed = encoder.finish()?;
+            if compressed.len() + 19 < self.content.len() {
+                self.dict.set("Filter", "FlateDecode");
+                self.set_content(compressed);
+            }
+        }
+        Ok(())
+    }
 
-	pub fn decompressed_content(&self) -> Result<Vec<u8>> {
-		let params = self.dict.get(b"DecodeParms").and_then(Object::as_dict).ok();
-		let filters = self.filters()?;
+    pub fn decompressed_content(&self) -> Result<Vec<u8>> {
+        let params = self.dict.get(b"DecodeParms").and_then(Object::as_dict).ok();
+        let filters = self.filters()?;
 
-		if self.dict.get(b"Subtype").and_then(Object::as_name_str).ok() == Some("Image") {
-			return Err(Error::Type);
-		}
+        if self.dict.get(b"Subtype").and_then(Object::as_name_str).ok() == Some("Image") {
+            return Err(Error::Type);
+        }
 
-		let mut input = self.content.as_slice();
-		let mut output = None;
+        let mut input = self.content.as_slice();
+        let mut output = None;
 
-		// Filters are in decoding order.
-		for filter in filters {
-			output = Some(match filter.as_str() {
-				"FlateDecode" => Self::decompress_zlib(input, params)?,
-				"LZWDecode" => Self::decompress_lzw(input, params)?,
-				_ => { return Err(Error::Type); },
-			});
-			input = output.as_ref().unwrap();
-		}
+        // Filters are in decoding order.
+        for filter in filters {
+            output = Some(match filter.as_str() {
+                "FlateDecode" => Self::decompress_zlib(input, params)?,
+                "LZWDecode" => Self::decompress_lzw(input, params)?,
+                _ => {
+                    return Err(Error::Type);
+                }
+            });
+            input = output.as_ref().unwrap();
+        }
 
-		output.ok_or(Error::Type)
-	}
+        output.ok_or(Error::Type)
+    }
 
-	fn decompress_lzw(input: &[u8], params: Option<&Dictionary>) -> Result<Vec<u8>> {
-		use lzw::{MsbReader, Decoder, DecoderEarlyChange};
-		const MIN_BITS: u8 = 9;
+    fn decompress_lzw(input: &[u8], params: Option<&Dictionary>) -> Result<Vec<u8>> {
+        use lzw::{Decoder, DecoderEarlyChange, MsbReader};
+        const MIN_BITS: u8 = 9;
 
-		let early_change = params.and_then(|p| p.get(b"EarlyChange").ok()).and_then(|p| Object::as_i64(p).ok()).map(|v| v != 0).unwrap_or(true);
+        let early_change = params
+            .and_then(|p| p.get(b"EarlyChange").ok())
+            .and_then(|p| Object::as_i64(p).ok())
+            .map(|v| v != 0)
+            .unwrap_or(true);
 
-		let output = if early_change {
-			Self::decompress_lzw_loop(input, DecoderEarlyChange::new(MsbReader::new(), MIN_BITS-1), DecoderEarlyChange::decode_bytes)
-		} else {
-			Self::decompress_lzw_loop(input, Decoder::new(MsbReader::new(), MIN_BITS-1), Decoder::decode_bytes)
-		};
+        let output = if early_change {
+            Self::decompress_lzw_loop(
+                input,
+                DecoderEarlyChange::new(MsbReader::new(), MIN_BITS - 1),
+                DecoderEarlyChange::decode_bytes,
+            )
+        } else {
+            Self::decompress_lzw_loop(
+                input,
+                Decoder::new(MsbReader::new(), MIN_BITS - 1),
+                Decoder::decode_bytes,
+            )
+        };
 
-		Self::decompress_predictor(output, params)
-	}
+        Self::decompress_predictor(output, params)
+    }
 
-	fn decompress_lzw_loop<F, D>(mut input: &[u8], mut decoder: D, decode: F) -> Vec<u8>
-		where F: for<'d> Fn(&'d mut D, &[u8]) -> std::io::Result<(usize, &'d [u8])>
-	{
-		let mut output = Vec::with_capacity(input.len() * 2);
+    fn decompress_lzw_loop<F, D>(mut input: &[u8], mut decoder: D, decode: F) -> Vec<u8>
+    where
+        F: for<'d> Fn(&'d mut D, &[u8]) -> std::io::Result<(usize, &'d [u8])>,
+    {
+        let mut output = Vec::with_capacity(input.len() * 2);
 
-		loop {
-			match decode(&mut decoder, input) {
-				Ok((consumed_bytes, out_bytes)) => {
-					output.extend(out_bytes);
-					input = &input[consumed_bytes..];
-					if input.is_empty() || consumed_bytes == 0 {
-						break;
-					}
-				},
-				Err(err) => {
-					warn!("{}", err);
-					break;
-				}
-			}
-		}
+        loop {
+            match decode(&mut decoder, input) {
+                Ok((consumed_bytes, out_bytes)) => {
+                    output.extend(out_bytes);
+                    input = &input[consumed_bytes..];
+                    if input.is_empty() || consumed_bytes == 0 {
+                        break;
+                    }
+                }
+                Err(err) => {
+                    warn!("{}", err);
+                    break;
+                }
+            }
+        }
 
-		output
-	}
+        output
+    }
 
-	fn decompress_zlib(input: &[u8], params: Option<&Dictionary>) -> Result<Vec<u8>> {
-		use flate2::read::ZlibDecoder;
-		use std::io::prelude::*;
+    fn decompress_zlib(input: &[u8], params: Option<&Dictionary>) -> Result<Vec<u8>> {
+        use flate2::read::ZlibDecoder;
+        use std::io::prelude::*;
 
-		let mut output = Vec::with_capacity(input.len() * 2);
-		let mut decoder = ZlibDecoder::new(input);
+        let mut output = Vec::with_capacity(input.len() * 2);
+        let mut decoder = ZlibDecoder::new(input);
 
-		if !input.is_empty() {
-			decoder.read_to_end(&mut output).unwrap_or_else(|err| {
-				warn!("{}", err);
-				0
-			});
-		}
-		Self::decompress_predictor(output, params)
-	}
+        if !input.is_empty() {
+            decoder.read_to_end(&mut output).unwrap_or_else(|err| {
+                warn!("{}", err);
+                0
+            });
+        }
+        Self::decompress_predictor(output, params)
+    }
 
-	fn decompress_predictor(mut data: Vec<u8>, params: Option<&Dictionary>) -> Result<Vec<u8>> {
-		use crate::filters::png;
+    fn decompress_predictor(mut data: Vec<u8>, params: Option<&Dictionary>) -> Result<Vec<u8>> {
+        use crate::filters::png;
 
-		if let Some(params) = params {
-			let predictor = params.get(b"Predictor").and_then(Object::as_i64).unwrap_or(1);
-			if predictor >= 10 && predictor <= 15 {
-				let pixels_per_row = params.get(b"Columns").and_then(Object::as_i64).unwrap_or(1) as usize;
-				let colors = params.get(b"Colors").and_then(Object::as_i64).unwrap_or(1) as usize;
-				let bits = params.get(b"BitsPerComponent").and_then(Object::as_i64).unwrap_or(8) as usize;
-				let bytes_per_pixel = colors * bits / 8;
-				data = png::decode_frame(data.as_slice(), bytes_per_pixel, pixels_per_row)?;
-			}
-			Ok(data)
-		} else {
-			Ok(data)
-		}
-	}
+        if let Some(params) = params {
+            let predictor = params
+                .get(b"Predictor")
+                .and_then(Object::as_i64)
+                .unwrap_or(1);
+            if predictor >= 10 && predictor <= 15 {
+                let pixels_per_row =
+                    params.get(b"Columns").and_then(Object::as_i64).unwrap_or(1) as usize;
+                let colors = params.get(b"Colors").and_then(Object::as_i64).unwrap_or(1) as usize;
+                let bits = params
+                    .get(b"BitsPerComponent")
+                    .and_then(Object::as_i64)
+                    .unwrap_or(8) as usize;
+                let bytes_per_pixel = colors * bits / 8;
+                data = png::decode_frame(data.as_slice(), bytes_per_pixel, pixels_per_row)?;
+            }
+            Ok(data)
+        } else {
+            Ok(data)
+        }
+    }
 
-	pub fn decompress(&mut self) {
-		if let Ok(data) = self.decompressed_content() {
-			self.dict.remove(b"DecodeParms");
-			self.dict.remove(b"Filter");
-			self.set_content(data);
-		}
-	}
+    pub fn decompress(&mut self) {
+        if let Ok(data) = self.decompressed_content() {
+            self.dict.remove(b"DecodeParms");
+            self.dict.remove(b"Filter");
+            self.set_content(data);
+        }
+    }
 }

--- a/src/xobject.rs
+++ b/src/xobject.rs
@@ -1,5 +1,5 @@
 use super::Object::*;
-use super::{Dictionary, Stream};
+use crate::{Dictionary, Result, Stream};
 
 #[cfg(feature = "embed_image")]
 use image::{self, ColorType, GenericImageView, ImageFormat};
@@ -7,72 +7,73 @@ use image::{self, ColorType, GenericImageView, ImageFormat};
 use std::path::Path;
 
 pub fn form(boundingbox: Vec<f64>, matrix: Vec<f64>, content: Vec<u8>) -> Stream {
-	let mut dict = Dictionary::new();
-	dict.set("Type", Name(b"XObject".to_vec()));
-	dict.set("Subtype", Name(b"Form".to_vec()));
-	dict.set("BBox", Array(boundingbox.into_iter().map(Real).collect()));
-	dict.set("Matrix", Array(matrix.into_iter().map(Real).collect()));
-	let mut xobject = Stream::new(dict, content);
-	// Ignore any compression error.
-	let _ = xobject.compress();
-	xobject
+    let mut dict = Dictionary::new();
+    dict.set("Type", Name(b"XObject".to_vec()));
+    dict.set("Subtype", Name(b"Form".to_vec()));
+    dict.set("BBox", Array(boundingbox.into_iter().map(Real).collect()));
+    dict.set("Matrix", Array(matrix.into_iter().map(Real).collect()));
+    let mut xobject = Stream::new(dict, content);
+    // Ignore any compression error.
+    let _ = xobject.compress();
+    xobject
 }
 
 #[cfg(feature = "embed_image")]
 pub fn image<P: AsRef<Path>>(path: P) -> Result<Stream> {
-	use std::fs::File;
-	use std::io::prelude::*;
-	let img = image::open(&path)?;
-	let (width, height) = img.dimensions();
-	let (color_space, bits) = match img.color() {
-		ColorType::Gray(bits) => (b"DeviceGray".to_vec(), bits),
-		ColorType::RGB(bits) => (b"DeviceRGB".to_vec(), bits),
-		ColorType::Palette(bits) => (b"Indexed".to_vec(), bits),
-		ColorType::GrayA(bits) => (b"DeviceN".to_vec(), bits),
-		ColorType::RGBA(bits) => (b"DeviceN".to_vec(), bits),
-		ColorType::BGR(bits) => (b"DeviceN".to_vec(), bits),
-		ColorType::BGRA(bits) => (b"DeviceN".to_vec(), bits),
-	};
+    use std::fs::File;
+    use std::io::prelude::*;
+    let img = image::open(&path)?;
+    let (width, height) = img.dimensions();
+    let (color_space, bits) = match img.color() {
+        ColorType::Gray(bits) => (b"DeviceGray".to_vec(), bits),
+        ColorType::RGB(bits) => (b"DeviceRGB".to_vec(), bits),
+        ColorType::Palette(bits) => (b"Indexed".to_vec(), bits),
+        ColorType::GrayA(bits) => (b"DeviceN".to_vec(), bits),
+        ColorType::RGBA(bits) => (b"DeviceN".to_vec(), bits),
+        ColorType::BGR(bits) => (b"DeviceN".to_vec(), bits),
+        ColorType::BGRA(bits) => (b"DeviceN".to_vec(), bits),
+    };
 
-	let mut dict = Dictionary::new();
-	dict.set("Type", Name(b"XObject".to_vec()));
-	dict.set("Subtype", Name(b"Image".to_vec()));
-	dict.set("Width", width);
-	dict.set("Height", height);
-	dict.set("ColorSpace", Name(color_space));
-	dict.set("BitsPerComponent", bits);
+    let mut dict = Dictionary::new();
+    dict.set("Type", Name(b"XObject".to_vec()));
+    dict.set("Subtype", Name(b"Image".to_vec()));
+    dict.set("Width", width);
+    dict.set("Height", height);
+    dict.set("ColorSpace", Name(color_space));
+    dict.set("BitsPerComponent", bits);
 
-	let mut file = File::open(&path)?;
-	let mut buffer = Vec::new();
-	file.read_to_end(&mut buffer)?;
+    let mut file = File::open(&path)?;
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer)?;
 
-	let is_jpeg = match image::guess_format(&buffer) {
-		Ok(format) => match format {
-			ImageFormat::JPEG => true,
-			_ => false,
-		},
-		Err(_) => false,
-	};
+    let is_jpeg = match image::guess_format(&buffer) {
+        Ok(format) => match format {
+            ImageFormat::JPEG => true,
+            _ => false,
+        },
+        Err(_) => false,
+    };
 
-	if is_jpeg {
-		dict.set("Filter", Name(b"DCTDecode".to_vec()));
-		Ok(Stream::new(dict, buffer))
-	} else {
-		let mut img_object = Stream::new(dict, img.raw_pixels());
-		// Ignore any compression error.
-		let _ = img_object.compress();
-		Ok(img_object)
-	}
+    if is_jpeg {
+        dict.set("Filter", Name(b"DCTDecode".to_vec()));
+        Ok(Stream::new(dict, buffer))
+    } else {
+        let mut img_object = Stream::new(dict, img.raw_pixels());
+        // Ignore any compression error.
+        let _ = img_object.compress();
+        Ok(img_object)
+    }
 }
 
 #[cfg(feature = "embed_image")]
 #[test]
 fn insert_image() {
-	use super::xobject;
-	let mut doc = Document::load("assets/example.pdf").unwrap();
-	let pages = doc.get_pages();
-	let page_id = *pages.get(&1).expect(&format!("Page {} not exist.", 1));
-	let img = xobject::image("assets/pdf_icon.jpg").unwrap();
-	doc.insert_image(page_id, img, (100.0, 210.0), (400.0, 225.0)).unwrap();
-	doc.save("test_5_image.pdf").unwrap();
+    use super::xobject;
+    let mut doc = Document::load("assets/example.pdf").unwrap();
+    let pages = doc.get_pages();
+    let page_id = *pages.get(&1).expect(&format!("Page {} not exist.", 1));
+    let img = xobject::image("assets/pdf_icon.jpg").unwrap();
+    doc.insert_image(page_id, img, (100.0, 210.0), (400.0, 225.0))
+        .unwrap();
+    doc.save("test_5_image.pdf").unwrap();
 }


### PR DESCRIPTION
Introduction of **Dictionary** `extend()` function with a new and fixed `renumber_objects_with()` that will renumber objects ids starting from a custom ID, this is very useful in case of document merging.

I provided a working example [here](https://github.com/J-F-Liu/lopdf/pull/117/files).