### PR TITLE
Fix a number of warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ required-features = ["default"]
 
 [[example]]
 name = "rotate"
-required-features = ["nom_parser"]
 
 [badges]
 travis-ci = { repository = "J-F-Liu/lopdf" }

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -353,12 +353,12 @@ fn parse_integer_array(array: &Object) -> Result<Vec<i64>> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::creator::tests::{create_document, create_document_with_texts, save_document};
-
     #[cfg(not(feature = "async"))]
     #[test]
     fn load_and_save() {
+        use crate::Document;
+        use crate::creator::tests::{create_document, save_document};
+
         // test load_from() and save_to()
         use std::fs::File;
         use std::io::Cursor;
@@ -382,6 +382,8 @@ mod tests {
 
     #[test]
     fn extract_text_chunks() {
+        use crate::creator::tests::create_document_with_texts;
+
         let text1 = "Hello world!";
         let text2 = "Ferris is the best!";
         let doc = create_document_with_texts(&[text1, text2]);
@@ -398,6 +400,8 @@ mod tests {
 
     #[test]
     fn extract_text_concatenates_text_from_multiple_pages() {
+        use crate::creator::tests::create_document_with_texts;
+
         let text1 = "Hello world!";
         let text2 = "Ferris is the best!";
         let doc = create_document_with_texts(&[text1, text2]);

--- a/tests/annotation.rs
+++ b/tests/annotation.rs
@@ -1,6 +1,3 @@
-// Only run test when parser is enabled
-#![cfg(feature = "nom_parser")]
-
 use lopdf::Result;
 
 mod utils;

--- a/tests/incremental_document.rs
+++ b/tests/incremental_document.rs
@@ -1,6 +1,3 @@
-// Only run test when parser is enabled
-#![cfg(feature = "nom_parser")]
-
 use lopdf::Result;
 use tempfile::tempdir;
 

--- a/tests/modify.rs
+++ b/tests/modify.rs
@@ -25,7 +25,6 @@ fn test_get_object() {
     assert!(obj2_exists);
 }
 
-#[cfg(feature = "nom_parser")]
 #[cfg(all(test, not(feature = "async")))]
 mod tests_with_parsing {
     use super::*;

--- a/tests/unicode.rs
+++ b/tests/unicode.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "nom_parser")]
-
 use lopdf::content::{Content, Operation};
 use lopdf::{dictionary, Document, Object, Stream, StringFormat};
 


### PR DESCRIPTION
This pull request fixes some warnings about some remnant nom_parser feature flag checks, unused imports and nom_parser is no longer a required feature for the rotate example.