### PR TITLE
Crypt filters

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -321,6 +321,19 @@ impl Document {
         // Find the ID of the encryption dict; we'll want to skip it when decrypting
         let encryption_obj_id = self.trailer.get(b"Encrypt").and_then(Object::as_reference)?;
 
+        // The name of the preferred security handler for this document. It shall be the name of
+        // the security handler that was used to encrypt the document.
+        //
+        // Standard shall be the name of the built-in password-based security handler.
+        let filter = self.get_encrypted()
+            .and_then(|dict| dict.get(b"Filter"))
+            .and_then(|object| object.as_name())
+            .map_err(|_| Error::DictKey("Filter".to_string()))?;
+
+        if filter != b"Standard" {
+            return Err(Error::UnsupportedSecurityHandler(filter.to_vec()));
+        }
+
         // Since PDF 1.5, metadata may or may not be encrypted; defaults to true
         let metadata_is_encrypted = self
             .get_object(encryption_obj_id)?

--- a/src/document.rs
+++ b/src/document.rs
@@ -334,6 +334,7 @@ impl Document {
         let crypt_filters = self.get_crypt_filters();
 
         let mut state = EncryptionState {
+            crypt_filters,
             key,
             stream_filter: Arc::new(Rc4CryptFilter),
             string_filter: Arc::new(Rc4CryptFilter),
@@ -343,7 +344,7 @@ impl Document {
             .and_then(|dict| dict.get(b"StmF"))
             .and_then(|object| object.as_name())
             .ok()
-            .and_then(|name| crypt_filters.get(name).cloned()) {
+            .and_then(|name| state.crypt_filters.get(name).cloned()) {
             state.stream_filter = stream_filter;
         }
 
@@ -351,7 +352,7 @@ impl Document {
             .and_then(|dict| dict.get(b"StrF"))
             .and_then(|object| object.as_name())
             .ok()
-            .and_then(|name| crypt_filters.get(name).cloned()) {
+            .and_then(|name| state.crypt_filters.get(name).cloned()) {
             state.string_filter = string_filter;
         }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,6 +97,9 @@ pub enum Error {
     /// Could not parse ToUnicodeCMap.
     #[error("failed parsing ToUnicode CMap: {0}")]
     ToUnicodeCMap(#[from] UnicodeCMapError),
+    /// Encountered an unsupported security handler.
+    #[error("unsupported security handler")]
+    UnsupportedSecurityHandler(Vec<u8>),
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
This pull request adds support for PDF documents encrypted with 256-bit AES-CBC and PDF documents that make use of crypt filters.

Since this is a rather large pull request, let me summarize each of the commits:

The first commit introduces a `CryptFilter` trait responsible for computing the key to be used to decrypt the ciphertext of a given string or stream object as well as decrypting said ciphertext. In addition, it implements a `Rc4CryptFilter`, an `Aes128CryptFilter` and an `IdentityCryptFilter` to handle the existing key computation and decryption. The `IdentityFilter` is essentially a no-op and is required by the specification where the `Identity` crypt filter is used to passthrough the ciphertext unaltered as plaintext. In addition, this commits adds some comments around the key computation citing the PDF specification to better clarify the code.

The second commit implements the `Aes256CryptFilter` which implements the 256-bit AES-CBC crypt filter used since PDF 2.0.

The third commit adds `Document::get_crypt_filters()` which parses the available crypt filters in the PDF document providing a `BTreeMap` with the name of each crypt filter as key and the crypt filter to use as value. Since we use dyn traits, we wrap the crypt filters in `Arc` to make it easy to clone the crypt filters if needed.

The fourth commit changes `Document::decrypt()` to no longer determine if the PDF document uses AES or not, but rather collects the crypt filters using `Document::get_crypt_filters()` and gets the crypt filters to use for stream and string objects by looking up the `StmF` and `StrF` keys in the encrypted dictionary respectively. Instead of providing the file encryption key and the `is_aes` parameter to `Object::decrypt()`, `Object::decrypt()` now simply accepts an `EncryptionState` holding the key as well as the stream and string crypt filters to use by default. It then proceeds to use the corresponding crypt filter to compute the key and decrypt the ciphertext. Finally, this commit also adds some more comments in `Object::decrypt()` to clarify what types of objects have to be decrypted and how.

The fifth commit handles the case where stream objects can override the default stream crypt filter by providing a `Crypt` filter with a `DecodeParms` dictionary containing the name of the crypt filter to use. We handle this in `Document::decrypt()` by checking if such a crypt filter is present and look up the crypt filter we need to use instead of the default one.

The sixth and final commit checks if the PDF document contains a `Filter` key in the encrypted dictionary. This is used to specify the security handler to use for the PDF document, and as we currently only support the `Standard` security handler, we only proceed to decrypt if `Filter` is equal to `b"Standard"`.

I have tested this with the document in issue #369 as well as some PDF documents that I have that use RC4 encryption to ensure that these changes don't break anything that was currently working before this pull request.