### PR TITLE
Add support for jiff and make both chrono and time optional features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ flate2 = "1.0"
 image = { version = "0.25", optional = true }
 indexmap = "2.2.3"
 itoa = "1.0"
+jiff = { version = "0.2", optional = true }
 log = "0.4"
 md-5 = "0.10"
 nom = { version = "7.1", optional = true }
@@ -36,7 +37,7 @@ rangemap = "1.5"
 rayon = { version = "1.6", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "2.0.3"
-time = { version = "0.3", features = ["formatting", "parsing"] }
+time = { version = "0.3", features = ["formatting", "parsing"], optional = true }
 tokio = { version = "1", features = ["fs", "io-util"], optional = true }
 weezl = "0.1"
 
@@ -49,11 +50,13 @@ tempfile = "3.3"
 
 [features]
 async = ["tokio/rt-multi-thread", "tokio/macros"]
-chrono_time = ["chrono"]
-default = ["chrono_time", "nom_parser", "rayon"]
+chrono = ["dep:chrono"]
+default = ["chrono", "jiff", "nom_parser", "rayon", "time"]
 embed_image = ["image"]
+jiff = ["dep:jiff"]
 nom_parser = ["nom", "nom_locate"]
 serde = ["dep:serde"]
+time = ["dep:time"]
 
 [[example]]
 name = "extract_toc"

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -115,6 +115,16 @@ pub mod tests {
     use crate::content::*;
     use crate::{Document, Object, Stream};
 
+    #[cfg(not(feature = "time"))]
+    pub fn get_timestamp() -> Object {
+        Object::string_literal("D:19700101000000Z")
+    }
+
+    #[cfg(feature = "time")]
+    pub fn get_timestamp() -> Object {
+        time::OffsetDateTime::now_utc().into()
+    }
+
     /// Create and return a document for testing
     pub fn create_document() -> Document {
         create_document_with_texts(&["Hello World!"])
@@ -125,7 +135,7 @@ pub mod tests {
         let info_id = doc.add_object(dictionary! {
             "Title" => Object::string_literal("Create PDF document example"),
             "Creator" => Object::string_literal("https://crates.io/crates/lopdf"),
-            "CreationDate" => time::OffsetDateTime::now_utc(),
+            "CreationDate" => get_timestamp(),
         });
         let pages_id = doc.new_object_id();
         let font_id = doc.add_object(dictionary! {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,15 +1,122 @@
 use super::Object;
-#[cfg(feature = "chrono_time")]
-use chrono::prelude::*;
 
-use time::{format_description::FormatItem, OffsetDateTime, Time};
+#[cfg(feature = "chrono")]
+mod chrono_impl {
+    use crate::{datetime::convert_utc_offset, Object};
+    use chrono::prelude::*;
 
-#[cfg(feature = "chrono_time")]
-impl From<DateTime<Local>> for Object {
-    fn from(date: DateTime<Local>) -> Self {
-        let mut timezone_str = date.format("D:%Y%m%d%H%M%S%:z'").to_string().into_bytes();
-        convert_utc_offset(&mut timezone_str);
-        Object::string_literal(timezone_str)
+    impl From<DateTime<Local>> for Object {
+        fn from(date: DateTime<Local>) -> Self {
+            let mut timezone_str = date.format("D:%Y%m%d%H%M%S%:z'").to_string().into_bytes();
+            convert_utc_offset(&mut timezone_str);
+            Object::string_literal(timezone_str)
+        }
+    }
+
+    impl From<DateTime<Utc>> for Object {
+        fn from(date: DateTime<Utc>) -> Self {
+            Object::string_literal(date.format("D:%Y%m%d%H%M%SZ").to_string())
+        }
+    }
+
+    impl TryInto<DateTime<Local>> for super::DateTime {
+        type Error = chrono::format::ParseError;
+
+        fn try_into(self) -> Result<DateTime<Local>, Self::Error> {
+            let from_date = |date: NaiveDate| {
+                FixedOffset::east_opt(0)
+                    .unwrap()
+                    .from_utc_datetime(&date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap()))
+            };
+
+            DateTime::parse_from_str(&self.0, "%Y%m%d%H%M%S%#z")
+                .or_else(|_| DateTime::parse_from_str(&self.0, "%Y%m%d%H%M%#z"))
+                .or_else(|_| NaiveDate::parse_from_str(&self.0, "%Y%m%d").map(from_date))
+                .map(|date| date.with_timezone(&Local))
+        }
+    }
+}
+
+#[cfg(feature = "jiff")]
+mod jiff_impl {
+    use crate::{datetime::convert_utc_offset, Object};
+    use jiff::{Timestamp, Zoned};
+
+    impl From<Zoned> for Object {
+        fn from(date: Zoned) -> Self {
+            let mut timezone_str = date.strftime("D:%Y%m%d%H%M%S%:z'").to_string().into_bytes();
+            convert_utc_offset(&mut timezone_str);
+            Object::string_literal(timezone_str)
+        }
+    }
+
+    impl From<Timestamp> for Object {
+        fn from(date: Timestamp) -> Self {
+            Object::string_literal(date.strftime("D:%Y%m%d%H%M%SZ").to_string())
+        }
+    }
+
+    impl TryInto<Zoned> for super::DateTime {
+        type Error = jiff::Error;
+
+        fn try_into(self) -> Result<Zoned, Self::Error> {
+            use jiff::civil::{Date, DateTime};
+
+            Zoned::strptime("%Y%m%d%H%M%S%#z", &self.0)
+                .or_else(|_| DateTime::strptime("%Y%m%d%H%M%SZ", &self.0).and_then(|dt| dt.in_tz("UTC")))
+                .or_else(|_| Zoned::strptime("%Y%m%d%H%M%#z", &self.0))
+                .or_else(|_| DateTime::strptime("%Y%m%d%H%MZ", &self.0).and_then(|dt| dt.in_tz("UTC")))
+                .or_else(|_| Date::strptime("%Y%m%d", &self.0).and_then(|dt| dt.at(0, 0, 0, 0).in_tz("UTC")))
+        }
+    }
+}
+
+#[cfg(feature = "time")]
+mod time_impl {
+    use crate::Object;
+    use time::{format_description::FormatItem, OffsetDateTime, Time};
+
+    impl From<Time> for Object {
+        fn from(date: Time) -> Self {
+            // can only fail if the TIME_FMT_ENCODE_STR would be invalid
+            Object::string_literal(
+                format!(
+                    "D:{}",
+                    date.format(&FormatItem::Literal("%Y%m%d%H%M%SZ".as_bytes())).unwrap()
+                )
+                .into_bytes(),
+            )
+        }
+    }
+
+    impl From<OffsetDateTime> for Object {
+        fn from(date: OffsetDateTime) -> Self {
+            Object::string_literal({
+                // D:%Y%m%d%H%M%S:%z'
+                let format = time::format_description::parse(
+                    "D:[year][month][day][hour][minute][second][offset_hour sign:mandatory]'[offset_minute]'",
+                )
+                .unwrap();
+                date.format(&format).unwrap()
+            })
+        }
+    }
+
+    /// WARNING: `tm_wday` (weekday), `tm_yday` (day index in year), `tm_isdst`
+    /// (daylight saving time) and `tm_nsec` (nanoseconds of the date from 1970)
+    /// are set to 0 since they aren't available in the PDF time format. They could,
+    /// however, be calculated manually
+    impl TryInto<OffsetDateTime> for super::DateTime {
+        type Error = time::Error;
+
+        fn try_into(self) -> Result<OffsetDateTime, Self::Error> {
+            let format = time::format_description::parse(
+                "[year][month][day][hour][minute][second][offset_hour sign:mandatory][offset_minute]",
+            )
+            .unwrap();
+
+            Ok(OffsetDateTime::parse(&self.0, &format)?)
+        }
     }
 }
 
@@ -26,38 +133,8 @@ fn convert_utc_offset(bytes: &mut [u8]) {
     }
 }
 
-#[cfg(feature = "chrono_time")]
-impl From<DateTime<Utc>> for Object {
-    fn from(date: DateTime<Utc>) -> Self {
-        Object::string_literal(date.format("D:%Y%m%d%H%M%SZ").to_string())
-    }
-}
-
-impl From<Time> for Object {
-    fn from(date: Time) -> Self {
-        // can only fail if the TIME_FMT_ENCODE_STR would be invalid
-        Object::string_literal(
-            format!(
-                "D:{}",
-                date.format(&FormatItem::Literal("%Y%m%d%H%M%SZ".as_bytes())).unwrap()
-            )
-            .into_bytes(),
-        )
-    }
-}
-
-impl From<OffsetDateTime> for Object {
-    fn from(date: OffsetDateTime) -> Self {
-        Object::string_literal({
-            // D:%Y%m%d%H%M%S:%z'
-            let format = time::format_description::parse(
-                "D:[year][month][day][hour][minute][second][offset_hour sign:mandatory]'[offset_minute]'",
-            )
-            .unwrap();
-            date.format(&format).unwrap()
-        })
-    }
-}
+#[derive(Clone, Debug)]
+pub struct DateTime(String);
 
 impl Object {
     // Parses the `D`, `:` and `\` out of a `Object::String` to parse the date time
@@ -76,76 +153,106 @@ impl Object {
         }
     }
 
-    #[cfg(feature = "chrono_time")]
-    pub fn as_datetime(&self) -> Option<DateTime<Local>> {
-        let text = self.datetime_string()?;
-        let from_date = |date: NaiveDate| {
-            FixedOffset::east_opt(0)
-                .unwrap()
-                .from_utc_datetime(&date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap()))
-        };
-        DateTime::parse_from_str(&text, "%Y%m%d%H%M%S%#z")
-            .or_else(|_| DateTime::parse_from_str(&text, "%Y%m%d%H%M%#z"))
-            .or_else(|_| NaiveDate::parse_from_str(&text, "%Y%m%d").map(from_date))
-            .map(|date| date.with_timezone(&Local))
-            .ok()
-    }
-
-    /// WARNING: `tm_wday` (weekday), `tm_yday` (day index in year), `tm_isdst`
-    /// (daylight saving time) and `tm_nsec` (nanoseconds of the date from 1970)
-    /// are set to 0 since they aren't available in the PDF time format. They could,
-    /// however, be calculated manually
-    #[cfg(not(feature = "chrono_time"))]
-    pub fn as_datetime(&self) -> Option<OffsetDateTime> {
-        let format = time::format_description::parse(
-            "[year][month][day][hour][minute][second][offset_hour sign:mandatory][offset_minute]",
-        )
-        .unwrap();
-        let text = self.datetime_string()?;
-        OffsetDateTime::parse(&text, &format).ok()
+    pub fn as_datetime(&self) -> Option<DateTime> {
+        self.datetime_string().map(DateTime)
     }
 }
 
-#[cfg(feature = "chrono_time")]
+#[cfg(feature = "chrono")]
 #[test]
 fn parse_datetime_local() {
+    use chrono::prelude::*;
+
     let time = Local::now().with_nanosecond(0).unwrap();
     let text: Object = time.into();
-    let time2 = text.as_datetime();
+    let time2: Option<DateTime<Local>> = text.as_datetime().and_then(|dt| dt.try_into().ok());
     assert_eq!(time2, Some(time));
 }
 
-#[cfg(feature = "chrono_time")]
+#[cfg(feature = "chrono")]
 #[test]
 fn parse_datetime_utc() {
+    use chrono::prelude::*;
+
     let time = Utc::now().with_nanosecond(0).unwrap();
     let text: Object = time.into();
-    let time2 = text.as_datetime();
+    let time2: Option<DateTime<Local>> = text.as_datetime().and_then(|dt| dt.try_into().ok());
     assert_eq!(time2, Some(time.with_timezone(&Local)));
 }
 
-#[cfg(feature = "chrono_time")]
+#[cfg(feature = "jiff")]
 #[test]
-fn parse_datetime_seconds_missing() {
+fn parse_zoned() {
+    use jiff::Zoned;
+
+    let time = Zoned::now().with().subsec_nanosecond(0).build().unwrap();
+    let text: Object = time.clone().into();
+    let time2: Option<Zoned> = text.as_datetime().and_then(|dt| dt.try_into().ok());
+    assert_eq!(time2, Some(time));
+}
+
+#[cfg(feature = "jiff")]
+#[test]
+fn parse_timestamp() {
+    use jiff::Zoned;
+
+    let time = Zoned::now().with().subsec_nanosecond(0).build().unwrap();
+    let text: Object = time.timestamp().into();
+    let time2: Option<Zoned> = text.as_datetime().and_then(|dt| dt.try_into().ok());
+    assert_eq!(time2, Some(time));
+}
+
+#[cfg(feature = "chrono")]
+#[test]
+fn parse_datetime_seconds_missing_chrono() {
+    use chrono::prelude::*;
+
     // this is the example from the PDF reference, version 1.7, chapter 3.8.3
     let text = Object::string_literal("D:199812231952-08'00'");
-    assert!(text.as_datetime().is_some());
+    let dt: Option<DateTime<Local>> = text.as_datetime().and_then(|dt| dt.try_into().ok());
+    assert!(dt.is_some());
 }
 
-#[cfg(feature = "chrono_time")]
+#[cfg(feature = "chrono")]
 #[test]
-fn parse_datetime_time_missing() {
+fn parse_datetime_time_missing_chrono() {
+    use chrono::prelude::*;
+
     let text = Object::string_literal("D:20040229");
-    assert!(text.as_datetime().is_some());
+    let dt: Option<DateTime<Local>> = text.as_datetime().and_then(|dt| dt.try_into().ok());
+    assert!(dt.is_some());
 }
 
-#[cfg(not(feature = "chrono_time"))]
+#[cfg(feature = "jiff")]
+#[test]
+fn parse_datetime_seconds_missing_jiff() {
+    use jiff::Zoned;
+
+    // this is the example from the PDF reference, version 1.7, chapter 3.8.3
+    let text = Object::string_literal("D:199812231952-08'00'");
+    let dt: Option<Zoned> = text.as_datetime().and_then(|dt| dt.try_into().ok());
+    assert!(dt.is_some());
+}
+
+#[cfg(feature = "jiff")]
+#[test]
+fn parse_datetime_time_missing_jiff() {
+    use jiff::Zoned;
+
+    let text = Object::string_literal("D:20040229");
+    let dt: Option<Zoned> = text.as_datetime().and_then(|dt| dt.try_into().ok());
+    assert!(dt.is_some());
+}
+
+#[cfg(feature = "time")]
 #[test]
 fn parse_datetime() {
-    let time = time::OffsetDateTime::now_utc();
+    use time::OffsetDateTime;
+
+    let time = OffsetDateTime::now_utc();
 
     let text: Object = time.into();
-    let time2 = text.as_datetime().unwrap();
+    let time2: OffsetDateTime = text.as_datetime().unwrap().try_into().unwrap();
 
     assert_eq!(time2.date(), time.date());
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -71,7 +71,7 @@ mod jiff_impl {
             // specified, the relationship of the specified time to UT shall be considered GMT."
             //
             // 1. Try parsing the full date and time with the `%#z` specifier to parse the timezone
-            //    as `Zoned` object.
+            //    as a `Zoned` object.
             // 2. Try parsing the full date and time with the 'Z' suffix as a `DateTime` interpreted
             //    to be in the UTC timezone.
             // 3. Try parsing the date and time without the seconds specified with the `%#z`

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -19,19 +19,19 @@ mod chrono_impl {
         }
     }
 
-    impl TryInto<DateTime<Local>> for super::DateTime {
+    impl TryFrom<super::DateTime> for DateTime<Local> {
         type Error = chrono::format::ParseError;
 
-        fn try_into(self) -> Result<DateTime<Local>, Self::Error> {
+        fn try_from(value: super::DateTime) -> Result<DateTime<Local>, Self::Error> {
             let from_date = |date: NaiveDate| {
                 FixedOffset::east_opt(0)
                     .unwrap()
                     .from_utc_datetime(&date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap()))
             };
 
-            DateTime::parse_from_str(&self.0, "%Y%m%d%H%M%S%#z")
-                .or_else(|_| DateTime::parse_from_str(&self.0, "%Y%m%d%H%M%#z"))
-                .or_else(|_| NaiveDate::parse_from_str(&self.0, "%Y%m%d").map(from_date))
+            DateTime::parse_from_str(&value.0, "%Y%m%d%H%M%S%#z")
+                .or_else(|_| DateTime::parse_from_str(&value.0, "%Y%m%d%H%M%#z"))
+                .or_else(|_| NaiveDate::parse_from_str(&value.0, "%Y%m%d").map(from_date))
                 .map(|date| date.with_timezone(&Local))
         }
     }
@@ -56,17 +56,17 @@ mod jiff_impl {
         }
     }
 
-    impl TryInto<Zoned> for super::DateTime {
+    impl TryFrom<super::DateTime> for Zoned {
         type Error = jiff::Error;
 
-        fn try_into(self) -> Result<Zoned, Self::Error> {
+        fn try_from(value: super::DateTime) -> Result<Self, Self::Error> {
             use jiff::civil::{Date, DateTime};
 
-            Zoned::strptime("%Y%m%d%H%M%S%#z", &self.0)
-                .or_else(|_| DateTime::strptime("%Y%m%d%H%M%SZ", &self.0).and_then(|dt| dt.in_tz("UTC")))
-                .or_else(|_| Zoned::strptime("%Y%m%d%H%M%#z", &self.0))
-                .or_else(|_| DateTime::strptime("%Y%m%d%H%MZ", &self.0).and_then(|dt| dt.in_tz("UTC")))
-                .or_else(|_| Date::strptime("%Y%m%d", &self.0).and_then(|dt| dt.at(0, 0, 0, 0).in_tz("UTC")))
+            Zoned::strptime("%Y%m%d%H%M%S%#z", &value.0)
+                .or_else(|_| DateTime::strptime("%Y%m%d%H%M%SZ", &value.0).and_then(|dt| dt.in_tz("UTC")))
+                .or_else(|_| Zoned::strptime("%Y%m%d%H%M%#z", &value.0))
+                .or_else(|_| DateTime::strptime("%Y%m%d%H%MZ", &value.0).and_then(|dt| dt.in_tz("UTC")))
+                .or_else(|_| Date::strptime("%Y%m%d", &value.0).and_then(|dt| dt.at(0, 0, 0, 0).in_tz("UTC")))
         }
     }
 }
@@ -106,16 +106,16 @@ mod time_impl {
     /// (daylight saving time) and `tm_nsec` (nanoseconds of the date from 1970)
     /// are set to 0 since they aren't available in the PDF time format. They could,
     /// however, be calculated manually
-    impl TryInto<OffsetDateTime> for super::DateTime {
+    impl TryFrom<super::DateTime> for OffsetDateTime {
         type Error = time::Error;
 
-        fn try_into(self) -> Result<OffsetDateTime, Self::Error> {
+        fn try_from(value: super::DateTime) -> Result<OffsetDateTime, Self::Error> {
             let format = time::format_description::parse(
                 "[year][month][day][hour][minute][second][offset_hour sign:mandatory][offset_minute]",
             )
             .unwrap();
 
-            Ok(OffsetDateTime::parse(&self.0, &format)?)
+            Ok(OffsetDateTime::parse(&value.0, &format)?)
         }
     }
 }


### PR DESCRIPTION
Rather than having a `chrono_time` toggle, this pull request introduces separate feature flags for the [chrono](https://docs.rs/chrono/latest/chrono/) and [time](https://docs.rs/chrono/latest/time/) crates. In addition, this pull request adds support for the new [jiff](https://docs.rs/chrono/latest/jiff/) crate. While all dependencies are enabled by default, this ultimately gives users more control over which dependencies they want to use to handle dates and times.

Unfortunately, this pull request introduces a **breaking API change (!)** to provide this level of compatibility as `Object::as_datetime()` had varying implementations depending on whether the original `chrono_time` feature was enabled or disabled. Instead, this pull request introduces a `DateTime` struct to hold the `String` created by `Object::datetime_string()` and implements the `TryInto<T>` trait for `DateTime`. This lets users specify into what type (e.g., `DateTime<Local>` from chrono, `Zoned` from jiff, etc.) the `DateTime` object should be converted.

Finally, this pull request adds test cases to ensure the jiff implementation works correctly.