### PR TITLE
Remove extraneous `Q` operation from `insert_image`

### DIFF
--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -167,7 +167,6 @@ impl Document {
             .operations
             .push(Operation::new("Do", vec![Name(img_name.as_bytes().to_vec())]));
         content.operations.push(Operation::new("Q", vec![]));
-        content.operations.push(Operation::new("Q", vec![]));
 
         self.change_page_content(page_id, content.encode()?)
     }


### PR DESCRIPTION
I don't think this double-pop of the graphics state stack was intentional, and it caused me difficult-to-diagnose problems a few months ago when I was trying to send something to a printing service.