### PR TITLE
Avoid parsing encrypted object streams early and correctly parse object streams upon decryption

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -309,12 +309,19 @@ impl Document {
             };
 
             if !stream.dict.has_type(b"ObjStm") {
-                let obj_stream = ObjectStream::new(stream).ok().unwrap();
-
-                // TODO: Is insert and replace intended behavior?
-                // See https://github.com/J-F-Liu/lopdf/issues/160 for more info
-                object_streams.extend(obj_stream.objects);
+                continue;
             }
+
+            let obj_stream = ObjectStream::new(stream).ok().unwrap();
+
+            // TODO: Is insert and replace intended behavior?
+            // See https://github.com/J-F-Liu/lopdf/issues/160 for more info
+            object_streams.extend(obj_stream.objects);
+        }
+
+        // Only add entries, but never replace entries
+        for (id, entry) in object_streams {
+            self.objects.entry(id).or_insert(entry);
         }
 
         self.trailer.remove(b"Encrypt");


### PR DESCRIPTION
OK, after testing upstream to make sure lopdf works for issue #369, I realized some things were still missing.

The first commit makes sure that `Reader::read()` does not try to parse object streams when the document is encrypted, thus leaving them intact for `Document::decrypt()` such that it can parse the object streams after decrypting the streams.

The second commit fixes #382. I was somehow missing a `continue` after checking that the stream is **not** an object stream as well as the part to actually add the newly parsed objects.

I tested this branch to make sure this all works for the document provided in issue #369 and everything looks good now.