### PR TITLE
Use get_deref for the Kids array to handle indirect references

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -628,7 +628,7 @@ impl<'a> PageTreeIter<'a> {
 
     fn kids(doc: &Document, page_tree_id: ObjectId) -> Option<&[Object]> {
         doc.get_dictionary(page_tree_id)
-            .and_then(|page_tree| page_tree.get(b"Kids"))
+            .and_then(|page_tree| page_tree.get_deref(b"Kids", doc))
             .and_then(Object::as_array)
             .map(|k| k.as_slice())
             .ok()


### PR DESCRIPTION
Fix issue #373 replacing `page_tree.get(b"Kids")` with the proposed `page_tree.get_deref(b"Kids", doc)` to handle the possibility of indirect references for the `Kids` array.