### PR TITLE
Remove nom_parser feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
                     - nightly
                     - "feat: no default features"
                     - "feat: all features"
-                    - "feat: nom only"
 
                 include:
                     - name: beta
@@ -29,8 +28,6 @@ jobs:
 
                     - name: "feat: all features"
                       features: "--all-features"
-                    - name: "feat: nom only"
-                      features: "--no-default-features --features nom_parser"
 
         steps:
             - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ itoa = "1.0"
 jiff = { version = "0.2", optional = true }
 log = "0.4"
 md-5 = "0.10"
-nom = { version = "7.1", optional = true }
-nom_locate = { version = "4.2.0", optional = true }
+nom = "7.1"
+nom_locate = "4.2.0"
 rand = { version = "0.9" }
 rangemap = "1.5"
 rayon = { version = "1.6", optional = true }
@@ -52,10 +52,9 @@ tempfile = "3.3"
 [features]
 async = ["tokio/rt-multi-thread", "tokio/macros"]
 chrono = ["dep:chrono"]
-default = ["chrono", "jiff", "nom_parser", "rayon", "time"]
+default = ["chrono", "jiff", "rayon", "time"]
 embed_image = ["image"]
 jiff = ["dep:jiff"]
-nom_parser = ["nom", "nom_locate"]
 serde = ["dep:serde"]
 time = ["dep:time"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,5 @@ pub use error::{Error, Result};
 pub use incremental_document::IncrementalDocument;
 pub use object_stream::ObjectStream;
 pub use outlines::Outline;
-#[cfg(feature = "nom_parser")]
 pub use reader::Reader;
 pub use toc::Toc;

--- a/src/object_stream.rs
+++ b/src/object_stream.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "nom_parser")]
 use crate::parser::{self, ParserInput};
 use crate::{Error, Object, ObjectId, Result, Stream};
 use std::collections::BTreeMap;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "nom_parser")]
 use super::{Dictionary, Object, ObjectId, Reader, Stream, StringFormat};
 use crate::content::*;
 use crate::error;

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "nom_parser")]
 use log::warn;
 
 use crate::{

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "nom_parser")]
 use log::{error, warn};
 use std::cmp;
 use std::collections::{BTreeMap, HashSet};

--- a/src/xref.rs
+++ b/src/xref.rs
@@ -137,5 +137,4 @@ impl XrefSection {
     }
 }
 
-#[cfg(feature = "nom_parser")]
 pub use crate::parser_aux::decode_xref_stream;


### PR DESCRIPTION
This will produce a clippy warning until commit 72be7e7 gets merged (currently part of PR #388, but let me know if you want me to open a separate pull request to fix the clippy warning. I think it is the result of a new clippy version).

This pull request attempts to fix #374 by removing the `nom_parser` feature flag entirely, which enables nom by default regardless of what feature flags are set. Since the removal of pom in #355, I don't think there is anything but nom left, so it makes sense to just remove the `nom_parser` feature flag to have this work properly. However, reviews are welcome to make sure I am not missing anything here.

Closes #374.