### PR TITLE
fix: allow 'length' entry to be present for V=1 encryption

### DIFF
--- a/src/encryption/algorithms.rs
+++ b/src/encryption/algorithms.rs
@@ -103,6 +103,13 @@ impl TryFrom<&Document> for PasswordAlgorithm {
         // documents with higher values for V seem to have this field).
         if let Some(length) = length {
             match version {
+                // Although "Optional" and/or not required for V1 it appears in some documents
+                // with a default value of 40.
+                1 => {
+                    if length != 40 {
+                        return Err(DecryptionError::InvalidKeyLength)?;
+                    }
+                },
                 // The length of the file encryption key shall be a multiple of 8 in the range 40
                 // to and including 128.
                 2..=3 => {


### PR DESCRIPTION
Although PDF spec explicitly states that "length" field is set only for V 2 or 3 I found it in documents where V was set to 1. In this case we should verify that the length has expected value of "40" as V1 does not allow other encryption key lengths in this case.

[Example PDF](https://ww1.microchip.com/downloads/en/DeviceDoc/I2C%20Serial%20EE%20Family%20Data%20Sheet%2021930C.pdf).