### PR TITLE
Set up WASM CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,16 @@ jobs:
               run: cargo clippy
             - name: clippy for pdfutil
               run: cargo clippy --manifest-path pdfutil/Cargo.toml
+
+    wasm:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Install
+              run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+            - run: cargo test
+            - run: RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack test --headless --chrome --features wasm_js
+            - run: RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack test --headless --firefox --features wasm_js

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ image = { version = "0.25", optional = true }
 indexmap = "2.2.3"
 itoa = "1.0"
 jiff = { version = "0.2", optional = true }
+getrandom = "0.3"
 log = "0.4"
 md-5 = "0.10"
 nom = "8.0"
@@ -55,6 +56,7 @@ env_logger = "0.11"
 serde_json = "1.0"
 shellexpand = "3.0"
 tempfile = "3.3"
+wasm-bindgen-test = "0.2"
 
 [features]
 async = ["tokio/rt-multi-thread", "tokio/macros"]
@@ -62,6 +64,7 @@ chrono = ["dep:chrono"]
 default = ["chrono", "jiff", "rayon", "time"]
 embed_image = ["image"]
 jiff = ["dep:jiff"]
+wasm_js = ["getrandom/wasm_js"]
 serde = ["dep:serde"]
 time = ["dep:time"]
 


### PR DESCRIPTION
Set up a workflow for `wasm32-unknown-unknown` using wasm-pack to ensure that lopdf builds for WebAssembly targets.

See also #408.