### PR TITLE
Fix bug with replacing text in non-single character TJ Arrays

### DIFF
--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -391,24 +391,26 @@ fn try_to_replace_encoded_text(
                 let mut str_collected = String::new();
                 collect_text(&mut str_collected, encoding, arr)?;
                 if str_collected == text_to_replace {
-                    let s_len = str_collected.chars().count();
-                    let r_len = replacement.chars().count();
-                    let mut cur = 0;
+                    // The number of `Object::String` items in a `TJ` array is
+                    // not guaranteed to match the character count of the
+                    // decoded text (each string may hold several glyphs, and
+                    // numeric kerning entries are interleaved).
+                    //
+                    // There is no **good** way to interpolate between the OG
+                    // and the replacement, but putting the full encoded replacement
+                    // into the first string slot and emptying out the remaining
+                    // string slots, leaving any numeric kerning entries in place
+                    // seems like the least bad option.
+                    let encoded_replacement = encode(encoding, replacement, default_str);
+                    let mut placed = false;
                     for item in arr.iter_mut() {
                         if let Object::String(bytes, _f) = item {
-                            if cur == s_len - 1 {
-                                let sub = substring(replacement, cur);
-                                let encoded_bytes = encode(encoding, sub, default_str);
-                                *bytes = encoded_bytes;
-                                break;
-                            } else if cur > r_len {
-                                *item = Object::Null;
+                            if placed {
+                                *bytes = Vec::new();
                             } else {
-                                let sub = substr(replacement, cur, 1);
-                                let encoded_bytes = encode(encoding, sub, default_str);
-                                *bytes = encoded_bytes;
+                                bytes.clone_from(&encoded_replacement);
+                                placed = true;
                             }
-                            cur += 1;
                         }
                     }
                 }

--- a/tests/modify.rs
+++ b/tests/modify.rs
@@ -87,6 +87,72 @@ mod tests_with_parsing {
         assert_eq!(text, "🔧🔨\n🔧\n🔨\n");
     }
 
+    fn build_doc_with_tj_array(
+        content_bytes: Vec<u8>,
+    ) -> Document {
+        use lopdf::dictionary;
+
+        let mut doc = Document::with_version("1.5");
+
+        let pages_id = doc.new_object_id();
+
+        let font_id = doc.add_object(dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type1",
+            "BaseFont" => "Helvetica",
+        });
+
+        let resources_id = doc.add_object(dictionary! {
+            "Font" => dictionary! {
+                "F1" => font_id,
+            },
+        });
+
+        let content_id = doc.add_object(lopdf::Stream::new(dictionary! {}, content_bytes));
+
+        let single_page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Resources" => resources_id,
+            "Contents" => content_id,
+            "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+        });
+
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![single_page_id.into()],
+                "Count" => 1,
+            }),
+        );
+
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        });
+        doc.trailer.set("Root", catalog_id);
+
+        doc
+    }
+
+    fn replace_text_in_tj_array_doc() -> Result<Document> {
+        // Content uses the TJ operator with a single-string array containing
+        // all 12 characters of "Hello World!".
+        let content =
+            b"BT\n/F1 12 Tf\n100 700 Td\n[(Hello World!)] TJ\nET\n".to_vec();
+        let mut doc = build_doc_with_tj_array(content);
+        doc.replace_text(1, "Hello World!", "Modified text!", None)?;
+        Ok(doc)
+    }
+
+    #[test]
+    fn test_replace_text_in_tj_array_does_not_truncate() {
+        let doc = replace_text_in_tj_array_doc().unwrap();
+        let text = doc.extract_text(&[1]).unwrap();
+        assert_eq!(text, "Modified text! \n");
+    }
+
     fn get_mut() -> Result<bool> {
         let mut doc = Document::load("assets/example.pdf")?;
         let arr = doc


### PR DESCRIPTION
I encountered a bug that resulted in the truncation of text in the output of the replace_text command.
I added a test case that reproduces it, and as a second commit, the fix that corrects it.

Fair disclosure: the code was written by me but with the help of Claude Opus 4.7, and the test case is fully AI; I am not experienced enough with PDFs to have diagnosed this myself.
Feel free to treat this as a bug report with reproduction code if you do not wish to accept AI assisted contributions.