### PR TITLE
Fix Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ shellexpand = "3.0"
 env_logger = "0.10"
 
 [features]
-default = ["chrono_time", "nom_parser", "rayon"]
 chrono_time = ["chrono"]
 default = ["chrono_time", "nom_parser", "rayon"]
 embed_image = ["image"]


### PR DESCRIPTION
```log
Run cargo build --verbose 
error: failed to parse manifest at `/home/runner/work/lopdf/lopdf/Cargo.toml`

Caused by:
  could not parse input as TOML

Caused by:
  TOML parse error at line [4](https://github.com/J-F-Liu/lopdf/actions/runs/3747109580/jobs/6363023887#step:4:5)[6](https://github.com/J-F-Liu/lopdf/actions/runs/3747109580/jobs/6363023887#step:4:7), column 1
     |
  46 | default = ["chrono_time", "nom_parser", "rayon"]
     | ^
  Duplicate key `default` in table `features`
```

Signed-off-by: Hollow Man <hollowman@opensuse.org>