### PR TITLE
Retain permission bits

### DIFF
--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -113,7 +113,13 @@ bitflags! {
 
 impl Default for Permissions {
     fn default() -> Self {
-        let mut bits = Self::all().bits();
+        Self::all()
+    }
+}
+
+impl Permissions {
+    fn correct_bits(self) -> Self {
+        let mut bits = self.bits();
 
         // 7-8: Reserved. Must be 1.
         bits |= 0b11 << 6;
@@ -221,6 +227,8 @@ impl TryFrom<EncryptionVersion<'_>> for EncryptionState {
                 user_password,
                 permissions,
             } => {
+                let permissions = permissions.correct_bits();
+
                 let mut algorithm = PasswordAlgorithm {
                     encrypt_metadata: true,
                     length: None,
@@ -267,6 +275,8 @@ impl TryFrom<EncryptionVersion<'_>> for EncryptionState {
                 key_length,
                 permissions,
             } => {
+                let permissions = permissions.correct_bits();
+
                 let mut algorithm = PasswordAlgorithm {
                     encrypt_metadata: true,
                     length: Some(key_length),
@@ -316,6 +326,8 @@ impl TryFrom<EncryptionVersion<'_>> for EncryptionState {
                 user_password,
                 permissions,
             } => {
+                let permissions = permissions.correct_bits();
+
                 let mut algorithm = PasswordAlgorithm {
                     encrypt_metadata,
                     length: Some(128),
@@ -372,6 +384,8 @@ impl TryFrom<EncryptionVersion<'_>> for EncryptionState {
                 if file_encryption_key.len() != 32 {
                     return Err(DecryptionError::InvalidKeyLength)?;
                 }
+
+                let permissions = permissions.correct_bits();
 
                 let mut algorithm = PasswordAlgorithm {
                     encrypt_metadata,
@@ -434,6 +448,8 @@ impl TryFrom<EncryptionVersion<'_>> for EncryptionState {
                 if file_encryption_key.len() != 32 {
                     return Err(DecryptionError::InvalidKeyLength)?;
                 }
+
+                let permissions = permissions.correct_bits();
 
                 let mut algorithm = PasswordAlgorithm {
                     encrypt_metadata,

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -113,20 +113,19 @@ bitflags! {
 
 impl Default for Permissions {
     fn default() -> Self {
-        Self::all()
-    }
-}
+        let mut bits = Self::all().bits();
 
-impl Permissions {
-    pub fn p_value(&self) -> u64 {
-        self.bits() |
         // 7-8: Reserved. Must be 1.
-        (0b11 << 6) |
+        bits |= 0b11 << 6;
+
         // 13-32: Reserved. Must be 1.
-        (0b1111 << 12) | (0xffff << 16) |
+        bits |= 0b1111 << 12 | 0xffff << 16;
+
         // Extend the permissions (contents of the P integer) to 64 bits by setting the upper 32
         // bits to all 1s.
-        (0xffffffff << 32)
+        bits |= 0xffffffff << 32;
+
+        Permissions::from_bits_retain(bits)
     }
 }
 
@@ -633,7 +632,7 @@ impl EncryptionState {
 
         encrypted.set(b"O", Object::string_literal(self.owner_value.clone()));
         encrypted.set(b"U", Object::string_literal(self.user_value.clone()));
-        encrypted.set(b"P", Object::Integer(self.permissions.p_value() as i64));
+        encrypted.set(b"P", Object::Integer(self.permissions.bits() as i64));
 
         if self.revision >= 4 {
             let mut filters = Dictionary::new();


### PR DESCRIPTION
Correctly fix the issue presented in #413 in which non-compliant PDF files may have a P-value that does not have the reserved bits set correctly:

 * Remove the `p_value()` method from `Permissions` entirely.
 * Replace all instances of `Permissions::p_value()` with `Permissions::bits()`.
 * Use `from_bits_retain()` rather than `from_bits_truncate()` to preserve the state of the reserved bits from the PDF. This is necessary to derive the correct file encryption key.
  * Move the logic from `Permissions::p_value()` to `Permissions::correct_bits()`, which we call when encrypting documents, such that when encrypting new/existing documents with lopdf, we always produce compliant PDF files where the reserved bits in the P-value contain the correct state.

The clippy test is expected to fail until #415 gets merged.