### PR TITLE
Make add_xobject follow references

### DIFF
--- a/src/creator.rs
+++ b/src/creator.rs
@@ -95,7 +95,15 @@ impl Document {
             if !resources.has(b"XObject") {
                 resources.set("XObject", Dictionary::new());
             }
-            let xobjects = resources.get_mut(b"XObject").and_then(Object::as_dict_mut)?;
+            let mut xobjects = resources.get_mut(b"XObject")?;
+            if let Object::Reference(xobjects_ref_id) = xobjects {
+                let mut xobjects_id = xobjects_ref_id.clone();
+                while let Object::Reference(id) = self.get_object(xobjects_id)? {
+                    xobjects_id = *id;
+                }
+                xobjects = self.get_object_mut(xobjects_id)?;
+            }
+            let xobjects = Object::as_dict_mut(xobjects)?;
             xobjects.set(xobject_name, Object::Reference(xobject_id));
         }
         Ok(())

--- a/src/incremental_document.rs
+++ b/src/incremental_document.rs
@@ -114,7 +114,15 @@ impl IncrementalDocument {
             if !resources.has(b"XObject") {
                 resources.set("XObject", Dictionary::new());
             }
-            let xobjects = resources.get_mut(b"XObject").and_then(Object::as_dict_mut)?;
+            let mut xobjects = resources.get_mut(b"XObject")?;
+            if let Object::Reference(xobjects_ref_id) = xobjects {
+                let mut xobjects_id = xobjects_ref_id.clone();
+                while let Object::Reference(id) = self.new_document.get_object(xobjects_id)? {
+                    xobjects_id = *id;
+                }
+                xobjects = self.new_document.get_object_mut(xobjects_id)?;
+            }
+            let xobjects = Object::as_dict_mut(xobjects)?;
             xobjects.set(xobject_name, Object::Reference(xobject_id));
         }
         Ok(())


### PR DESCRIPTION
The XObject resource can be a reference and needs to be properly dereferenced to be modified safely in this case.

Fix #186 