### PR TITLE
Use IndexMap isntead of BTreeMap in TOC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 time = { version = "^0.3", features = ["formatting", "parsing"] }
 tokio = { version = "1", features = ["fs", "io-util"], optional = true }
 weezl = "0.1"
+indexmap = "2.2.3"
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/src/destinations.rs
+++ b/src/destinations.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use super::{Dictionary, Document, Object, Result};
-
+use indexmap::IndexMap;
 #[derive(Debug, Clone)]
 pub struct Destination {
     map: BTreeMap<Vec<u8>, Object>,
@@ -33,7 +33,7 @@ impl Destination {
 
 impl Document {
     pub fn get_named_destinations(
-        &self, tree: &Dictionary, named_destinations: &mut BTreeMap<Vec<u8>, Destination>,
+        &self, tree: &Dictionary, named_destinations: &mut IndexMap<Vec<u8>, Destination>,
     ) -> Result<()> {
         if let Ok(kids) = tree.get(b"Kids") {
             for kid in kids.as_array()? {

--- a/src/outlines.rs
+++ b/src/outlines.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use indexmap::IndexMap;
 
 use super::{Destination, Dictionary, Document, Error, Object, Result};
 
@@ -8,7 +8,7 @@ pub enum Outline {
 }
 
 fn build_outline_result(
-    dest: &Object, title: &Object, named_destinations: &mut BTreeMap<Vec<u8>, Destination>,
+    dest: &Object, title: &Object, named_destinations: &mut IndexMap<Vec<u8>, Destination>,
 ) -> Result<Option<Outline>> {
     return Ok(Some(match dest {
         Object::Array(ref obj_array) => Outline::Destination(Destination::new(
@@ -30,7 +30,7 @@ fn build_outline_result(
 
 impl Document {
     pub fn get_outline(
-        &self, node: &Dictionary, named_destinations: &mut BTreeMap<Vec<u8>, Destination>,
+        &self, node: &Dictionary, named_destinations: &mut IndexMap<Vec<u8>, Destination>,
     ) -> Result<Option<Outline>> {
         let action = match self.get_dict_in_dict(node, b"A") {
             Ok(a) => a,
@@ -55,7 +55,7 @@ impl Document {
 
     pub fn get_outlines(
         &self, mut node: Option<Object>, mut outlines: Option<Vec<Outline>>,
-        named_destinations: &mut BTreeMap<Vec<u8>, Destination>,
+        named_destinations: &mut IndexMap<Vec<u8>, Destination>,
     ) -> Result<Option<Vec<Outline>>> {
         if outlines.is_none() {
             outlines = Some(Vec::new());

--- a/src/toc.rs
+++ b/src/toc.rs
@@ -1,4 +1,5 @@
-use std::{collections::BTreeMap, usize};
+use indexmap::IndexMap;
+use std::{usize, vec::Vec}; // Import IndexMap
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -32,13 +33,13 @@ impl Toc {
 
 #[derive(Debug, Clone)]
 pub struct Destination {
-    map: BTreeMap<Vec<u8>, Object>,
+    map: IndexMap<Vec<u8>, Object>, // Use IndexMap instead of BTreeMap
 }
 
 #[allow(dead_code)]
 impl Destination {
     pub fn new(title: Object, page: Object, typ: Object) -> Self {
-        let mut map = BTreeMap::new();
+        let mut map = IndexMap::new(); // Use IndexMap
         map.insert(b"Title".to_vec(), title);
         map.insert(b"Page".to_vec(), page);
         map.insert(b"Type".to_vec(), typ);
@@ -58,7 +59,7 @@ impl Destination {
     }
 }
 
-type OutlinePageIds = BTreeMap<Vec<u8>, ((u32, u16), usize, usize)>;
+type OutlinePageIds = IndexMap<Vec<u8>, ((u32, u16), usize, usize)>; // Use IndexMap
 
 fn setup_outline_page_ids<'a>(
     outlines: &'a Vec<Outline>, result: &mut OutlinePageIds, level: usize,
@@ -80,8 +81,9 @@ fn setup_outline_page_ids<'a>(
 }
 
 impl Document {
-    fn setup_page_id_to_num(&self) -> BTreeMap<(u32, u16), u32> {
-        let mut result = BTreeMap::new();
+    fn setup_page_id_to_num(&self) -> IndexMap<(u32, u16), u32> {
+        // Use IndexMap
+        let mut result = IndexMap::new(); // Use IndexMap
         for (page_num, page_id) in self.get_pages() {
             result.insert(page_id, page_num);
         }
@@ -93,9 +95,9 @@ impl Document {
             toc: Vec::new(),
             errors: Vec::new(),
         };
-        let mut named_destinations = BTreeMap::new();
+        let mut named_destinations = IndexMap::new(); // Use IndexMap
         if let Some(outlines) = self.get_outlines(None, None, &mut named_destinations)? {
-            let mut outline_page_ids = BTreeMap::new();
+            let mut outline_page_ids = IndexMap::new(); // Use IndexMap
             setup_outline_page_ids(&outlines, &mut outline_page_ids, 1);
             let page_id_to_page_numbers = self.setup_page_id_to_num();
             for (title, (page_id, _page_idx, level)) in outline_page_ids {


### PR DESCRIPTION
Replace the use of BTreeMap with IndexMap in TOC. 

By default BTreemap is sorted ( in this case by title), so by default get_toc() returns the table of contents sorted alphabetically instead of the order they occur in the document. 

For most parsing use cases the order of TOC matters. 

Changes are minimal and just use IndexMap instead of BTreeMap. 