### PR TITLE
made XREF parser accept an optional space character after 'xref'

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -225,7 +225,7 @@ fn xref<'a>() -> Parser<'a, u8, Xref> {
         - take(2);
     let xref_section =
         integer().map(|i| i as usize) - sym(b' ') + integer() - sym(b' ').opt() - eol() + xref_entry.repeat(0..);
-    let xref = seq(b"xref") * eol() * xref_section.repeat(1..) - space();
+    let xref = seq(b"xref") * sym(b' ').opt() * eol() * xref_section.repeat(1..) - space();
     xref.map(|sections| {
         sections
             .into_iter()


### PR DESCRIPTION
I had to read in a PDF with a space after an `xref`, which was not accepted by `lopdf`. Since other programs can open this PDF without issue, I think `lopdf` should accept this spurious space character as well.