### PR TITLE
Support Non-ASCII Bookmark Title

### DIFF
--- a/src/bookmarks.rs
+++ b/src/bookmarks.rs
@@ -65,8 +65,20 @@ impl Document {
                 "S" => "GoTo",
             };
 
+            let title_bytes = if bookmark.title.is_ascii() {
+                bookmark.title.as_bytes().to_vec()
+            } else {
+                // If the title contains non-ASCII characters:
+                // Create a new vector with the UTF-16 Byte Order Mark (BOM) for UTF-16BE.
+                let mut bom = vec![0xFE, 0xFF];
+                let utf16_title = bookmark.title.encode_utf16();
+                // Append the UTF-16BE encoded bytes of the title to the BOM.
+                bom.extend(utf16_title.flat_map(u16::to_be_bytes));
+                bom
+            };
+
             child.set("Parent", parent.0);
-            child.set("Title", Object::string_literal(bookmark.title.clone()));
+            child.set("Title", Object::string_literal(title_bytes));
             child.set("A", info_id);
             child.set("F", Object::Integer(bookmark.format.into()));
             child.set(


### PR DESCRIPTION
### Description:
Currently, `lopdf` generates garbled text when handling bookmark titles containing non-ASCII characters. This issue arises because the PDF specification requires bookmark titles to be encoded in `UTF-16BE`, with a Byte Order Mark (BOM) to correctly parse non-ASCII characters. However, the existing implementation directly uses the value of bookmark.title without properly encoding non-ASCII characters.

### Changes
This PR determine if the bookmark title is ASCII:
- If it is ASCII, use the original bytes directly.
- If it is not ASCII, convert the title to UTF-16BE encoding.

### Testing and Verification
Tested with Chinese ("例子"), Russian ("Пример"), and Arabic ("أمثلة") in bookmark titles, all of which displayed correctly in Edge's PDF viewer.

### Performance Impact
No significant impact on performance for ASCII titles.
For non-ASCII titles, there is an overhead of UTF-16 encoding and byte conversion, but considering that bookmark titles are usually short, this overhead is negligible.

fix this https://github.com/J-F-Liu/lopdf/issues/146#issuecomment-1362860813