### PR TITLE
Fix for long document load times introduced in v0.35.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ getrandom = "0.4"
 log = "0.4"
 md-5 = "0.10"
 nom = "8.0"
-nom_locate = "5.0"
 rand = { version = "0.10" }
 rangemap = "1.5"
 rayon = { version = "1.6", optional = true }

--- a/src/common_data_structures/mod.rs
+++ b/src/common_data_structures/mod.rs
@@ -46,7 +46,7 @@ pub fn decode_text_string(obj: &Object) -> Result<String> {
 #[cfg(test)]
 mod test {
     use crate::{
-        common_data_structures::decode_text_string, encodings, parser::ParserInput, text_string, writer::Writer,
+        common_data_structures::decode_text_string, encodings, text_string, writer::Writer,
         Object, StringFormat,
     };
 
@@ -69,7 +69,7 @@ mod test {
     #[test]
     fn spec_example1_decode() {
         let input = b"<</Key(text\\213)>>";
-        let dict = crate::parser::direct_object(ParserInput::new_extra(input, "")).unwrap();
+        let dict = crate::parser::direct_object(input).unwrap();
         let dict = dict.as_dict().unwrap();
         let actual = decode_text_string(dict.get(b"Key").unwrap()).unwrap();
         let expected = "text‰";
@@ -93,7 +93,7 @@ mod test {
     #[test]
     fn spec_example2_decode() {
         let input = b"<</Key<FEFF0442043504410442>>>";
-        let dict = crate::parser::direct_object(ParserInput::new_extra(input, "")).unwrap();
+        let dict = crate::parser::direct_object(input).unwrap();
         let dict = dict.as_dict().unwrap();
         let actual = decode_text_string(dict.get(b"Key").unwrap()).unwrap();
         // Russian for "test"

--- a/src/encodings/cmap.rs
+++ b/src/encodings/cmap.rs
@@ -1,6 +1,5 @@
 use crate::cmap_section::{CMapParseError, CMapSection, CodeLen, SourceCode};
 use crate::parser::cmap_parser::parse;
-use crate::parser::ParserInput;
 
 use log::error;
 use rangemap::RangeInclusiveMap;
@@ -51,7 +50,7 @@ impl ToUnicodeCMap {
     }
 
     pub(crate) fn parse(stream_content: Vec<u8>) -> Result<ToUnicodeCMap, UnicodeCMapError> {
-        let cmap_sections = parse(ParserInput::new_extra(&stream_content[..], "cmap"))?;
+        let cmap_sections = parse(&stream_content[..])?;
         Self::from_sections(cmap_sections)
     }
 

--- a/src/object_stream.rs
+++ b/src/object_stream.rs
@@ -1,4 +1,4 @@
-use crate::parser::{self, ParserInput};
+use crate::parser;
 use crate::{Document, Error, Object, ObjectId, Result, Stream};
 use std::collections::BTreeMap;
 use std::num::TryFromIntError;
@@ -89,7 +89,7 @@ impl ObjectStream {
                 warn!("only whitespace after offset in object stream");
                 return None;
             }
-            let object = parser::direct_object(ParserInput::new_extra(&stream.content[start..], "direct object"))?;
+            let object = parser::direct_object(&stream.content[start..])?;
 
             Some(((id, 0), object))
         };

--- a/src/parser/cmap_parser.rs
+++ b/src/parser/cmap_parser.rs
@@ -220,13 +220,13 @@ mod tests {
     use super::*;
 
     fn test_span(s: &'_ [u8]) -> ParserInput<'_> {
-        ParserInput::new_extra(s, "")
+        s
     }
     #[test]
     fn parse_1byte_source_code() {
         let data = b"<0A>";
         let (rem, res) = source_code(test_span(data)).unwrap();
-        assert_eq!(*rem, b"");
+        assert_eq!(rem, b"");
         assert_eq!(res, (0x0a, 1));
     }
 
@@ -234,7 +234,7 @@ mod tests {
     fn parse_source_code() {
         let data = b"<080F>";
         let (rem, res) = source_code(test_span(data)).unwrap();
-        assert_eq!(*rem, b"");
+        assert_eq!(rem, b"");
         assert_eq!(res, (0x080f, 2));
     }
 
@@ -254,7 +254,7 @@ mod tests {
     fn parse_code_range_pair() {
         let data = b"<080F> <08FF> ";
         let (rem, res) = code_range_pair(test_span(data)).unwrap();
-        assert_eq!(*rem, b" ");
+        assert_eq!(rem, b" ");
         assert_eq!(res, (0x080f, 0x08ff, 2));
     }
 
@@ -263,7 +263,7 @@ mod tests {
         let data = b"<080F><08FF>";
 
         let (rem, res) = code_range_pair(test_span(data)).unwrap();
-        assert_eq!(*rem, b"");
+        assert_eq!(rem, b"");
         assert_eq!(res, (0x080f, 0x08ff, 2));
     }
 
@@ -277,14 +277,14 @@ mod tests {
     fn parse_bfrange_line() {
         let data = b"<080f> <08ff> <09000110>\n";
         let (rem, res) = bf_range_line(test_span(data)).unwrap();
-        assert_eq!(*rem, b"");
+        assert_eq!(rem, b"");
         assert_eq!(res, ((0x080f, 0x08ff, 2), vec![vec![0x0900, 0x0110]]));
     }
     #[test]
     fn parse_bfrange_line_without_spaces() {
         let data = b"<080f><08ff><09000110>\n";
         let (rem, res) = bf_range_line(test_span(data)).unwrap();
-        assert_eq!(*rem, b"");
+        assert_eq!(rem, b"");
         assert_eq!(res, ((0x080f, 0x08ff, 2), vec![vec![0x0900, 0x0110]]));
     }
 
@@ -292,7 +292,7 @@ mod tests {
     fn parse_bfrange_line_array() {
         let data = b"<080f> <08ff> [ <09000110> <08fe> ] \n";
         let (rem, res) = bf_range_line(test_span(data)).unwrap();
-        assert_eq!(*rem, b"");
+        assert_eq!(rem, b"");
         assert_eq!(res, ((0x080f, 0x08ff, 2), vec![vec![0x0900, 0x0110], vec![0x08fe]]));
     }
     #[test]
@@ -307,7 +307,7 @@ mod tests {
             <0000> <FFFF> \n\
         endcodespacerange\n";
         let (rem, res) = codespace_range_section(test_span(data)).unwrap();
-        assert_eq!(*rem, b"");
+        assert_eq!(rem, b"");
         assert_eq!(res, CMapSection::CsRange(vec![(0x0000, 0xffff, 2)]));
     }
 
@@ -320,7 +320,7 @@ mod tests {
         endbfrange\n";
 
         let (rem, res) = bf_range_section(test_span(data)).unwrap();
-        assert_eq!(*rem, b"");
+        assert_eq!(rem, b"");
         assert_eq!(
             res,
             CMapSection::BfRange(vec![
@@ -340,7 +340,7 @@ mod tests {
             <20> <0020>\n\
         endbfchar\n";
         let (rem, res) = bf_char_section(test_span(data)).unwrap();
-        assert_eq!(*rem, b"");
+        assert_eq!(rem, b"");
         assert_eq!(
             res,
             CMapSection::BfChar(vec![

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,11 +17,10 @@ use nom::error::{ErrorKind, ParseError};
 use nom::multi::{fold_many0, fold_many1, many0, many0_count};
 use nom::sequence::{delimited, pair, preceded, separated_pair, terminated};
 use nom::{AsBytes, AsChar, Input, IResult, Parser};
-use nom_locate::LocatedSpan;
 
 pub(crate) mod cmap_parser;
 
-pub(crate) type ParserInput<'a> = LocatedSpan<&'a [u8], &'a str>;
+pub(crate) type ParserInput<'a> = &'a [u8];
 // Change this to something else that implements ParseError to get a
 // different error type out of nom.
 pub(crate) type NomError<'a> = nom::error::Error<ParserInput<'a>>;
@@ -199,7 +198,7 @@ fn inner_literal_string(depth: usize) -> impl Fn(ParserInput) -> NomResult<Vec<u
 fn nested_literal_string(depth: usize) -> impl Fn(ParserInput) -> NomResult<Vec<u8>> {
     move |input| {
         if depth == 0 {
-            map(verify(tag(&b"too deep"[..]), |_| false), |_| vec![]).parse(input)
+            map(verify(tag(&b"too deep"[..]), |_: &[u8]| false), |_| vec![]).parse(input)
         } else {
             map(
                 delimited(tag(&b"("[..]), inner_literal_string(depth - 1), tag(&b")"[..])),
@@ -519,8 +518,8 @@ pub fn xref_start(input: ParserInput) -> Option<i64> {
 }
 
 fn trim_spaces<'a, O>(
-    p: impl Parser<ParserInput<'a>, Output = O, Error = nom::error::Error<LocatedSpan<&'a [u8], &'a str>>>,
-) -> impl Parser<ParserInput<'a>, Output = O, Error = nom::error::Error<LocatedSpan<&'a [u8], &'a str>>> {
+    p: impl Parser<ParserInput<'a>, Output = O, Error = NomError<'a>>,
+) -> impl Parser<ParserInput<'a>, Output = O, Error = NomError<'a>> {
     delimited(many0(tag(" ")), p, many0(tag(" ")))
 }
 
@@ -579,7 +578,7 @@ fn inline_image_impl(input: ParserInput) -> NomResult<(Vec<Object>, String)> {
         Err(e) => {
             // Skip to EI marker so the rest of the content stream can still be parsed.
             log::warn!("Skipping unparseable inline image: {e}");
-            let bytes = input.fragment();
+            let bytes = input;
             // EI must appear after whitespace to distinguish from data bytes.
             let ei_pos = bytes.windows(4)
                 .position(|w| (w[0] == b' ' || w[0] == b'\n' || w[0] == b'\r')
@@ -673,7 +672,7 @@ mod tests {
     use super::*;
 
     fn test_span(s: &'_ [u8]) -> ParserInput<'_> {
-        LocatedSpan::new_extra(s, "test")
+        s
     }
 
     fn tstrip<O>(r: NomResult<O>) -> Option<O> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -113,10 +113,10 @@ fn real(input: ParserInput) -> NomResult<f32> {
 
 pub(crate) fn hex_char(input: ParserInput) -> NomResult<u8> {
     map_res(
-        verify(take(2usize), |h: &ParserInput| {
+        verify(take(2usize), |h: ParserInput| {
             h.as_bytes().iter().copied().all(AsChar::is_hex_digit)
         }),
-        |x: ParserInput| u8::from_str_radix(str::from_utf8(&x).unwrap(), 16),
+        |x: ParserInput| u8::from_str_radix(str::from_utf8(x).unwrap(), 16),
     ).parse(input)
 }
 
@@ -124,7 +124,7 @@ fn oct_char(input: ParserInput) -> NomResult<u8> {
     map_res(
         take_while_m_n(1, 3, AsChar::is_oct_digit),
         // Spec requires us to ignore any overflow.
-        |x: ParserInput| u16::from_str_radix(str::from_utf8(&x).unwrap(), 8).map(|o| o as u8),
+        |x: ParserInput| u16::from_str_radix(str::from_utf8(x).unwrap(), 8).map(|o| o as u8),
     ).parse(input)
 }
 
@@ -219,7 +219,7 @@ fn literal_string(input: ParserInput) -> NomResult<Vec<u8>> {
 #[inline]
 fn hex_digit(input: ParserInput) -> NomResult<u8> {
     map_opt(take(1usize), |c: ParserInput| {
-        str::from_utf8(&c).ok().and_then(|c| u8::from_str_radix(c, 16).ok())
+        str::from_utf8(c).ok().and_then(|c| u8::from_str_radix(c, 16).ok())
     }).parse(input)
 }
 
@@ -331,7 +331,7 @@ fn stream<'a>(input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSe
 
 fn unsigned_int<I: FromStr>(input: ParserInput) -> NomResult<I> {
     map_res(digit1, |digits: ParserInput| {
-        I::from_str(str::from_utf8(&digits).unwrap())
+        I::from_str(str::from_utf8(digits).unwrap())
     }).parse(input)
 }
 
@@ -428,7 +428,7 @@ pub fn header(input: ParserInput, strict: bool) -> Option<String> {
         return None;
     }
 
-    let version = str::from_utf8(&version_raw).ok()?.to_string();
+    let version = str::from_utf8(version_raw).ok()?.to_string();
     Some(version)
 }
 
@@ -532,7 +532,7 @@ fn content_space(input: ParserInput) -> NomResult<()> {
 fn operator(input: ParserInput) -> NomResult<String> {
     map_res(
         take_while1(|c: u8| c.is_ascii_alphabetic() || b"*'\"".contains(&c)),
-        |op: ParserInput| str::from_utf8(&op).map(Into::into),
+        |op: ParserInput| str::from_utf8(op).map(Into::into),
     ).parse(input)
 }
 

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -6,7 +6,6 @@ use crate::{
     encodings::Encoding,
     error::ParseError,
     object::Object::Name,
-    parser::ParserInput,
     xref::{Xref, XrefEntry, XrefType},
     Error, Result,
 };
@@ -19,7 +18,7 @@ use std::{
 impl Content<Vec<Operation>> {
     /// Decode content operations.
     pub fn decode(data: &[u8]) -> Result<Self> {
-        parser::content(ParserInput::new_extra(data, "content operations"))
+        parser::content(data)
             .ok_or(ParseError::InvalidContentStream.into())
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -22,7 +22,7 @@ use crate::encryption::{self, EncryptionState};
 use crate::error::{ParseError, XrefError};
 use crate::load_options::{FilterFunc, LoadOptions};
 use crate::object_stream::ObjectStream;
-use crate::parser::{self, ParserInput};
+use crate::parser;
 use crate::xref::XrefEntry;
 use crate::{Dictionary, Document, Error, IncrementalDocument, Object, ObjectId, Result};
 use crate::common_data_structures;
@@ -500,7 +500,7 @@ impl Reader<'_> {
         self.buffer = &self.buffer[offset..];
 
         let version =
-            parser::header(ParserInput::new_extra(self.buffer, "header"), self.strict).ok_or(ParseError::InvalidFileHeader)?;
+            parser::header(self.buffer, self.strict).ok_or(ParseError::InvalidFileHeader)?;
 
         let xref_start = Self::get_xref_start(self.buffer)?;
         if xref_start > self.buffer.len() {
@@ -508,7 +508,7 @@ impl Reader<'_> {
         }
 
         let (mut xref, mut trailer) =
-            parser::xref_and_trailer(ParserInput::new_extra(&self.buffer[xref_start..], "xref"), &self)?;
+            parser::xref_and_trailer(&self.buffer[xref_start..], &self)?;
 
         let mut already_seen = HashSet::new();
         let mut prev_xref_start = trailer.remove(b"Prev");
@@ -522,7 +522,7 @@ impl Reader<'_> {
             }
 
             let (prev_xref, prev_trailer) =
-                parser::xref_and_trailer(ParserInput::new_extra(&self.buffer[prev as usize..], ""), &self)?;
+                parser::xref_and_trailer(&self.buffer[prev as usize..], &self)?;
             xref.merge(prev_xref);
 
             let prev_xref_stream_start = trailer.remove(b"XRefStm");
@@ -532,7 +532,7 @@ impl Reader<'_> {
                 }
 
                 let (prev_xref, _) =
-                    parser::xref_and_trailer(ParserInput::new_extra(&self.buffer[prev as usize..], ""), &self)?;
+                    parser::xref_and_trailer(&self.buffer[prev as usize..], &self)?;
                 xref.merge(prev_xref);
             }
 
@@ -741,12 +741,12 @@ impl Reader<'_> {
         // The document structure can be expressed in PEG as:
         //   document <- header indirect_object* xref trailer xref_start
         let version =
-            parser::header(ParserInput::new_extra(self.buffer, "header"), self.strict).ok_or(ParseError::InvalidFileHeader)?;
+            parser::header(self.buffer, self.strict).ok_or(ParseError::InvalidFileHeader)?;
 
         //The binary_mark is in line 2 after the pdf version. If at other line number, then will be declared as invalid pdf.
         if let Some(pos) = self.buffer.iter().position(|&byte| byte == b'\n') {
             if let Some(binary_mark) =
-                parser::binary_mark(ParserInput::new_extra(&self.buffer[pos + 1..], "binary_mark"))
+                parser::binary_mark(&self.buffer[pos + 1..])
             {
                 if binary_mark.iter().all(|&byte| byte >= 128) {
                     self.document.binary_mark = binary_mark;
@@ -761,7 +761,7 @@ impl Reader<'_> {
         self.document.xref_start = xref_start;
 
         let (mut xref, mut trailer) =
-            parser::xref_and_trailer(ParserInput::new_extra(&self.buffer[xref_start..], "xref"), &self)?;
+            parser::xref_and_trailer(&self.buffer[xref_start..], &self)?;
 
         // Read previous Xrefs of linearized or incremental updated document.
         let mut already_seen = HashSet::new();
@@ -776,7 +776,7 @@ impl Reader<'_> {
             }
 
             let (prev_xref, prev_trailer) =
-                parser::xref_and_trailer(ParserInput::new_extra(&self.buffer[prev as usize..], ""), &self)?;
+                parser::xref_and_trailer(&self.buffer[prev as usize..], &self)?;
             xref.merge(prev_xref);
 
             // Read xref stream in hybrid-reference file
@@ -787,7 +787,7 @@ impl Reader<'_> {
                 }
 
                 let (prev_xref, _) =
-                    parser::xref_and_trailer(ParserInput::new_extra(&self.buffer[prev as usize..], ""), &self)?;
+                    parser::xref_and_trailer(&self.buffer[prev as usize..], &self)?;
                 xref.merge(prev_xref);
             }
 
@@ -918,7 +918,7 @@ impl Reader<'_> {
     fn parse_raw_object(&self, raw_bytes: &[u8]) -> Result<(ObjectId, Object)> {
         // Parse the raw bytes as an indirect object
         parser::indirect_object(
-            ParserInput::new_extra(raw_bytes, "indirect object"),
+            raw_bytes,
             0,
             None,
             self,
@@ -1264,7 +1264,7 @@ impl Reader<'_> {
 
         // Just parse without decryption - we'll decrypt later
         parser::indirect_object(
-            ParserInput::new_extra(self.buffer, "indirect object"),
+            self.buffer,
             offset,
             expected_id,
             self,
@@ -1280,7 +1280,7 @@ impl Reader<'_> {
             .ok_or(Error::Xref(XrefError::Start))
             .and_then(|xref_pos| {
                 if xref_pos <= buffer.len() {
-                    match parser::xref_start(ParserInput::new_extra(&buffer[xref_pos..], "xref")) {
+                    match parser::xref_start(&buffer[xref_pos..]) {
                         Some(startxref) => Ok(startxref as usize),
                         None => Err(Error::Xref(XrefError::Start)),
                     }

--- a/tests/document_load_performance.rs
+++ b/tests/document_load_performance.rs
@@ -1,6 +1,7 @@
 use lopdf::Document;
 use std::time::Instant;
 
+#[cfg(not(feature = "async"))]
 #[test]
 fn page_count_meta_data_performance_test() {
     let document_path = "tests/regression/test.pdf";
@@ -18,6 +19,7 @@ fn page_count_meta_data_performance_test() {
     assert!(elapsed_time.as_millis() < 100, "Expected load in <100ms, got {}ms", elapsed_time.as_millis());
 }
 
+#[cfg(not(feature = "async"))]
 #[test]
 fn page_count_performance_test() {
     let document_path = "tests/regression/test.pdf";

--- a/tests/document_load_performance.rs
+++ b/tests/document_load_performance.rs
@@ -1,0 +1,36 @@
+use lopdf::Document;
+use std::time::Instant;
+
+#[test]
+fn page_count_meta_data_performance_test() {
+    let document_path = "tests/regression/test.pdf";
+    let start_time = Instant::now();
+    let doc = Document::load_metadata(document_path).expect("Failed to load document");
+    let result = doc.page_count;
+    let elapsed_time = start_time.elapsed();
+    println!("--- Meta Page Count Stats ---");
+    println!(
+        "Page count: {} in {:.2}s",
+        result,
+        elapsed_time.as_secs_f64()
+    );
+    assert_eq!(result, 100);
+    assert!(elapsed_time.as_millis() < 100, "Expected load in <100ms, got {}ms", elapsed_time.as_millis());
+}
+
+#[test]
+fn page_count_performance_test() {
+    let document_path = "tests/regression/test.pdf";
+    let start_time = Instant::now();
+    let doc = Document::load(document_path).expect("Failed to load document");
+    let result = doc.get_pages().len();
+    let elapsed_time = start_time.elapsed();
+    println!("--- Page Count Stats ---");
+    println!(
+        "Page count: {} in {:.2}s",
+        result,
+        elapsed_time.as_secs_f64()
+    );
+    assert_eq!(result, 100);
+    assert!(elapsed_time.as_millis() < 100, "Expected load in <100ms, got {}ms", elapsed_time.as_millis());
+}

--- a/tests/regression/document_load_performance.rs
+++ b/tests/regression/document_load_performance.rs
@@ -1,0 +1,34 @@
+use lopdf::Document;
+use std::time::Instant;
+
+#[test]
+fn page_count_meta_data_performance_test() {
+    let document_path = "tests/fixtures/test.pdf";
+    let start_time = Instant::now();
+    let doc = Document::load_metadata(document_path).expect("Failed to load document");
+    let result = doc.page_count;
+    let elapsed_time = start_time.elapsed();
+    println!("--- Meta Page Count Stats ---");
+    println!(
+        "Page count: {} in {:.2}s",
+        result,
+        elapsed_time.as_secs_f64()
+    );
+    assert_eq!(result, 100);
+}
+
+#[test]
+fn page_count_performance_test() {
+    let document_path = "tests/fixtures/test.pdf";
+    let start_time = Instant::now();
+    let doc = Document::load(document_path).expect("Failed to load document");
+    let result = doc.get_pages().len();
+    let elapsed_time = start_time.elapsed();
+    println!("--- Page Count Stats ---");
+    println!(
+        "Page count: {} in {:.2}s",
+        result,
+        elapsed_time.as_secs_f64()
+    );
+    assert_eq!(result, 100);
+}


### PR DESCRIPTION
## Summary

Removes `nom_locate` dependency to fix a performance regression introduced in v0.35.0. See https://github.com/J-F-Liu/lopdf/issues/412 for details.

The parser input type was changed from `&[u8]` to `LocatedSpan<&[u8], &str>` in 0.35.0 to carry debug labels through the parser. `LocatedSpan` tracks line/column position by scanning for newlines (via `memchr::count_raw`) on every slice operation. For a large PDF, this means millions of redundant newline scans during parsing.

> [!NOTE]
> Neither the line/column tracking nor the debug labels were ever read.** The only `LocatedSpan` methods actually used (`.len()`, `.take_from()`, `.fragment()`) all have direct equivalents on `&[u8]`.

## Fix

- Removed `nom_locate` from `Cargo.toml`
- Changed `ParserInput<'a>` from `LocatedSpan<&[u8], &str>` back to `&[u8]`
- Replaced all `ParserInput::new_extra(bytes, "label")` construction sites with plain byte slices
- Fixed minor type adjustments in `trim_spaces` signature, a `verify` closure, and cmap_parser test assertions

## Result

Loading a 100-page PDF dropped from 9-10 seconds to ~10ms

**Test:**
`tests/document_load_performance.rs` with `tests/regression/test.pdf`

> [!WARNING]
> I've included the test.pd for testing but you may not actually want it. I just wanted to point it out because it's quite large. I can remove from the PR if you'd like.
