### PR TITLE
Add support for ', ", and T* text-showing operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 * Add `LoadOptions` struct with `password`, `filter`, and `strict` fields for extensible loading configuration
 * Add `load_with_options`, `load_from_with_options`, and `load_mem_with_options` methods (sync + async)
+* Add support for the `'`, `"`, and `T*` text-showing operators in `extract_text` / `extract_text_chunks` (PDF 1.7 §9.4.2-3). Previously these operators fell through the silent-drop arm, losing their associated text content.
+* Add `creator::tests::create_document_with_operations` helper for tests that need to exercise specific content-stream operators not produced by `create_document_with_texts`.
 
 ### Deprecate
 

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -279,6 +279,57 @@ pub mod tests {
         doc
     }
 
+    /// Create a single-page document whose content stream is the
+    /// caller-supplied list of operations (wrapped in `BT`/`ET` if not
+    /// already). Used by tests that need to exercise specific
+    /// content-stream operators not produced by `create_document_with_texts`.
+    pub fn create_document_with_operations(operations: Vec<Operation>) -> Document {
+        let mut doc = Document::with_version("1.5");
+        let info_id = doc.add_object(dictionary! {
+            "Title" => Object::string_literal("Create PDF document example"),
+            "Creator" => Object::string_literal("https://crates.io/crates/lopdf"),
+            "CreationDate" => get_timestamp(),
+        });
+        let pages_id = doc.new_object_id();
+        let font_id = doc.add_object(dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type1",
+            "BaseFont" => "Courier",
+        });
+        let resources_id = doc.add_object(dictionary! {
+            "Font" => dictionary! {
+                "F1" => font_id,
+            },
+        });
+        let content = Content { operations };
+        let content_id = doc.add_object(Stream::new(dictionary! {}, content.encode().unwrap()));
+        let page = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Contents" => content_id,
+        });
+        let pages = dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![page.into()],
+            "Count" => 1,
+            "Resources" => resources_id,
+            "MediaBox" => vec![0.into(), 0.into(), 595.into(), 842.into()],
+        };
+        doc.objects.insert(pages_id, Object::Dictionary(pages));
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        });
+        doc.trailer.set("Root", catalog_id);
+        doc.trailer.set("Info", info_id);
+        doc.trailer.set(
+            "ID",
+            Object::Array(vec![Object::string_literal(b"ABC"), Object::string_literal(b"DEF")]),
+        );
+        doc.compress();
+        doc
+    }
+
     /// Save a document
     pub fn save_document(file_path: &PathBuf, doc: &mut Document) {
         let res = doc.save(file_path);

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -121,9 +121,47 @@ impl Document {
                     }
                     None => warn!("Could not decode extracted text"),
                 },
-                "ET" if !current_text.ends_with('\n') => {
-                    current_text.push('\n')
-                }
+                // PDF 32000-1 §9.4.3 — `'` is equivalent to `T* Tj`:
+                // move to next line, then show string from the single
+                // string operand.
+                "'" => match current_encoding {
+                    Some(encoding) => {
+                        if !current_text.ends_with('\n') {
+                            current_text.push('\n');
+                        }
+                        let res = collect_text(&mut current_text, encoding, &operation.operands);
+                        if let Err(err) = res {
+                            collected_chunks_and_errs.push(Err(err));
+                        }
+                    }
+                    None => warn!("Could not decode extracted text"),
+                },
+                // PDF 32000-1 §9.4.3 — `"` is equivalent to
+                // `aw Tw ac Tc T* Tj` with operands `[aw, ac, string]`.
+                // Operands 0/1 set word/character spacing for rendering
+                // and don't affect the extracted character sequence;
+                // operand 2 is the string to show.
+                "\"" => match current_encoding {
+                    Some(encoding) => {
+                        if !current_text.ends_with('\n') {
+                            current_text.push('\n');
+                        }
+                        if let Some(string_operand) = operation.operands.get(2) {
+                            let res = collect_text(&mut current_text, encoding, std::slice::from_ref(string_operand));
+                            if let Err(err) = res {
+                                collected_chunks_and_errs.push(Err(err));
+                            }
+                        }
+                    }
+                    None => warn!("Could not decode extracted text"),
+                },
+                // PDF 32000-1 §9.4.2 — `T*` moves to the start of the
+                // next line. For text extraction we approximate this
+                // as `\n`, matching how the `ET` arm above handles end
+                // of text object.
+                "T*" if !current_text.ends_with('\n') => current_text.push('\n'),
+                "T*" => {}
+                "ET" if !current_text.ends_with('\n') => current_text.push('\n'),
                 "ET" => {}
                 _ => {}
             }
