### PR TITLE
Specify minimum Rust version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ name = "lopdf"
 readme = "README.md"
 repository = "https://github.com/J-F-Liu/lopdf.git"
 version = "0.34.0"
+rust-version = "1.74"
 
 [dependencies]
 chrono = { version = "0.4", optional = true, features = [


### PR DESCRIPTION
Compiling using 1.74.0 works, when using 1.73.0 the following errors are reported:
```
error[E0277]: the trait bound `Vec<u8>: From<&[u8; 9]>` is not satisfied
   --> src/incremental_document.rs:82:22
    |
82  |             page.set(b"Resources", Dictionary::new());
    |                  --- ^^^^^^^^^^^^ the trait `From<&[u8; 9]>` is not implemented for `Vec<u8>`
    |                  |
    |                  required by a bound introduced by this call
    |
    = note: required for `&[u8; 9]` to implement `std::convert::Into<Vec<u8>>`
note: required by a bound in `Dictionary::set`
   --> src/object.rs:323:12
    |
321 |     pub fn set<K, V>(&mut self, key: K, value: V)
    |            --- required by a bound in this associated function
322 |     where
323 |         K: Into<Vec<u8>>,
    |            ^^^^^^^^^^^^^ required by this bound in `Dictionary::set`
help: consider dereferencing here
    |
82  |             page.set(*b"Resources", Dictionary::new());
    |                      +

error[E0277]: the trait bound `Vec<u8>: From<&[u8; 9]>` is not satisfied
   --> src/creator.rs:65:22
    |
65  |             page.set(b"Resources", Dictionary::new());
    |                  --- ^^^^^^^^^^^^ the trait `From<&[u8; 9]>` is not implemented for `Vec<u8>`
    |                  |
    |                  required by a bound introduced by this call
    |
    = note: required for `&[u8; 9]` to implement `std::convert::Into<Vec<u8>>`
note: required by a bound in `Dictionary::set`
   --> src/object.rs:323:12
    |
321 |     pub fn set<K, V>(&mut self, key: K, value: V)
    |            --- required by a bound in this associated function
322 |     where
323 |         K: Into<Vec<u8>>,
    |            ^^^^^^^^^^^^^ required by this bound in `Dictionary::set`
help: consider dereferencing here
    |
65  |             page.set(*b"Resources", Dictionary::new());
    |                      +

For more information about this error, try `rustc --explain E0277`.
error: could not compile `lopdf` (lib) due to 2 previous errors
```