### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,28 +16,28 @@ repository = "https://github.com/J-F-Liu/lopdf.git"
 version = "0.33.0"
 
 [dependencies]
-chrono = { version = "^0.4", optional = true, features = [
+chrono = { version = "0.4", optional = true, features = [
     "std",
     "clock",
 ], default-features = false }
 encoding_rs = "0.8.32"
-flate2 = "^1.0"
-image = { version = "^0.24", optional = true }
+flate2 = "1.0"
+image = { version = "0.25", optional = true }
 indexmap = "2.2.3"
-itoa = "^1.0"
-log = "^0.4"
+itoa = "1.0"
+log = "0.4"
 md-5 = "0.10"
-nom = { version = "^7.1", optional = true }
-pom = { version = "^3.2", optional = true }
-rayon = { version = "^1.6", optional = true }
+nom = { version = "7.1", optional = true }
+pom = { version = "3.2", optional = true }
+rayon = { version = "1.6", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-time = { version = "^0.3", features = ["formatting", "parsing"] }
+time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio = { version = "1", features = ["fs", "io-util"], optional = true }
 weezl = "0.1"
 
 [dev-dependencies]
 clap = { version = "4.0", features = ["derive"] }
-env_logger = "0.10"
+env_logger = "0.11"
 serde_json = "1.0"
 shellexpand = "3.0"
 tempfile = "3.3"


### PR DESCRIPTION
Also removes the `^` (caret) from most of the dependencies.

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements:
> Leaving off the caret is a simplified equivalent syntax to using caret requirements. While caret requirements are the default, it is recommended to use the simplified syntax when possible.