### PR TITLE
Fixed parsing of the PDFs with incorrect xrefs to indirect objects

### DIFF
--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -344,7 +344,7 @@ pub fn indirect_object(
 fn _indirect_object(
     input: &[u8], offset: usize, expected_id: Option<ObjectId>, reader: &Reader,
 ) -> crate::Result<(ObjectId, Object)> {
-    let (i, object_id) = terminated(object_id, pair(tag(b"obj"), space))(input).map_err(|_| Error::Parse { offset })?;
+    let (i, (_, object_id)) = terminated(tuple((space, object_id)), pair(tag(b"obj"), space))(input).map_err(|_| Error::Parse { offset })?;
     if let Some(expected_id) = expected_id {
         if object_id != expected_id {
             return Err(crate::error::Error::ObjectIdMismatch);


### PR DESCRIPTION
This fixes issue #248 where some PDFs have incorrect xrefs to objects pointing to the trailing whitespace, so the library could still handle them instead of throwing parse errors.

Specifically in this particular case the attached PDF has:

```text
xref
0 26
0000000000 65535 f
0000205013 00000 n
```

Where at offset 205013 the object begins with 0x0a:

![Screenshot_20231222_003949](https://github.com/J-F-Liu/lopdf/assets/2361919/941ea780-4cf7-407b-86e1-3c245660254a)
