### PR TITLE
Inline images

### DIFF
--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -545,12 +545,12 @@ fn inline_image(input: ParserInput) -> NomResult<(Vec<Object>, String)> {
 fn inline_image_impl(input: ParserInput) -> NomResult<(Vec<Object>, String)> {
     let (input, stream_dict) = inner_dictionary(input)?;
     let (input, _) = pair(tag(b"ID"), content_space)(input)?;
-    let (input, stream) = convert_result(image_data_stream(input, stream_dict), input, ErrorKind::Fail)?;
+    let (_, (input, stream)) = convert_result(image_data_stream(input, stream_dict), input, ErrorKind::Fail)?;
     let (input, _) = tuple((content_space, tag(b"EI"), content_space))(input)?;
-    Ok((input, (vec![Object::Stream(stream.1)], String::from("BI"))))
+    Ok((input, (vec![Object::Stream(stream)], String::from("BI"))))
 }
 
-fn image_data_stream<'a>(input: ParserInput<'a>, stream_dict: Dictionary) -> crate::Result<(ParserInput<'a>, Stream)> {
+fn image_data_stream(input: ParserInput, stream_dict: Dictionary) -> crate::Result<(ParserInput, Stream)> {
     let get_abbr = |key_abbr: &[u8], key: &[u8]| stream_dict.get(key_abbr).or_else(|_| stream_dict.get(key));
     let width = get_abbr(b"W", b"Width")?.as_i64()? as usize;
     let height = get_abbr(b"H", b"Height")?.as_i64()? as usize;
@@ -750,6 +750,7 @@ startxref
 
     #[test]
     fn inline_image() {
+        env_logger::init();
         let input = b"BI /W 4 /H 4 /CS /RGB /BPC 8
 ID
 00000z0z00zzz00z0zzz0zzzEI aazazaazzzaazazzzazzz

--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -547,8 +547,6 @@ fn inline_image_impl(input: ParserInput) -> NomResult<(Vec<Object>, String)> {
     let (input, _) = pair(tag(b"ID"), content_space)(input)?;
     let (input, stream) = convert_result(image_data_stream(input, stream_dict), input, ErrorKind::Fail)?;
     let (input, _) = tuple((content_space, tag(b"EI"), content_space))(input)?;
-    println!("{:?}", Object::Stream(stream.1.clone()));
-    println!("{:?}", String::from_utf8(stream.1.content.clone()).unwrap());
     Ok((input, (vec![Object::Stream(stream.1)], String::from("BI"))))
 }
 
@@ -575,7 +573,6 @@ fn image_data_stream<'a>(input: ParserInput<'a>, stream_dict: Dictionary) -> cra
 
     let stride = (width * (num_colors * bpc) + 7) / 8;
     let length = height * stride;
-    println!("stride:{stride}, length: {length}");
 
     let (input, content) = match get_abbr(b"F", b"Filter") {
         Err(_) => {

--- a/src/nom_parser.rs
+++ b/src/nom_parser.rs
@@ -752,4 +752,18 @@ startxref
         let out = content(test_span(input)).unwrap();
         assert_eq!(out.operations.len(), 3);
     }
+
+    #[test]
+    fn inline_image() {
+        let input = b"BI /W 4 /H 4 /CS /RGB /BPC 8
+ID
+00000z0z00zzz00z0zzz0zzzEI aazazaazzzaazazzzazzz
+EI";
+        let out = super::inline_image(test_span(input)).unwrap().1;
+        assert_eq!(&out.1, "BI");
+        assert_eq!(
+            &out.0[0].as_stream().unwrap().content,
+            b"00000z0z00zzz00z0zzz0zzzEI aazazaazzzaazazzzazzz"
+        )
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -579,8 +579,14 @@ fn image_data_stream(input: ParserInput, stream_dict: Dictionary) -> crate::Resu
             // no decompression needed
             take(length)(input).map_err(|_: nom::Err<()>| Error::ContentDecode)?
         }
-        Ok(Object::Name(_filter)) => todo!(),
-        Ok(Object::Array(_filters)) => todo!(),
+        Ok(Object::Name(_filter)) => {
+            log::warn!("Filters for inline images are not yet implemented");
+            return Err(Error::ContentDecode);
+        }
+        Ok(Object::Array(_filters)) => {
+            log::warn!("Filters for inline images are not yet implemented");
+            return Err(Error::ContentDecode);
+        }
         Ok(_) => {
             log::warn!("Filter must be either a Name or and Array.");
             return Err(Error::DictKey);


### PR DESCRIPTION
This pull request lays the groundwork to properly support inline images.

What makes inline images hard to support, is that they include a data stream of arbitrary bytes and unknown length. If the (final) filter on the stream has an EOD marker, finding the end isn't that hard (although it isn't hard, this PR doesn't implement it).
If the (final) filter doesn't have an EOD marker, it's much harder to find the end, as it effectively forces the us to decompress the stream.

This PR addresses #78 and #221, but I wouldn't say that the issue is resolved. In practice, the images are compressed in some way, and this PR doesn't implement that.