### PR TITLE
Throw error if xref stream cannot be uncompressed

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -770,11 +770,15 @@ impl Stream {
         }
     }
 
-    pub fn decompress(&mut self) {
-        if let Ok(data) = self.decompressed_content() {
-            self.dict.remove(b"DecodeParms");
-            self.dict.remove(b"Filter");
-            self.set_content(data);
-        }
+    pub fn decompress(&mut self) -> Result<()> {
+        let data = self.decompressed_content()?;
+        self.dict.remove(b"DecodeParms");
+        self.dict.remove(b"Filter");
+        self.set_content(data);
+        Ok(())
+    }
+
+    pub fn is_compressed(&self) -> bool {
+        self.dict.get(b"Filter").is_ok()
     }
 }

--- a/src/object_stream.rs
+++ b/src/object_stream.rs
@@ -16,7 +16,7 @@ pub struct ObjectStream {
 
 impl ObjectStream {
     pub fn new(stream: &mut Stream) -> Result<ObjectStream> {
-        stream.decompress();
+        let _ = stream.decompress();
 
         if stream.content.is_empty() {
             return Ok(ObjectStream {

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -203,7 +203,9 @@ fn try_to_replace_encoded_text(
 
 /// Decode CrossReferenceStream
 pub fn decode_xref_stream(mut stream: Stream) -> Result<(Xref, Dictionary)> {
-    stream.decompress();
+    if stream.is_compressed() {
+        stream.decompress()?;
+    }
     let mut dict = stream.dict;
     let mut reader = Cursor::new(stream.content);
     let size = dict

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -34,7 +34,7 @@ impl Document {
     pub fn decompress(&mut self) {
         for object in self.objects.values_mut() {
             if let Object::Stream(ref mut stream) = *object {
-                stream.decompress()
+                let _ = stream.decompress();
             }
         }
     }


### PR DESCRIPTION
When loading documents, return an error if an xref stream cannot be uncompressed due to an unsupported filter or any other problem.
Fixes #338