### PR TITLE
Use PKCS#5 and implement encryption logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ log = "0.4"
 md-5 = "0.10"
 nom = { version = "7.1", optional = true }
 nom_locate = { version = "4.2.0", optional = true }
+rand = { version = "0.9" }
 rangemap = "1.5"
 rayon = { version = "1.6", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -493,8 +493,87 @@ where
     }
 }
 
-/// Decrypts `obj` and returns the content of the string or stream.
-/// If obj is not an decryptable type, returns the NotDecryptable error.
+/// Encrypts `obj`.
+pub fn encrypt_object(state: &EncryptionState, obj_id: ObjectId, obj: &mut Object) -> Result<(), DecryptionError> {
+    // The cross-reference stream shall not be encrypted and strings appearing in the
+    // cross-reference stream dictionary shall not be encrypted.
+    let is_xref_stream = obj.as_stream()
+        .map(|stream| stream.dict.has_type(b"XRef"))
+        .unwrap_or(false);
+
+    if is_xref_stream {
+        return Ok(());
+    }
+
+    // A stream filter type, the Crypt filter can be specified for any stream in the document to
+    // override the default filter for streams. The stream's DecodeParms entry shall contain a
+    // Crypt filter decode parameters dictionary whose Name entry specifies the particular crypt
+    // filter that shell be used (if missing, Identity is used).
+    let override_crypt_filter = obj.as_stream().ok()
+        .filter(|stream| stream.filters().map(|filters| filters.contains(&&b"Crypt"[..])).unwrap_or(false))
+        .and_then(|stream| stream.dict.get(b"DecodeParms").ok())
+        .and_then(|object| object.as_dict().ok())
+        .map(|dict| dict.get(b"Name")
+            .and_then(|object| object.as_name())
+            .ok()
+            .and_then(|name| state.crypt_filters.get(name).cloned())
+            .unwrap_or(Arc::new(IdentityCryptFilter))
+        );
+
+    // Retrieve the plaintext and the crypt filter to use to decrypt the ciphertext from the given
+    // object.
+    let (mut crypt_filter, plaintext) = match obj {
+        // Encryption applies to all strings and streams in the document's PDF file, i.e., we have to
+        // recursively process array and dictionary objects to decrypt any string and stream objects
+        // stored inside of those.
+        Object::Array(objects) => {
+            for obj in objects {
+                encrypt_object(state, obj_id, obj)?;
+            }
+
+            return Ok(());
+        }
+        Object::Dictionary(objects) => {
+            for (_, obj) in objects.iter_mut() {
+                encrypt_object(state, obj_id, obj)?;
+            }
+
+            return Ok(());
+        }
+        // Encryption applies to all strings and streams in the document's PDF file. We return the
+        // crypt filter and the content here.
+        Object::String(content, _) => (state.string_filter.clone(), &*content),
+        Object::Stream(stream) => (state.stream_filter.clone(), &stream.content),
+        // Encryption is not applied to other object types such as integers and boolean values.
+        _ => {
+            return Ok(());
+        }
+    };
+
+    // If the stream object specifies its own crypt filter, override the default one with the one
+    // from this stream object.
+    if let Some(filter) = override_crypt_filter {
+        crypt_filter = filter;
+    }
+
+    // Compute the key from the original file encryption key and the object identifier to use for
+    // the corresponding object.
+    let key = crypt_filter.compute_key(&state.key, obj_id)?;
+
+    // Encrypt the plaintext.
+    let ciphertext = crypt_filter.encrypt(&key, plaintext)?;
+
+    // Store the ciphertext in the object.
+    match obj {
+        Object::Stream(stream) => stream.set_content(ciphertext),
+        Object::String(content, _) => *content = ciphertext,
+        _ => (),
+    }
+
+    Ok(())
+}
+
+/// Decrypts `obj`.
 pub fn decrypt_object(state: &EncryptionState, obj_id: ObjectId, obj: &mut Object) -> Result<(), DecryptionError> {
     // The cross-reference stream shall not be encrypted and strings appearing in the
     // cross-reference stream dictionary shall not be encrypted.

--- a/src/toc.rs
+++ b/src/toc.rs
@@ -116,7 +116,7 @@ impl Document {
                     let t16: Vec<u16> = title
                         .chunks(2)
                         .skip(1)
-                        .map(|x| (x[0] as u16) << 8 | x[1] as u16)
+                        .map(|x| ((x[0] as u16) << 8) | x[1] as u16)
                         .collect();
                     s = String::from_utf16_lossy(&t16);
                 } else if title[0] == 0xff && title[1] == 0xfe {
@@ -128,7 +128,7 @@ impl Document {
                     let t16: Vec<u16> = title
                         .chunks(2)
                         .skip(1)
-                        .map(|x| (x[1] as u16) << 8 | x[0] as u16)
+                        .map(|x| ((x[1] as u16) << 8) | x[0] as u16)
                         .collect();
                     s = String::from_utf16_lossy(&t16);
                 } else {


### PR DESCRIPTION
This pull request implements PKCS#5 padding rather than using PKCS#7 padding to better adhere to the PDF specification which states that AES encryption should use PKCS#5 padding.

In addition, this pull request starts initial work on being able to encrypt documents by adding `encrypt()` to the `CryptFilter` trait, implementing the `encrypt()` function for the various existing crypt filters and implementing `encrypt_object()` (which can later be used by `Document::encrypt()` once the remaining password algorithms are in place).