### PR TITLE
Remove unneccessary time 0.1 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ dtoa = "^0.4"
 itoa = "^0.4"
 encoding = "^0.2"
 image = { version = "^0.23", optional = true }
-chrono = { version = "^0.4", optional = true }
+chrono = { version = "^0.4", optional = true, features = ["std", "clock"], default-features = false }
 log = "^0.4"
 rayon = { version = "^1.4", optional = true }
 nom = { version = "^6.0", optional = true }


### PR DESCRIPTION
This is pulled in by chrono's default features.