### PR TITLE
Fix document save race in parser_aux::load_and_save and creator::create_document

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ log = "^0.4"
 rayon = { version = "^1.4", optional = true }
 nom = { version = "^6.0", optional = true }
 weezl = "0.1.4"
+lazy_static = "^1.4"
 
 [features]
 default = ["chrono_time", "pom_parser"]

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -270,14 +270,23 @@ fn parse_integer_array(array: &Object) -> Result<Vec<i64>> {
 #[test]
 fn load_and_save() {
     // test load_from() and save_to()
+    use crate::creator::tests::{create_document, remove_document, save_document};
     use std::fs::File;
     use std::io::Cursor;
 
-    let in_file = File::open("test_1_create.pdf").unwrap();
+    let filename = String::from("test_1_load_and_save.pdf");
+    let mut doc = create_document();
+
+    save_document(&filename, &mut doc);
+
+    let in_file = File::open("test_1_load_and_save.pdf").unwrap();
     let mut in_doc = Document::load_from(in_file).unwrap();
 
     let out_buf = Vec::new();
     let mut memory_cursor = Cursor::new(out_buf);
     in_doc.save_to(&mut memory_cursor).unwrap();
     assert!(!memory_cursor.get_ref().is_empty());
+
+    // Clean up the saved document
+    remove_document(&filename);
 }


### PR DESCRIPTION
This fixes the race condition identified in issue 137:
https://github.com/J-F-Liu/lopdf/issues/137

There were several changes to fix the existing code and make adding new tests that create files more safe:

Make public helper functions to create and remove documents that can be called from other tests.
Put those helpers and the other unit tests in a tests namespace to make it clear they're for testing.
Use different filenames in different file tests (parser_aux and creator).
In creator, add a mutex around saving and reading files with the same filename.

Let me know if there are any questions or if you have any changes.

Thanks for the great work on this project.