### PR TITLE
Unwrap the text

### DIFF
--- a/pdfutil/src/main.rs
+++ b/pdfutil/src/main.rs
@@ -108,7 +108,7 @@ fn main() {
 					if let Some(pages) = args.value_of("pages") {
 						let page_numbers = compute_page_numbers(pages);
 						let text = doc.extract_text(&page_numbers);
-						info!("{}", text);
+						info!("{}", text.unwrap());
 					}
 				}
 				"replace_text" => {


### PR DESCRIPTION
Dearest Reviewer,

Thank you for your work on this project.  I have yet to figure out how to get it to work(`Err` value: Xref(Start)). I wanted to test my file code was correct by using this util program. Indeed my pdf is bad. The util program was broken and this helps it run.  If you do merge this it might also be nice to update the cargo program.

Dictated but not reviewed, 
Becker


```
error[E0277]: `std::result::Result<std::string::String, lopdf::Error>` doesn't implement `std::fmt::Display`
   --> src/main.rs:111:19
    |
111 |                         info!("{}", text);
    |                                     ^^^^ `std::result::Result<std::string::String, lopdf::Error>` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `std::result::Result<std::string::String, lopdf::Error>`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```