### PR TITLE
Update readme of pdfutil

### DIFF
--- a/pdfutil/README.md
+++ b/pdfutil/README.md
@@ -7,8 +7,8 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -i, --input <input file>
-    -o, --output <output file>
+    -i, --input <input file>      
+    -o, --output <output file>    
 
 SUBCOMMANDS:
     compress                      Compress PDF document
@@ -16,8 +16,13 @@ SUBCOMMANDS:
     delete_objects                Delete objects
     delete_pages                  Delete pages
     delete_zero_length_streams    Delete zero length stream objects
+    extract_pages                 Extract pages
+    extract_stream                Extract stream content
+    extract_text                  Extract text
     help                          Prints this message or the help of the given subcommand(s)
+    print_streams                 Print streams
     process                       Process PDF document with specified operations
     prune_objects                 Prune unused objects
     renumber_objects              Renumber objects
+    replace_text                  Replace text
 ```


### PR DESCRIPTION
Resolves #188.
Makes the README of pdfutil match the output of `pdfutil -h`.
