### PR TITLE
reader: preserve custom Info dictionary entries in PdfMetadata

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,6 +1,6 @@
 use log::{error, warn};
 use std::cmp;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryInto;
 #[cfg(not(feature = "async"))]
 use std::fs::File;
@@ -473,6 +473,14 @@ pub struct PdfMetadata {
     pub creation_date: Option<String>,
     /// Document modification date (PDF date format: D:YYYYMMDDHHmmSSOHH'mm')
     pub modification_date: Option<String>,
+    /// Custom Info dictionary entries that are not part of the standard set above.
+    ///
+    /// Producers commonly use the Info dictionary to attach application-specific
+    /// metadata (for example, Microsoft Information Protection labels stored as
+    /// `MSIP_Label_{GUID}_{Property}` keys). Such entries used to be discarded
+    /// by the metadata-only loader; they are now preserved here as raw `Object`
+    /// values so callers can inspect or decode them as needed.
+    pub custom: HashMap<Vec<u8>, Object>,
     /// Number of pages in the document
     pub page_count: u32,
     /// PDF version
@@ -488,7 +496,39 @@ struct InfoMetadata {
     producer: Option<String>,
     creation_date: Option<String>,
     modification_date: Option<String>,
+    custom: HashMap<Vec<u8>, Object>,
 }
+
+impl InfoMetadata {
+    fn empty() -> Self {
+        Self {
+            title: None,
+            author: None,
+            subject: None,
+            keywords: None,
+            creator: None,
+            producer: None,
+            creation_date: None,
+            modification_date: None,
+            custom: HashMap::new(),
+        }
+    }
+}
+
+/// Standard Info dictionary keys defined in PDF 1.7 §14.3.3 ("Document
+/// Information Dictionary"). Any other key is preserved on
+/// `PdfMetadata::custom` rather than dropped.
+const STANDARD_INFO_KEYS: &[&[u8]] = &[
+    b"Title",
+    b"Author",
+    b"Subject",
+    b"Keywords",
+    b"Creator",
+    b"Producer",
+    b"CreationDate",
+    b"ModDate",
+    b"Trapped",
+];
 
 impl Reader<'_> {
     /// Read metadata (title and page count) without loading the entire document.
@@ -562,6 +602,7 @@ impl Reader<'_> {
             producer: info_metadata.producer,
             creation_date: info_metadata.creation_date,
             modification_date: info_metadata.modification_date,
+            custom: info_metadata.custom,
             page_count,
             version,
         })
@@ -570,68 +611,32 @@ impl Reader<'_> {
     fn extract_info_metadata(&self) -> Result<InfoMetadata> {
         let info_ref = match self.document.trailer.get(b"Info") {
             Ok(obj) => obj.as_reference().ok(),
-            Err(_) => {
-                return Ok(InfoMetadata {
-                    title: None,
-                    author: None,
-                    subject: None,
-                    keywords: None,
-                    creator: None,
-                    producer: None,
-                    creation_date: None,
-                    modification_date: None,
-                });
-            }
+            Err(_) => return Ok(InfoMetadata::empty()),
         };
 
         let info_id = match info_ref {
             Some(id) => id,
-            None => {
-                return Ok(InfoMetadata {
-                    title: None,
-                    author: None,
-                    subject: None,
-                    keywords: None,
-                    creator: None,
-                    producer: None,
-                    creation_date: None,
-                    modification_date: None,
-                });
-            }
+            None => return Ok(InfoMetadata::empty()),
         };
 
         let mut already_seen = HashSet::new();
         let info_obj = match self.get_object(info_id, &mut already_seen) {
             Ok(obj) => obj,
-            Err(_) => {
-                return Ok(InfoMetadata {
-                    title: None,
-                    author: None,
-                    subject: None,
-                    keywords: None,
-                    creator: None,
-                    producer: None,
-                    creation_date: None,
-                    modification_date: None,
-                });
-            }
+            Err(_) => return Ok(InfoMetadata::empty()),
         };
 
         let info_dict = match info_obj.as_dict() {
             Ok(dict) => dict,
-            Err(_) => {
-                return Ok(InfoMetadata {
-                    title: None,
-                    author: None,
-                    subject: None,
-                    keywords: None,
-                    creator: None,
-                    producer: None,
-                    creation_date: None,
-                    modification_date: None,
-                });
-            }
+            Err(_) => return Ok(InfoMetadata::empty()),
         };
+
+        let mut custom = HashMap::new();
+        for (key, value) in info_dict.iter() {
+            if STANDARD_INFO_KEYS.contains(&key.as_slice()) {
+                continue;
+            }
+            custom.insert(key.clone(), value.clone());
+        }
 
         Ok(InfoMetadata {
             title: Self::extract_string_field(info_dict, b"Title"),
@@ -642,6 +647,7 @@ impl Reader<'_> {
             producer: Self::extract_string_field(info_dict, b"Producer"),
             creation_date: Self::extract_string_field(info_dict, b"CreationDate"),
             modification_date: Self::extract_string_field(info_dict, b"ModDate"),
+            custom,
         })
     }
 

--- a/tests/metadata_test.rs
+++ b/tests/metadata_test.rs
@@ -242,3 +242,83 @@ fn test_metadata_extraction_encrypted_wrong_password() {
     assert!(result.is_err());
     assert!(matches!(result.unwrap_err(), lopdf::Error::InvalidPassword));
 }
