### PR TITLE
Annotate feature usage

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -14,6 +14,7 @@ impl From<DateTime<Local>> for Object {
 }
 
 // Find the last `:` and turn it into an `'` to account for PDF weirdness
+#[allow(dead_code)]
 fn convert_utc_offset(bytes: &mut [u8]) {
     let mut index = bytes.len();
     while let Some(last) = bytes[..index].last_mut() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub use crate::object::{Dictionary, Object, ObjectId, Stream, StringFormat};
 mod document;
 mod incremental_document;
 mod object_stream;
+#[cfg(any(feature = "pom_parser", feature = "nom_parser"))]
 pub use object_stream::ObjectStream;
 pub mod xref;
 pub use crate::document::Document;
@@ -38,7 +39,9 @@ mod parser;
 mod parser;
 mod parser_aux;
 mod processor;
+#[cfg(any(feature = "pom_parser", feature = "nom_parser"))]
 mod reader;
+#[cfg(any(feature = "pom_parser", feature = "nom_parser"))]
 pub use reader::Reader;
 mod rc4;
 mod writer;


### PR DESCRIPTION
Fixes #226

* Several mod/use statements in lib.rs relied on optional modules.
* `convert_utc_offset` becomes dead code if chrono is not enabled; annotated to prevent compiler warning.