### PR TITLE
Replace lzw with weezl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { version = "^0.4", optional = true }
 log = "^0.4"
 rayon = { version = "^1.4", optional = true }
 nom = { version = "^6.0", optional = true }
-lzw = "^0.10"
+weezl = "0.1.4"
 
 [features]
 default = ["chrono_time", "pom_parser"]


### PR DESCRIPTION
Fixes: #138 

I'm unsure if this is covered by any tests. In any case, we could deactivate the `std` features if we manually do the output loop. There's not a lot to gain though. I'll also consider adding an `into_vec` adaptor to `weezl` that works with `alloc` alone and does not require the whole of `std`, let me know if this is of interest to you.