### PR TITLE
Fix addition overflow

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -260,8 +260,7 @@ impl<'a> Reader<'a> {
 
             prev_xref_start = prev_trailer.get(b"Prev").cloned();
         }
-
-        let xref_entry_count = xref.max_id() + 1;
+        let xref_entry_count = xref.max_id().checked_add(1).ok_or(Error::Xref(XrefError::Parse))?;
         if xref.size != xref_entry_count {
             warn!(
                 "Size entry of trailer dictionary is {}, correct value is {}.",


### PR DESCRIPTION
Fixes #311.
The error occurred when the xref table/stream contained a too big object ID.