### PR TITLE
Fix extract_text to split text at word boundaries.

### DIFF
--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -53,6 +53,12 @@ impl Document {
                     }
                     Object::Array(ref arr) => {
                         collect_text(text, encoding, arr);
+                        text.push(' ');
+                    }
+                    Object::Integer(i) => {
+                        if i < -100 {
+                            text.push(' ');
+                        }
                     }
                     _ => {}
                 }


### PR DESCRIPTION
The -100 @line 59 is a result of some trials. I'm not sure if it fit's for all cases.