### PR TITLE
fix(parser): allow whitespace after stream keyword

### DIFF
--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -9,8 +9,8 @@ use std::str::{self, FromStr};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take, take_while, take_while1, take_while_m_n};
 use nom::character::complete::multispace1;
-use nom::character::complete::space1;
 use nom::character::complete::{digit0, digit1, one_of};
+use nom::character::complete::{space0, space1};
 use nom::character::{is_hex_digit, is_oct_digit};
 use nom::combinator::{map, map_opt, map_res, opt, verify};
 use nom::error::{ErrorKind, ParseError};
@@ -310,7 +310,7 @@ pub(crate) fn dict_dup(input: ParserInput) -> NomResult<Dictionary> {
 }
 
 fn stream<'a>(input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSet<ObjectId>) -> NomResult<'a, Object> {
-    let (i, dict) = terminated(dictionary, tuple((space, tag(b"stream"), eol)))(input)?;
+    let (i, dict) = terminated(dictionary, tuple((space, tag(b"stream"), space0, eol)))(input)?;
 
     if let Ok(length) = dict.get(b"Length").and_then(|value| {
         if let Ok(id) = value.as_reference() {


### PR DESCRIPTION
Some generators such as the Microsoft Reporting Services 10.0.0.0 add
an additional whitespace character after the stream keyword despite it
not being allowed in the pdf spec:

> The keyword stream that follows the stream dictionary should be
> followed by either a carriage return and a line feed or by just
> a line feed, and not by a carriage return alone.

Full credit for @IiroP for researching this. Like he mentioned in https://github.com/Tietokilta/laskugeneraattori/issues/29
[others](https://sources.debian.org/patches/pdftk/1.44-7/fix_infinite_loop_on_lf_eol/) have also had issues with this.

I think it is better to support this than to just refuse to parse the pdf-files. 
Let me know if you want me to include a warning for not following the spec or something.