### PR TITLE
Add more checks to the encryption/decryption logic

### DIFF
--- a/examples/encrypt.rs
+++ b/examples/encrypt.rs
@@ -60,7 +60,6 @@ fn main() {
                 string_filter: b"StdCF".to_vec(),
                 owner_password,
                 user_password,
-                key_length: 128,
                 permissions,
             }
         }
@@ -162,7 +161,6 @@ async fn main() {
                 string_filter: b"StdCF".to_vec(),
                 owner_password,
                 user_password,
-                key_length: 128,
                 permissions,
             }
         }

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -159,7 +159,6 @@ pub enum EncryptionVersion<'a> {
         string_filter: Vec<u8>,
         owner_password: &'a str,
         user_password: &'a str,
-        key_length: usize,
         permissions: Permissions,
     },
     /// (PDF 2.0) The security handler defines the use of encryption and decryption in the
@@ -299,12 +298,11 @@ impl TryFrom<EncryptionVersion<'_>> for EncryptionState {
                 string_filter,
                 owner_password,
                 user_password,
-                key_length,
                 permissions,
             } => {
                 let mut algorithm = PasswordAlgorithm {
                     encrypt_metadata,
-                    length: Some(key_length),
+                    length: Some(128),
                     version: 4,
                     revision: 4,
                     permissions,

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -59,6 +59,8 @@ pub enum DecryptionError {
 
     #[error(transparent)]
     StringPrep(#[from] stringprep::Error),
+    #[error("invalid padding encountered when decrypting, key might be incorrect")]
+    Padding,
 }
 
 bitflags! {

--- a/src/encryption/crypt_filters.rs
+++ b/src/encryption/crypt_filters.rs
@@ -116,6 +116,11 @@ impl CryptFilter for Aes128CryptFilter {
     }
 
     fn encrypt(&self, key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, DecryptionError> {
+        // Ensure that the key is 128 bits (i.e., 16 bytes).
+        if key.len() != 16 {
+            return Err(DecryptionError::InvalidKeyLength);
+        }
+
         // The ciphertext needs to be a multiple of 16 bytes to include the padding.
         let ciphertext_len = (plaintext.len() + 16) / 16 * 16;
 
@@ -147,6 +152,11 @@ impl CryptFilter for Aes128CryptFilter {
     }
 
     fn decrypt(&self, key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, DecryptionError> {
+        // Ensure that the key is 128 bits (i.e., 16 bytes).
+        if key.len() != 16 {
+            return Err(DecryptionError::InvalidKeyLength);
+        }
+
         // Ensure that the ciphertext length is a multiple of 16 bytes.
         if ciphertext.len() % 16 != 0 {
             return Err(DecryptionError::InvalidCipherTextLength);
@@ -189,6 +199,11 @@ impl CryptFilter for Aes256CryptFilter {
     }
 
     fn encrypt(&self, key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, DecryptionError> {
+        // Ensure that the key is 256 bits (i.e., 32 bytes).
+        if key.len() != 32 {
+            return Err(DecryptionError::InvalidKeyLength);
+        }
+
         // The ciphertext needs to be a multiple of 16 bytes to include the padding.
         let ciphertext_len = (plaintext.len() + 16) / 16 * 16;
 
@@ -220,6 +235,11 @@ impl CryptFilter for Aes256CryptFilter {
     }
 
     fn decrypt(&self, key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, DecryptionError> {
+        // Ensure that the key is 256 bits (i.e., 32 bytes).
+        if key.len() != 32 {
+            return Err(DecryptionError::InvalidKeyLength);
+        }
+
         // Ensure that the ciphertext length is a multiple of 16 bytes.
         if ciphertext.len() % 16 != 0 {
             return Err(DecryptionError::InvalidCipherTextLength);

--- a/src/encryption/crypt_filters.rs
+++ b/src/encryption/crypt_filters.rs
@@ -146,7 +146,8 @@ impl CryptFilter for Aes128CryptFilter {
         // (M mod 16) bytes whose value shall also be 16 - (M mod 16).
         Aes128CbcEnc::new(key.into(), &iv.into())
             .encrypt_padded_mut::<Pkcs5>(&mut ciphertext[16..], plaintext.len())
-            .unwrap();
+            // Padding errors should not occur when encrypting, but avoid causing a panic.
+            .map_err(|_| DecryptionError::Padding)?;
 
         Ok(ciphertext)
     }
@@ -180,7 +181,7 @@ impl CryptFilter for Aes128CryptFilter {
 
         Ok(Aes128CbcDec::new(key.into(), &iv.into())
             .decrypt_padded_mut::<Pkcs5>(data)
-            .unwrap()
+            .map_err(|_| DecryptionError::Padding)?
             .to_vec())
     }
 }
@@ -229,7 +230,8 @@ impl CryptFilter for Aes256CryptFilter {
         // (M mod 16) bytes whose value shall also be 16 - (M mod 16).
         Aes256CbcEnc::new(key.into(), &iv.into())
             .encrypt_padded_mut::<Pkcs5>(&mut ciphertext[16..], plaintext.len())
-            .unwrap();
+            // Padding errors should not occur when encrypting, but avoid causing a panic.
+            .map_err(|_| DecryptionError::Padding)?;
 
         Ok(ciphertext)
     }
@@ -263,7 +265,7 @@ impl CryptFilter for Aes256CryptFilter {
 
         Ok(Aes256CbcDec::new(key.into(), &iv.into())
             .decrypt_padded_mut::<Pkcs5>(data)
-            .unwrap()
+            .map_err(|_| DecryptionError::Padding)?
             .to_vec())
     }
 }


### PR DESCRIPTION
This PR adds a few more commits to harden the encryption/decryption logic in lopdf a bit more against invalid inputs.

The first commit ensures that the file encryption length is always 128 bits. It basically sets the Length file to 128 bits and removes the explicit length field in `EncryptionVersion::V4`.

The second commit adds checks to the AES crypt filters to ensure that the key length is 16 bytes for 128-bit AES and 32 bytes for 256-bit AES and returns errors (instead of potentially causing a panic).

The third commit removes `.unwrap()` in the AES crypt filters when invalid padding is encountered. This can happen during decryption when the file encryption key is simply not the actual file encryption key that was used to encrypt the streams (e.g., in PDF 2.0 it is possible to store a file encryption key different from the one used to encrypt the streams). This fixes #398. I have also replaced `.unwrap()` when encrypting which can also theoretically result in padding errors, but shouldn't practically occur (but it just better to return an error rather than causing a panic).