### PR TITLE
Replace md5 with md-5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ image = { version = "^0.24", optional = true }
 itoa = "^1.0"
 linked-hash-map = "^0.5"
 log = "^0.4"
-md5 = "0.7.0"
+md-5 = "0.10"
 nom = { version = "^7.1", optional = true }
 pom = { version = "^3.2", optional = true }
 rayon = { version = "^1.6", optional = true }


### PR DESCRIPTION
This replaces the `md5` crate with the more trustworthy `md-5` crate, which is maintained by the [`RustCrypto`](https://github.com/RustCrypto/.github/blob/master/profile/README.md) project.

Tests seem to pass but I haven't tested this further.