### PR TITLE
Accept comments in content parsing

### DIFF
--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -473,7 +473,10 @@ fn operand(input: &[u8]) -> NomResult<Object> {
 
 fn operation(input: &[u8]) -> NomResult<Operation> {
     map(
-        terminated(pair(many0(operand), operator), content_space),
+        preceded(
+            many0(comment),
+            terminated(pair(many0(operand), operator), content_space),
+        ),
         |(operands, operator)| Operation { operator, operands },
     )(input)
 }
@@ -618,5 +621,18 @@ startxref
             Ok((_, re)) => assert_eq!(re.entries.len(), 15),
             Err(err) => panic!("unexpected {:?}", err),
         }
+    }
+
+    #[test]
+    fn content_with_comments() {
+        // It should be processed as usual but ignoring the comments
+        let input = b"0.5 0.5 0.5 setrgbcolor
+% This is a comment
+100 100 moveto
+(Hello, world!) show
+% Another comment
+";
+        let out = content(input).unwrap();
+        assert_eq!(out.operations.len(), 3);
     }
 }


### PR DESCRIPTION
Comments can be found also inside the content stream.
This is an example 
[este.pdf](https://github.com/J-F-Liu/lopdf/files/14226373/este.pdf)

Based on the metadata, it was created by Canon iR-ADV which is a photocopier that can scan documents so there should be many documents like this out there.

I tried to make the minimal changes and I also added a test 
