### PR TITLE
Change remove_object() to only remove the object

### DIFF
--- a/src/creator.rs
+++ b/src/creator.rs
@@ -28,20 +28,11 @@ impl Document {
     }
 
     /// Remove PDF object from document's object list.
+    ///
+    /// Other objects may still hold references to this object! Therefore, removing the object might
+    /// lead to dangling references.
     pub fn remove_object(&mut self, object_id: &ObjectId) -> Result<()> {
-        for (_, page_id) in self.get_pages() {
-            let page = self.get_object_mut(page_id)?.as_dict_mut()?;
-            let annots = page.get_mut(b"Annots")?.as_array_mut()?;
-
-            annots.retain(|object| {
-                if let Ok(id) = object.as_reference() {
-                    return id != *object_id;
-                }
-
-                true
-            });
-        }
-
+        self.objects.remove(object_id);
         Ok(())
     }
 

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -36,6 +36,29 @@ impl Document {
         Ok(())
     }
 
+    /// Remove annotation from the document.
+    ///
+    /// References to this annotation are removed from the pages' lists of annotations. Finally, the
+    /// annotation object itself is removed.
+    pub fn remove_annot(&mut self, object_id: &ObjectId) -> Result<()> {
+        for (_, page_id) in self.get_pages() {
+            let page = self.get_object_mut(page_id)?.as_dict_mut()?;
+            let annots = page.get_mut(b"Annots")?.as_array_mut()?;
+
+            annots.retain(|object| {
+                if let Ok(id) = object.as_reference() {
+                    return id != *object_id;
+                }
+
+                true
+            });
+        }
+
+        self.remove_object(object_id)?;
+
+        Ok(())
+    }
+
     /// Get the page's resource dictionary.
     ///
     /// Get Object that has the key "Resources".


### PR DESCRIPTION
The `add_object()` method adds an object into the object list.

Now, I would assume that `remove_object()` would do the opposite. However, looking at [the source](https://github.com/J-F-Liu/lopdf/blob/4003a9e4a6feb1ae2c2b961455f71981a5f6de70/src/creator.rs#L31), the method instead goes through all the pages and tries to remove the object from the page's annotations (failing if there's no `Annots` entry).

I think that should be changed. Or is there any other way to just delete the object in question?