### PR TITLE
Reorder Pages before Renumbering Objects.

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -194,17 +194,29 @@ impl Document {
 
             for (old, new) in pages.iter().zip(page_order) {
                 if let Some(object) = self.objects.remove(&old.1) {
-                    objects.insert(new.1, object);
+                    objects.insert((new.1 .0, old.1 .1), object);
+                    replace.insert(old.1, (new.1 .0, old.1 .1));
                 }
 
                 if old.1 != new.1 {
-                    self.renumber_bookmarks(&old.1, &new.1);
+                    self.renumber_bookmarks(&old.1, &(new.1 .0, old.1 .1));
                 }
             }
 
             for (new, object) in objects {
                 self.objects.insert(new, object);
             }
+
+            let action = |object: &mut Object| {
+                if let Object::Reference(ref mut id) = *object {
+                    if replace.contains_key(id) {
+                        *id = replace[id];
+                    }
+                }
+            };
+
+            self.traverse_objects(action);
+            replace.clear();
         }
 
         let mut ids = self.objects.keys().cloned().collect::<Vec<ObjectId>>();

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -178,7 +178,7 @@ impl Document {
             })
             .collect();
 
-        page_order.sort_by(|a, b| a.1.partial_cmp(&b.1));
+        page_order.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
 
         i = 0;
 
@@ -189,7 +189,7 @@ impl Document {
 
         if needs_ordering {
             let mut pages = page_order.clone();
-            pages.sort_by(|a, b| a.0.partial_cmp(&b.0));
+            pages.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
             let mut objects = BTreeMap::new();
 
             for (old, new) in pages.iter().zip(page_order) {

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -165,6 +165,48 @@ impl Document {
     pub fn renumber_objects_with(&mut self, starting_id: u32) {
         let mut replace = BTreeMap::new();
         let mut new_id = starting_id;
+        let mut i = 0;
+
+        //lets check if we need to order the pages First as this means the first page doesnt have a lower ID
+        //So it ends up in a random spot based on its ID. We check first to avoid double transverse unless we have too.
+
+        let mut page_order: Vec<(i32, (u32, u16))> = self
+            .page_iter()
+            .map(|id| {
+                i += 1;
+                (i, id)
+            })
+            .collect();
+
+        page_order.sort_by(|a, b| a.1.partial_cmp(&b.1));
+
+        i = 0;
+
+        let needs_ordering = page_order.iter().any(|a| {
+            i += 1;
+            a.0 != i
+        });
+
+        if needs_ordering {
+            let mut pages = page_order.clone();
+            pages.sort_by(|a, b| a.0.partial_cmp(&b.0));
+            let mut objects = BTreeMap::new();
+
+            for (old, new) in pages.iter().zip(page_order) {
+                if let Some(object) = self.objects.remove(&old.1) {
+                    objects.insert(new.1, object);
+                }
+
+                if old.1 != new.1 {
+                    self.renumber_bookmarks(&old.1, &new.1);
+                }
+            }
+
+            for (new, object) in objects {
+                self.objects.insert(new, object);
+            }
+        }
+
         let mut ids = self.objects.keys().cloned().collect::<Vec<ObjectId>>();
         ids.sort_unstable();
 


### PR DESCRIPTION
Basically the issue i had is that there was a premade PDF that had pages in a certain Order. when it was loaded the first page ended up being the last page because the the ObjectID was greater than the other 3 pages.  This fixes that issue by first parsing out each page and checking and switching their ID's around. It then goes and updates the pages object Id's and swaps the old ID within any stored Objects to that of the new Page ID's. thus allowing us to reorder the pages properly and not have them swapped around. 

ATM I don't know of any better way to do this other than trans versing the objects Twice if there are pages out of order.