### PR TITLE
Add Placeholder object type

### DIFF
--- a/src/content.rs
+++ b/src/content.rs
@@ -1,5 +1,5 @@
 use super::Object;
-use crate::writer::Writer;
+use crate::writer::{CountingWrite, Writer};
 use crate::Result;
 use std::io::Write;
 
@@ -36,7 +36,7 @@ impl<Operations: AsRef<[Operation]>> Content<Operations> {
                 buffer.write_all(b"\n")?;
             }
             for operand in &operation.operands {
-                Writer::write_object(&mut buffer, operand)?;
+                Writer::write_object(&mut CountingWrite::new(&mut buffer), operand)?;
                 buffer.write_all(b" ")?;
             }
             buffer.write_all(operation.operator.as_bytes())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 #[macro_use]
 mod object;
 mod datetime;
-pub use crate::object::{Dictionary, Object, ObjectId, Stream, StringFormat};
+pub use crate::object::{Dictionary, Object, ObjectId, Offset, Stream, StringFormat};
 
 mod document;
 mod incremental_document;

--- a/src/object.rs
+++ b/src/object.rs
@@ -43,10 +43,11 @@ pub enum Object {
     Dictionary(Dictionary),
     Stream(Stream),
     Reference(ObjectId),
+    /// Used for recording the object position in the written file. The file must be post-processed so that it can be read by PDF Reader. Intended solely for use when signing the document.
     Placeholder(usize, Offset),
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct Offset(pub(crate) Arc<AtomicUsize>);
 
 impl PartialEq for Offset {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -566,6 +566,6 @@ fn save_document() {
     assert!(file_path.is_file());
     // Check if the file is above 400 bytes (should be about 610 bytes)
     assert!(file_path.metadata().unwrap().len() > 400);
-    // Check that placeholder offset was captured
+    // Check if placeholder offset was captured
     assert!(placeholder_offset.get().is_some())
 }


### PR DESCRIPTION
ISO 32000, so it should only be used in documents where post-processing is performed before the file is opened by a reader.

The intended use for this object is to sign a PDF document in three passes in accordance with ISO 32000-1 12.8.1, which behaves roughly as follows
1. the signature dictionary is created and linked to a corresponding form field. The entries `ByteRange` and `Contents` should each be set to a placeholder. The pdf is then written to a file, while taking into account the offsets of the placeholders
2. the correct `ByteRange` is written to the offset observed by the placeholder object.
3. the signature is generated over the entire document with the exception of the 'Content' field. The generated signature is then written to the given offset, which is observed by the `Contents` placeholder object.