### PR TITLE
Add support for Revision 5

### DIFF
--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -166,6 +166,7 @@ pub enum EncryptionVersion<'a> {
     /// proprietary Adobe extension.
     ///
     /// This exists for testing purposes to guarantee improved compatibility.
+    #[deprecated(note="R5 is a proprietary Adobe extension and should not be used in newly produced documents other than for testing purposes.")]
     R5 {
         encrypt_metadata: bool,
         crypt_filters: BTreeMap<Vec<u8>, Arc<dyn CryptFilter>>,
@@ -358,6 +359,7 @@ impl TryFrom<EncryptionVersion<'_>> for EncryptionState {
                     ..Default::default()
                 })
             }
+            #[allow(deprecated)]
             EncryptionVersion::R5 {
                 encrypt_metadata,
                 crypt_filters,

--- a/src/encryption/algorithms.rs
+++ b/src/encryption/algorithms.rs
@@ -464,6 +464,12 @@ impl PasswordAlgorithm {
 
         let mut k = hasher.finalize().to_vec();
 
+        // Revision 5 uses a simplified hash algorithm that simply calculates the SHA-256 hash of
+        // the original input to the algorithm.
+        if self.revision == 5 {
+            return Ok(k);
+        }
+
         let mut k1 = Vec::with_capacity(64 * (password.len() + 64 + user_key.map(|user_key| user_key.len()).unwrap_or(0)));
 
         // Perform the following steps at least 64 times, until the value of the last byte in K is

--- a/src/encryption/algorithms.rs
+++ b/src/encryption/algorithms.rs
@@ -1158,7 +1158,7 @@ impl PasswordAlgorithm {
     ) -> Result<Vec<u8>, DecryptionError> {
         match self.revision {
             2..=4 => self.sanitize_password_r4(password),
-            6 => self.sanitize_password_r6(password),
+            5..=6 => self.sanitize_password_r6(password),
             _ => Err(DecryptionError::UnsupportedRevision),
         }
     }
@@ -1174,7 +1174,7 @@ impl PasswordAlgorithm {
     {
         match self.revision {
             2..=4 => self.compute_file_encryption_key_r4(doc, password),
-            6 => self.compute_file_encryption_key_r6(password),
+            5..=6 => self.compute_file_encryption_key_r6(password),
             _ => Err(DecryptionError::UnsupportedRevision),
         }
     }
@@ -1190,7 +1190,7 @@ impl PasswordAlgorithm {
     {
         match self.revision {
             2..=4 => self.authenticate_user_password_r4(doc, user_password),
-            6 => self.authenticate_user_password_r6(user_password),
+            5..=6 => self.authenticate_user_password_r6(user_password),
             _ => Err(DecryptionError::UnsupportedRevision),
         }
     }
@@ -1206,7 +1206,7 @@ impl PasswordAlgorithm {
     {
         match self.revision {
             2..=4 => self.authenticate_owner_password_r4(doc, owner_password),
-            6 => self.authenticate_owner_password_r6(owner_password),
+            5..=6 => self.authenticate_owner_password_r6(owner_password),
             _ => Err(DecryptionError::UnsupportedRevision),
         }
     }


### PR DESCRIPTION
Revision 5 was once used by a proprietary Adobe extension, but should not be used to produce new documents. It is almost identical to revision 6, but short-circuits the hash algorithm by simply returning the initial SHA-256 hash. We want to support this on the decryption side to make it possible to read such documents, and on the encryption side to test that this works correctly.

The first commit adds an early return of the SHA-256 hash in the hash algorithm when the revision is 5.

The second commit re-uses the R6 algorithms for R5 as these are identical.

The third commit adds the `R5` variant to `EncryptionVersion` allowing us to implement tests to ensure that the decryption works correctly.

The fourth commit adds a deprecation warning which should warn users if they try to use `EncryptionVersion::R5` as they really shouldn't be using this variant. They can simply disable the warning with `#[allow(deprecated)]` when constructing the enum variant.