@@ -603,5 +641,83 @@ mod tests {
 
         let extracted_text = doc.extract_text(&[1]).unwrap();
         assert!(extracted_text.contains("Hi World! Hi Universe!"));
+    }
+
+    /// PDF 1.7 / ISO 32000-1 §9.4.3 — `'` is equivalent to `T* Tj`:
+    /// move to the next line and show a string. extract_text should
+    /// recover the string operand and emit a line break before it.
+    #[test]
+    fn extract_text_handles_apostrophe_show_text_op() {
+        use crate::Object;
+        use crate::content::Operation;
+        use crate::creator::tests::create_document_with_operations;
+
+        let doc = create_document_with_operations(vec![
+            Operation::new("BT", vec![]),
+            Operation::new("Tf", vec!["F1".into(), 12.into()]),
+            Operation::new("Td", vec![100.into(), 700.into()]),
+            Operation::new("Tj", vec![Object::string_literal("first")]),
+            Operation::new("'", vec![Object::string_literal("second")]),
+            Operation::new("'", vec![Object::string_literal("third")]),
+            Operation::new("ET", vec![]),
+        ]);
+
+        let text = doc.extract_text(&[1]).unwrap();
+        assert!(text.contains("first"), "Tj string lost: {text:?}");
+        assert!(text.contains("second"), "first ' string lost: {text:?}");
+        assert!(text.contains("third"), "second ' string lost: {text:?}");
+    }
+
+    /// PDF 1.7 / ISO 32000-1 §9.4.3 — `"` is equivalent to
+    /// `aw Tw ac Tc T* Tj` with operands `[aw, ac, string]`. extract_text
+    /// should recover operand index 2 (the string); operands 0 and 1 set
+    /// rendering spacing and don't affect the extracted character sequence.
+    #[test]
+    fn extract_text_handles_quote_show_text_op() {
+        use crate::Object;
+        use crate::content::Operation;
+        use crate::creator::tests::create_document_with_operations;
+
+        let doc = create_document_with_operations(vec![
+            Operation::new("BT", vec![]),
+            Operation::new("Tf", vec!["F1".into(), 12.into()]),
+            Operation::new("Td", vec![100.into(), 700.into()]),
+            Operation::new("\"", vec![0.into(), 0.into(), Object::string_literal("from-quote-op")]),
+            Operation::new("ET", vec![]),
+        ]);
+
+        let text = doc.extract_text(&[1]).unwrap();
+        assert!(text.contains("from-quote-op"), "\" string operand lost: {text:?}");
+    }
+
+    /// PDF 1.7 / ISO 32000-1 §9.4.2 — `T*` moves to the start of the
+    /// next line. For text extraction we approximate as `\n`, so a
+    /// `Tj T* Tj` sequence should produce two strings separated by a
+    /// newline rather than running together.
+    #[test]
+    fn extract_text_preserves_line_breaks_for_t_star() {
+        use crate::Object;
+        use crate::content::Operation;
+        use crate::creator::tests::create_document_with_operations;
+
+        let doc = create_document_with_operations(vec![
+            Operation::new("BT", vec![]),
+            Operation::new("Tf", vec!["F1".into(), 12.into()]),
+            Operation::new("Td", vec![100.into(), 700.into()]),
+            Operation::new("Tj", vec![Object::string_literal("line-one")]),
+            Operation::new("T*", vec![]),
+            Operation::new("Tj", vec![Object::string_literal("line-two")]),
+            Operation::new("ET", vec![]),
+        ]);
+
+        let text = doc.extract_text(&[1]).unwrap();
+        let one = text.find("line-one").expect("line-one missing");
+        let two = text.find("line-two").expect("line-two missing");
+        assert!(one < two, "order wrong: {text:?}");
+        let between = &text[one + "line-one".len()..two];
+        assert!(
+            between.contains('\n'),
+            "T* did not insert a line break between Tj strings: between={between:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds match arms for three PDF text operators that are present in the
PDF 1.7 specification (ISO 32000-1, Table 109) but currently unhandled
by lopdf's text extractor:

- `'` — move to next line and show string (equivalent to `T* Tj`)
- `"` — set word/char spacing, move to next line, show string
        (equivalent to `aw Tw ac Tc T* Tj` with operands `[aw, ac, string]`)
- `T*` — move to next line (emits `\n` in extracted text)

These operators are commonly emitted by document generators that lay
out text line-by-line — academic typesetters, older Word/LaTeX
exporters, and government-form generators in particular. When they
appear, `extract_text` silently drops the text content associated with
them.

## Impact

Discovered while benchmarking [spectre-rs](https://github.com/RyanJamesStewart/spectre-rs)
(a Rust PDF extraction crate built on lopdf) against pymupdf on the
ICDAR 2013 Table Competition corpus — the canonical academic benchmark
for table-heavy PDF extraction.

Before this patch, four PDFs in the 67-PDF corpus were under-extracting
relative to pymupdf by 11-69%:

| PDF       | Before  | After   | Mechanism                      |
|-----------|--------:|--------:|--------------------------------|
| us-038    | -68.8%  |  -0.3%  | 24 `'` operators               |
| us-039    | -50.0%  |  -1.0%  | 25 `'` operators               |
| us-034    | -47.9%  |  -0.8%  | `'` ops + `T*` line breaks     |
| us-001    | -10.7%  |  -5.4%  | partial (residual is a separate |
|           |         |         | encoding-layer concern, not    |
|           |         |         | addressed here)                |

The patch also incidentally improved eight other corpus PDFs by 2+
percentage points (e.g. `us-004` -8.2% → -1.3%, `us-028` -5.3% →
+0.2%), suggesting the affected operators are more pervasive in
real-world PDFs than the targeted minimal repro implies.

Aggregate parity vs pymupdf across the corpus:
- Mean Δ: -3.7% → -0.1%
- Median Δ: -0.1% → +0.6%
- PDFs within ±10% parity: 56/65 (86%) → 60/65 (92%)

Total character-count gain across the corpus: **+19,767 characters of
correctly-extracted content, with no change in extraction time** (309.70
ms → 309.65 ms, well within run-to-run noise).

## Scope and architectural note

`extract_text_chunks_from_page` is structured as a glyph-run collector,
not a text-state-machine renderer. This patch handles the missing
operators that emit text content. It does NOT add full text-state
tracking (Tm position math, reading-order inference, column detection)
— that would be a substantially larger architectural change and is
out of scope.

The `T*` handler emits `\n` as the appropriate text-extraction
approximation for line-break semantics, consistent with how the
existing `ET` arm handles end-of-text-object. The `TL` leading
parameter governs vertical spacing in rendering but does not affect
extracted text content under the current architecture, so it is also
not tracked here.

The `"` operator's first two operands (`aw`, `ac`) set word/character
spacing for rendering and don't affect the extracted character
sequence; only operand index 2 (the string) is consumed.

## Tests

Three tests added in `parser_aux::tests`, mirroring the existing
`extract_text_chunks` test pattern:

- `extract_text_handles_apostrophe_show_text_op`
- `extract_text_handles_quote_show_text_op`
- `extract_text_preserves_line_breaks_for_t_star`

A new `create_document_with_operations` helper was added in
`creator::tests` for constructing single-page test fixtures with
caller-specified operations, since `create_document_with_texts` only
emits `Tj`.

`cargo test --lib parser_aux` reports 7/7 passing (4 pre-existing +
3 new). `cargo clippy` is clean. `cargo fmt` was run.

## Verification

Full per-PDF benchmark data (timings + character counts for spectre-rs,
pymupdf, pdfminer.six, and pdfplumber on all 67 ICDAR PDFs, plus the
side-by-side pre/post-patch comparison) is published at
[`data/icdar2013-results.csv`](https://github.com/RyanJamesStewart/spectre-rs/blob/main/data/icdar2013-results.csv)
and [`data/lopdf-patch-impact.md`](https://github.com/RyanJamesStewart/spectre-rs/blob/main/data/lopdf-patch-impact.md)
for independent verification of any aggregate claim above.

## CHANGELOG

Entry added under `[Unreleased]` / `Add` per the existing format.

---

Happy to adjust scope, naming, or test structure based on review.
