### PR TITLE
Implement Document::encrypt()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.74"
 
 [dependencies]
 aes = "0.8.4"
+bitflags = "2.8.0"
 cbc = "0.1.2"
 chrono = { version = "0.4", optional = true, default-features = false, features = [
     "std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ chrono = { version = "0.4", optional = true, default-features = false, features 
     "std",
     "clock",
 ] }
+ecb = "0.1.2"
 encoding_rs = "0.8.32"
 flate2 = "1.0"
 image = { version = "0.25", optional = true }

--- a/src/document.rs
+++ b/src/document.rs
@@ -421,6 +421,27 @@ impl Document {
         crypt_filters
     }
 
+    /// Replaces all encrypted Strings and Streams with their encrypted contents
+    pub fn encrypt(
+        &mut self,
+        state: &EncryptionState,
+    ) -> Result<()> {
+        if self.is_encrypted() {
+            return Err(Error::AlreadyEncrypted);
+        }
+
+        let encrypted = state.encode()?;
+
+        for (&id, obj) in self.objects.iter_mut() {
+            encryption::encrypt_object(state, id, obj)?;
+        }
+
+        self.trailer.set(b"Encrypt", encrypted);
+
+        Ok(())
+    }
+
+
     /// Replaces all encrypted Strings and Streams with their decrypted contents
     pub fn decrypt(
         &mut self,

--- a/src/document.rs
+++ b/src/document.rs
@@ -473,13 +473,13 @@ impl Document {
             .unwrap_or(true);
 
         let algorithm = PasswordAlgorithm::try_from(&*self)?;
-        let key = algorithm.compute_file_encryption_key(self, &password)?;
+        let file_encryption_key = algorithm.compute_file_encryption_key(self, &password)?;
 
         let crypt_filters = self.get_crypt_filters();
 
         let mut state = EncryptionState {
             crypt_filters,
-            key,
+            file_encryption_key,
             stream_filter: Arc::new(Rc4CryptFilter),
             string_filter: Arc::new(Rc4CryptFilter),
         };

--- a/src/document.rs
+++ b/src/document.rs
@@ -451,24 +451,11 @@ impl Document {
         // Find the ID of the encryption dict; we'll want to skip it when decrypting
         let encryption_obj_id = self.trailer.get(b"Encrypt").and_then(Object::as_reference)?;
 
-        // Since PDF 1.5, metadata may or may not be encrypted; defaults to true
-        let metadata_is_encrypted = self
-            .get_object(encryption_obj_id)?
-            .as_dict()?
-            .get(b"EncryptMetadata")
-            .and_then(|o| o.as_bool())
-            .unwrap_or(true);
-
         let state = EncryptionState::decode(&*self, password)?;
 
         for (&id, obj) in self.objects.iter_mut() {
             // The encryption dictionary is not encrypted, leave it alone
             if id == encryption_obj_id {
-                continue;
-            }
-
-            // If a Metadata stream but metadata isn't encrypted, leave it alone
-            if obj.type_name().ok() == Some(b"Metadata") && !metadata_is_encrypted {
                 continue;
             }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -480,24 +480,22 @@ impl Document {
         let mut state = EncryptionState {
             crypt_filters,
             file_encryption_key,
-            stream_filter: Arc::new(Rc4CryptFilter),
-            string_filter: Arc::new(Rc4CryptFilter),
+            stream_filter: vec![],
+            string_filter: vec![],
         };
 
         if let Some(stream_filter) = self.get_encrypted()
             .and_then(|dict| dict.get(b"StmF"))
             .and_then(|object| object.as_name())
-            .ok()
-            .and_then(|name| state.crypt_filters.get(name).cloned()) {
-            state.stream_filter = stream_filter;
+            .ok() {
+            state.stream_filter = stream_filter.to_vec();
         }
 
         if let Some(string_filter) = self.get_encrypted()
             .and_then(|dict| dict.get(b"StrF"))
             .and_then(|object| object.as_name())
-            .ok()
-            .and_then(|name| state.crypt_filters.get(name).cloned()) {
-            state.string_filter = string_filter;
+            .ok() {
+            state.string_filter = string_filter.to_vec();
         }
 
         for (&id, obj) in self.objects.iter_mut() {

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -319,6 +319,11 @@ pub fn encrypt_object(state: &EncryptionState, obj_id: ObjectId, obj: &mut Objec
         return Ok(());
     }
 
+    // The Metadata stream shall only be encrypted if EncryptMetadata is set to true.
+    if obj.type_name().ok() == Some(b"Metadata") && !state.encrypt_metadata {
+        return Ok(());
+    }
+
     // A stream filter type, the Crypt filter can be specified for any stream in the document to
     // override the default filter for streams. The stream's DecodeParms entry shall contain a
     // Crypt filter decode parameters dictionary whose Name entry specifies the particular crypt
@@ -396,6 +401,11 @@ pub fn decrypt_object(state: &EncryptionState, obj_id: ObjectId, obj: &mut Objec
         .unwrap_or(false);
 
     if is_xref_stream {
+        return Ok(());
+    }
+
+    // The Metadata stream shall only be encrypted if EncryptMetadata is set to true.
+    if obj.type_name().ok() == Some(b"Metadata") && !state.encrypt_metadata {
         return Ok(());
     }
 

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -168,7 +168,7 @@ impl EncryptionState {
             .and_then(Object::as_str)
             .map(|s| s.to_vec())
             .ok()
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
 
         // Get the user value and user encrypted blobs.
         let user_value = document.get_encrypted()
@@ -183,7 +183,7 @@ impl EncryptionState {
             .and_then(Object::as_str)
             .map(|s| s.to_vec())
             .ok()
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
 
         // Get the permission value.
         let permission_value = document.get_encrypted()
@@ -209,17 +209,15 @@ impl EncryptionState {
             permissions,
         };
 
-        if let Some(stream_filter) = document.get_encrypted()
+        if let Ok(stream_filter) = document.get_encrypted()
             .and_then(|dict| dict.get(b"StmF"))
-            .and_then(|object| object.as_name())
-            .ok() {
+            .and_then(|object| object.as_name()) {
             state.stream_filter = stream_filter.to_vec();
         }
 
-        if let Some(string_filter) = document.get_encrypted()
+        if let Ok(string_filter) = document.get_encrypted()
             .and_then(|dict| dict.get(b"StrF"))
-            .and_then(|object| object.as_name())
-            .ok() {
+            .and_then(|object| object.as_name()) {
             state.string_filter = string_filter.to_vec();
         }
 

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -33,6 +33,8 @@ pub enum DecryptionError {
     InvalidKeyLength,
     #[error("invalid ciphertext length")]
     InvalidCipherTextLength,
+    #[error("invalid permission length")]
+    InvalidPermissionLength,
     #[error("invalid revision")]
     InvalidRevision,
     // Used generically when the object type violates the spec

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -55,7 +55,7 @@ pub enum DecryptionError {
 #[derive(Clone, Debug)]
 pub struct EncryptionState {
     pub crypt_filters: BTreeMap<Vec<u8>, Arc<dyn CryptFilter>>,
-    pub key: Vec<u8>,
+    pub file_encryption_key: Vec<u8>,
     pub stream_filter: Arc<dyn CryptFilter>,
     pub string_filter: Arc<dyn CryptFilter>,
 }
@@ -125,7 +125,7 @@ pub fn encrypt_object(state: &EncryptionState, obj_id: ObjectId, obj: &mut Objec
 
     // Compute the key from the original file encryption key and the object identifier to use for
     // the corresponding object.
-    let key = crypt_filter.compute_key(&state.key, obj_id)?;
+    let key = crypt_filter.compute_key(&state.file_encryption_key, obj_id)?;
 
     // Encrypt the plaintext.
     let ciphertext = crypt_filter.encrypt(&key, plaintext)?;
@@ -205,7 +205,7 @@ pub fn decrypt_object(state: &EncryptionState, obj_id: ObjectId, obj: &mut Objec
 
     // Compute the key from the original file encryption key and the object identifier to use for
     // the corresponding object.
-    let key = crypt_filter.compute_key(&state.key, obj_id)?;
+    let key = crypt_filter.compute_key(&state.file_encryption_key, obj_id)?;
 
     // Decrypt the ciphertext.
     let plaintext = crypt_filter.decrypt(&key, ciphertext)?;

--- a/src/encryption/algorithms.rs
+++ b/src/encryption/algorithms.rs
@@ -382,7 +382,7 @@ impl PasswordAlgorithm {
             //   concatenation of the input password, K, and the 48-byte user key.
             // * Otherwise, K0 is the concatenation of the input password and K.
             //
-            // Next, set k1 to 64 repetitions of K0.
+            // Next, set K1 to 64 repetitions of K0.
             k1.clear();
 
             for _ in 0..64 {
@@ -397,6 +397,9 @@ impl PasswordAlgorithm {
             // Encrypt K1 with the AES-128 (CBC, no padding) algorithm, using the first 16 bytes of
             // K as the key, and the second 16 bytes of K as the initialization vector. The result
             // of this encryption is E.
+            //
+            // The 64 repetitions of K0 ensure that K1 is a multiple of 64 bytes, thus a multiple
+            // of 16 bytes, i.e., it does not require padding.
             let key = &k[0..][..16];
             let iv = &k[16..][..16];
 

--- a/src/encryption/crypt_filters.rs
+++ b/src/encryption/crypt_filters.rs
@@ -13,6 +13,7 @@ type Aes128CbcDec = cbc::Decryptor<aes::Aes128>;
 type Aes256CbcDec = cbc::Decryptor<aes::Aes256>;
 
 pub trait CryptFilter: std::fmt::Debug {
+    fn method(&self) -> &[u8];
     fn compute_key(&self, key: &[u8], obj_id: ObjectId) -> Result<Vec<u8>, DecryptionError>;
     fn encrypt(&self, key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, DecryptionError>;
     fn decrypt(&self, key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, DecryptionError>;
@@ -22,6 +23,10 @@ pub trait CryptFilter: std::fmt::Debug {
 pub struct IdentityCryptFilter;
 
 impl CryptFilter for IdentityCryptFilter {
+    fn method(&self) -> &[u8] {
+        b"Identity"
+    }
+
     fn compute_key(&self, key: &[u8], _obj_id: ObjectId) -> Result<Vec<u8>, DecryptionError> {
         Ok(key.to_vec())
     }
@@ -39,6 +44,10 @@ impl CryptFilter for IdentityCryptFilter {
 pub struct Rc4CryptFilter;
 
 impl CryptFilter for Rc4CryptFilter {
+    fn method(&self) -> &[u8] {
+        b"V2"
+    }
+
     fn compute_key(&self, key: &[u8], obj_id: ObjectId) -> Result<Vec<u8>, DecryptionError> {
         let mut hasher = Md5::new();
 
@@ -75,6 +84,10 @@ impl CryptFilter for Rc4CryptFilter {
 pub struct Aes128CryptFilter;
 
 impl CryptFilter for Aes128CryptFilter {
+    fn method(&self) -> &[u8] {
+        b"AESV2"
+    }
+
     fn compute_key(&self, key: &[u8], obj_id: ObjectId) -> Result<Vec<u8>, DecryptionError> {
         let mut builder = Vec::with_capacity(key.len() + 9);
 
@@ -165,6 +178,10 @@ impl CryptFilter for Aes128CryptFilter {
 pub struct Aes256CryptFilter;
 
 impl CryptFilter for Aes256CryptFilter {
+    fn method(&self) -> &[u8] {
+        b"AESV3"
+    }
+
     fn compute_key(&self, key: &[u8], _obj_id: ObjectId) -> Result<Vec<u8>, DecryptionError> {
         // Use the 32-byte file encryption key for the AES-256 symmetric key algorithm.
         Ok(key.to_vec())

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,9 @@ pub enum Error {
     },
     #[error("dictionary has wrong type: ")]
     DictType { expected: &'static str, found: String },
+    /// PDF document is already encrypted.
+    #[error("PDF document is already encrypted")]
+    AlreadyEncrypted,
     /// The encountered character encoding is invalid.
     #[error("invalid character encoding")]
     CharacterEncoding,


### PR DESCRIPTION
Since this pull request is getting quite large already, I am leaving the work of implementing more sanity checks in terms of what is possible depending on the version/revision, actual test cases and an `EncryptionStateBuilder` when creating new PDF documents for the next pull request, but I think those are the tasks that are currently left to do.

This pull request implements `Document::encrypt()`. 

The `EncryptionState` has been reworked to store all the relevant pieces of information from the encrypted dictionary, that way we can encode it back to an encrypted dictionary when encrypting it. The decoding logic has also been moved into `EncryptionState::decode()`. In addition, some fixes were required to make this work such as storing the default stream/string crypt filters by name and adding `CryptFilter::method()` which returns the name to be stored in the CFM field.

This pull request also implements the remaining algorithms to compute the owner values, user values and permissions for revision 6 as well as the algorithm to verify the permissions. Part of which will become relevant for the `EncryptionStateBuilder`.

Most of the other commits clean up the code a bit here and there.

`Document::encrypt()` uses `EncryptionState::encode()` to create the encrypted dictionary and store it in the trailer of the documents and proceeds to use `encrypt_object()` to encrypts the stream/string objects.