### PR TITLE
Do not limit Real precision to two digits

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -127,7 +127,7 @@ impl Writer {
                 let _ = itoa::write(file, *value);
                 Ok(())
             }
-            Real(ref value) => file.write_all(format!("{:.02?}", *value).as_bytes()),
+            Real(ref value) => file.write_all(format!("{}", *value).as_bytes()),
             Name(ref name) => Writer::write_name(file, name),
             String(ref text, ref format) => Writer::write_string(file, text, format),
             Array(ref array) => Writer::write_array(file, array),


### PR DESCRIPTION
I was trying to integrate `svg2pdf` with my crate `printpdf` in order to add the ability to convert SVG files into PDF content streams. While doing so I noticed that the resulting `FormXObject` had a wrong `/Matrix`, even though the matrix given to lopdf was correct. The `/Matrix` entry was set to `/Matrix [0.0011111111 0 0 0.0011111111 0 0]`, but when writing the file to disk, I only got `/Matrix [0.00 0.00 0.00 0.00 0.00 0.00]`, so my SVG file wasn't showing up as a result (multiplying a `cm` matrix with 0 = still 0). Also, some transformations were slightly off, and I couldn't figure out why.

This commit fixes the problem, now my SVG files show up correctly.