### PR TITLE
Set up WASI CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,18 @@ jobs:
             - run: cargo test
             - run: RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack test --headless --chrome --features wasm_js
             - run: RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack test --headless --firefox --features wasm_js
+
+    wasi:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                target: [wasm32-wasip1, wasm32-wasip2]
+
+        steps:
+            - uses: actions/checkout@v2
+            - uses: hecrj/setup-rust-action@v1
+              with:
+                targets: ${{ matrix.target }}
+
+            - name: Build
+              run: cargo build --verbose --target ${{ matrix.target }}


### PR DESCRIPTION
Set up CI workflows to build lopdf for wasm32-wasip1 and wasm32-wasip2, but avoid running `cargo test` for now. `cargo test` seems to require Rust nightly and `#![feature(wasip2)]` somewhere due to the tempfile dependency.

See also issue #408.