### PR TITLE
Implement test cases for encryption

### DIFF
--- a/src/creator.rs
+++ b/src/creator.rs
@@ -182,6 +182,10 @@ pub mod tests {
         });
         doc.trailer.set("Root", catalog_id);
         doc.trailer.set("Info", info_id);
+        doc.trailer.set("ID", Object::Array(vec![
+            Object::string_literal(b"ABC"),
+            Object::string_literal(b"DEF"),
+        ]));
         doc.compress();
         doc
     }

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -842,7 +842,6 @@ pub fn decrypt_object(state: &EncryptionState, obj_id: ObjectId, obj: &mut Objec
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::rc4::Rc4;
 
     #[test]

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -652,7 +652,7 @@ impl EncryptionState {
             encrypted.set(b"StrF", Object::Name(self.string_filter.clone()));
         }
 
-        if self.revision >= 6 {
+        if self.revision >= 5 {
             encrypted.set(b"OE", Object::string_literal(self.owner_encrypted.clone()));
             encrypted.set(b"UE", Object::string_literal(self.user_encrypted.clone()));
             encrypted.set(b"Perms", Object::string_literal(self.permission_encrypted.clone()));


### PR DESCRIPTION
This PR implements test cases for the password algorithms and document encryption/decryption. It also fixes a bug where the OE, UE and Perms field didn't get encoded for R5 (spotted this issue thanks to the tests).