### PR TITLE
Guard example based on if the "parser" feature is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,15 @@ fn main() -> std::io::Result<()> {
 ```rust
 use lopdf::Document;
 
-let mut doc = Document::load("example.pdf").unwrap();
-doc.version = "1.4".to_string();
-doc.replace_text(1, "Hello World!", "Modified text!");
-doc.save("modified.pdf").unwrap();
+// For this example to work a parser feature needs to be enabled
+#[cfg(any(feature = "pom_parser", feature = "nom_parser"))]
+{
+    let mut doc = Document::load("example.pdf").unwrap();
+
+    doc.version = "1.4".to_string();
+    doc.replace_text(1, "Hello World!", "Modified text!");
+    doc.save("modified.pdf").unwrap();
+}
 ```
 
 ## FAQ


### PR DESCRIPTION
Now that the examples are being run as part of the CI one of the CI tests checks if the code compiles with no default features. Since the example is dependant on one of the parsers being enabled adjust the code to check for the parser feature.

This fixes the CI build error.