### PR TITLE
Gracefully handle the is_aes check without throwing errors

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -274,16 +274,24 @@ impl Document {
             .unwrap_or(true);
 
         let key = encryption::get_encryption_key(self, &password, true)?;
-        let cfm = self
-            .get_encrypted()?
-            .get(b"CF")?
-            .as_dict()?
-            .get(b"StdCF")?
-            .as_dict()?
-            .get(b"CFM")?
-            .as_name()
-            .unwrap_or_default();
-        let is_aes = cfm == b"AESV2";
+
+        let is_aes = self
+            .get_encrypted().ok()
+            .map(|dict| dict.get(b"CF").ok())
+            .flatten()
+            .map(|object| object.as_dict().ok())
+            .flatten()
+            .map(|dict| dict.get(b"StdCF").ok())
+            .flatten()
+            .map(|object| object.as_dict().ok())
+            .flatten()
+            .map(|dict| dict.get(b"CFM").ok())
+            .flatten()
+            .map(|object| object.as_name().ok())
+            .flatten()
+            .map(|cfm| cfm == b"AESV2")
+            .unwrap_or(false);
+
         for (&id, obj) in self.objects.iter_mut() {
             // The encryption dictionary is not encrypted, leave it alone
             if id == encryption_obj_id {

--- a/src/document.rs
+++ b/src/document.rs
@@ -277,18 +277,12 @@ impl Document {
 
         let is_aes = self
             .get_encrypted().ok()
-            .map(|dict| dict.get(b"CF").ok())
-            .flatten()
-            .map(|object| object.as_dict().ok())
-            .flatten()
-            .map(|dict| dict.get(b"StdCF").ok())
-            .flatten()
-            .map(|object| object.as_dict().ok())
-            .flatten()
-            .map(|dict| dict.get(b"CFM").ok())
-            .flatten()
-            .map(|object| object.as_name().ok())
-            .flatten()
+            .and_then(|dict| dict.get(b"CF").ok())
+            .and_then(|object| object.as_dict().ok())
+            .and_then(|dict| dict.get(b"StdCF").ok())
+            .and_then(|object| object.as_dict().ok())
+            .and_then(|dict| dict.get(b"CFM").ok())
+            .and_then(|object| object.as_name().ok())
             .map(|cfm| cfm == b"AESV2")
             .unwrap_or(false);
 


### PR DESCRIPTION
Commit 9f22915 introduces a regression in 0.35 compared to 0.34 when decrypting a PDF document that does not use AES. Instead of decrypting the document, it throws an error that the CF dictionary is missing. Consequently, this prevents the document from being decrypted.

To remedy this, this pull request eliminates all uses of `?` in the `is_aes` check to gracefully determine if the PDF document uses AES or not. It then proceeds to decrypt it accordingly.

Instead of using `?`, we carefully convert all `Result<T, E>` types into `Option<T>` using `.ok()` in combination with `.map()` and `.flatten()` to walk through the series of dictionaries. Then at the final step we simply compare if the `cfm` is equal to `b"AESV2"`. If any of the steps fails, we would get `None`, in which case we default to `is_aes = false` (rather than throwing an error).