+
+/// Verifies that custom (non-standard) Info dictionary entries are preserved on
+/// `PdfMetadata::custom`, while the standard fields remain available through
+/// their typed accessors. This is the path used to extract producer-specific
+/// metadata such as Microsoft Information Protection labels
+/// (`MSIP_Label_{GUID}_{Property}`) without loading the full document.
+#[test]
+fn test_metadata_extraction_preserves_custom_info_entries() {
+    let mut doc = Document::with_version("1.5");
+
+    let catalog_dict = lopdf::dictionary! {
+        "Type" => "Catalog",
+        "Pages" => lopdf::Object::Reference((2, 0))
+    };
+    let catalog_id = doc.add_object(catalog_dict);
+    doc.trailer.set("Root", lopdf::Object::Reference(catalog_id));
+
+    let pages_dict = lopdf::dictionary! {
+        "Type" => "Pages",
+        "Kids" => vec![lopdf::Object::Reference((3, 0))],
+        "Count" => 1
+    };
+    doc.objects.insert((2, 0), lopdf::Object::Dictionary(pages_dict));
+
+    let page_dict = lopdf::dictionary! {
+        "Type" => "Page",
+        "Parent" => lopdf::Object::Reference((2, 0)),
+        "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()]
+    };
+    doc.objects.insert((3, 0), lopdf::Object::Dictionary(page_dict));
+
+    let mip_guid_enabled = "MSIP_Label_754d9351-9ade-4bd5-893a-95071572330d_Enabled";
+    let mip_guid_name = "MSIP_Label_754d9351-9ade-4bd5-893a-95071572330d_Name";
+
+    let info_dict = lopdf::dictionary! {
+        "Title" => lopdf::Object::String(b"Doc with custom info".to_vec(), lopdf::StringFormat::Literal),
+        "Producer" => lopdf::Object::String(b"Test Suite".to_vec(), lopdf::StringFormat::Literal),
+        mip_guid_enabled => lopdf::Object::String(b"True".to_vec(), lopdf::StringFormat::Literal),
+        mip_guid_name => lopdf::Object::String(b"Confidential".to_vec(), lopdf::StringFormat::Literal),
+        "AppCustomCounter" => lopdf::Object::Integer(42)
+    };
+    let info_id = doc.add_object(info_dict);
+    doc.trailer.set("Info", lopdf::Object::Reference(info_id));
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = temp_dir.path().join("test_custom_info.pdf");
+    doc.save(&path).unwrap();
+
+    let buffer = std::fs::read(&path).unwrap();
+    let metadata = Document::load_metadata_mem(&buffer).unwrap();
+
+    // Standard fields still populated.
+    assert_eq!(metadata.title, Some("Doc with custom info".to_string()));
+    assert_eq!(metadata.producer, Some("Test Suite".to_string()));
+
+    // Custom fields preserved on the new `custom` map.
+    assert_eq!(metadata.custom.len(), 3);
+
+    let enabled = metadata
+        .custom
+        .get(mip_guid_enabled.as_bytes())
+        .expect("MIP Enabled entry preserved");
+    assert!(matches!(enabled, lopdf::Object::String(bytes, _) if bytes == b"True"));
+
+    let name = metadata
+        .custom
+        .get(mip_guid_name.as_bytes())
+        .expect("MIP Name entry preserved");
+    assert!(matches!(name, lopdf::Object::String(bytes, _) if bytes == b"Confidential"));
+
+    let counter = metadata
+        .custom
+        .get(&b"AppCustomCounter"[..])
+        .expect("non-string custom entry preserved");
+    assert!(matches!(counter, lopdf::Object::Integer(42)));
+
+    // Standard keys must NOT leak into `custom`.
+    assert!(!metadata.custom.contains_key(&b"Title"[..]));
+    assert!(!metadata.custom.contains_key(&b"Producer"[..]));
+}


### PR DESCRIPTION
## Summary

The metadata-only loader (`Document::load_metadata*`) currently extracts the eight standard Document Information Dictionary fields and discards every other Info dictionary entry. Producers commonly use the Info dictionary for application-specific metadata that callers cannot recover without falling back to a full `Document::load_mem`, which defeats the purpose of the fast metadata path.

The motivating example is Microsoft Information Protection (MIP): sensitivity labels are stored on PDFs as `MSIP_Label_{GUID}_{Property}` entries in the Info dictionary. To read them today we have to load the full document, parsing the page bodies we already extract through other means (e.g. PDFium for text/images). With this change we can stay on the cheap xref+trailer+Info path.

## Change

Add a `custom: HashMap<Vec<u8>, Object>` field to `PdfMetadata`. It preserves every Info dictionary entry whose key is not part of the standard set defined in PDF 1.7 §14.3.3 — the existing eight typed fields plus `Trapped`. Values are kept as raw `Object`s so callers retain the same decoding flexibility they have in the full-document path.

This is purely additive:
- Existing typed accessors keep their current behavior and types.
- For documents whose Info dictionary contains only standard keys, `custom` is empty.
- No change to public APIs other than the new field.

## Test plan

- [x] New regression test `test_metadata_extraction_preserves_custom_info_entries` builds a synthetic PDF with two MSIP-style keys and an integer custom entry, then verifies:
  - Standard fields (`title`, `producer`) populate as before.
  - All three custom entries are preserved on `custom` with their original `Object` variants.
  - Standard keys do not leak into `custom`.
- [x] `cargo test` — full suite (230 tests across 21 binaries) passes with no regressions.
- [x] `cargo fmt --all` clean.
- [x] `cargo clippy --all-targets` — no new warnings introduced (remaining hits are pre-existing in unrelated lines).