### PR TITLE
Update to nom 8.0 and nom_locate 5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ itoa = "1.0"
 jiff = { version = "0.2", optional = true }
 log = "0.4"
 md-5 = "0.10"
-nom = "7.1"
-nom_locate = "4.2.0"
+nom = "8.0"
+nom_locate = "5.0"
 rand = { version = "0.9" }
 rangemap = "1.5"
 rayon = { version = "1.6", optional = true }


### PR DESCRIPTION
Update nom to version 8.0 and nom_locate to version 5.0.

Most notably, nom merged the various traits into a single `Input` trait, which means that the `Slice` trait no longer exists. So we have to replace every `tag(b"xyz")` with `tag(&b"xyz"[..])`. Furthermore, nom 8.0 returns a `Parser` trait instead of closures, which means that we have to call `parser.parse(input)` rather than `parser(input)`. Other than that, some minimal changes are required such as fixing the function signature of `trim_spaces()`  and replacing the discard functions in `parser_aux.rs` with `.map(|(i, _)| (i, ()))` or `.map(|_| ())` to discard the result.