### PR TITLE
Introduce Content::decode_strict

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -704,6 +704,16 @@ pub fn content(input: ParserInput) -> Option<Content<Vec<Operation>>> {
     strip_nom(_content.parse(input))
 }
 
+pub fn content_strict(input: ParserInput) -> Result<Content<Vec<Operation>>, error::ParseError> {
+    let (rest, content) = _content
+        .parse(input)
+        .map_err(|_| error::ParseError::InvalidContentStream)?;
+    if !rest.is_empty() {
+        return Err(error::ParseError::InvalidContentStream);
+    }
+    Ok(content)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -958,5 +968,25 @@ EI";
             Some(num) => assert_eq!(num, 135738),
             None => panic!("startxref with trailing space should parse"),
         }
+    }
+
+    #[test]
+    fn content_silently_truncates_corrupted_data() {
+        // Corrupted data with unterminated string literal
+        let data = b"q 1 0 0 1 10 10 cm (corrupted Q";
+
+        let content = content(data).unwrap();
+
+        // Operations before the corruption returned without an error.
+        // Trailing Q was silently dropped.
+        assert_eq!(content.operations.len(), 2);
+        assert_eq!(content.operations[0].operator, "q");
+        assert_eq!(content.operations[1].operator, "cm");
+    }
+
+    #[test]
+    fn content_strict_rejects_corrupted_data() {
+        let data = b"q 1 0 0 1 10 10 cm (corrupted Q";
+        assert!(content_strict(data).is_err());
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,13 +1,13 @@
 use super::{Dictionary, Object, ObjectId, Reader, Stream, StringFormat};
-use crate::Error;
 use crate::content::*;
 use crate::error;
 use crate::xref::*;
+use crate::Error;
 use std::collections::HashSet;
 use std::str::{self, FromStr};
 
 use nom::branch::alt;
-use nom::bytes::complete::{tag, take, take_while, take_while_m_n, take_while1};
+use nom::bytes::complete::{tag, take, take_while, take_while1, take_while_m_n};
 use nom::character::complete::multispace1;
 use nom::character::complete::{digit0, digit1, one_of};
 use nom::character::complete::{space0, space1};
@@ -804,24 +804,24 @@ T* (encoded streams.) Tj
     fn big_generation_value() {
         let input = b"xref
 0 1
-0000000000 65536 f 
+0000000000 65536 f\x20
 0 16
-0000000000 65535 f 
-0000153238 00000 n 
-0000000019 00000 n 
-0000000313 00000 n 
-0000000333 00000 n 
-0000145531 00000 n 
-0000153407 00000 n 
-0000145554 00000 n 
-0000152303 00000 n 
-0000152324 00000 n 
-0000152514 00000 n 
-0000152880 00000 n 
-0000153106 00000 n 
-0000153139 00000 n 
-0000153532 00000 n 
-0000153629 00000 n 
+0000000000 65535 f\x20
+0000153238 00000 n\x20
+0000000019 00000 n\x20
+0000000313 00000 n\x20
+0000000333 00000 n\x20
+0000145531 00000 n\x20
+0000153407 00000 n\x20
+0000145554 00000 n\x20
+0000152303 00000 n\x20
+0000152324 00000 n\x20
+0000152514 00000 n\x20
+0000152880 00000 n\x20
+0000153106 00000 n\x20
+0000153139 00000 n\x20
+0000153532 00000 n\x20
+0000153629 00000 n\x20
 trailer
 <</Size 16/Root 14 0 R
 /Info 15 0 R
@@ -830,7 +830,7 @@ trailer
 /DocChecksum /2BCC3C7DE26E6BF3573E4A6E8362221F
 >>
 startxref
-153804
+153804\x20
 %%EOF
 ";
         match xref(test_span(input)) {
@@ -842,7 +842,7 @@ startxref
     #[test]
     fn space_in_startxref_number() {
         let input = b"startxref
-153804 
+153804\x20
 %%EOF
 ";
         match xref_start(test_span(input)) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -693,9 +693,10 @@ fn image_data_stream(input: ParserInput, stream_dict: Dictionary) -> crate::Resu
 }
 
 fn _content(input: ParserInput) -> NomResult<Content<Vec<Operation>>> {
-    preceded(
+    delimited(
         content_space,
         map(many0(operation), |operations| Content { operations }),
+        many0(terminated(comment, content_space)),
     )
     .parse(input)
 }
@@ -914,6 +915,8 @@ startxref
 % Another comment
 ";
         let out = content(test_span(input)).unwrap();
+        let out_strict = content_strict(test_span(input)).unwrap();
+        assert_eq!(out.operations.len(), out_strict.operations.len());
         assert_eq!(out.operations.len(), 3);
     }
 

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -1,15 +1,15 @@
 use log::warn;
 
-use crate::{Dictionary, Object, ObjectId, Stream, parser};
 use crate::{
-    Error, Result,
     content::{Content, Operation},
     document::Document,
     encodings::Encoding,
     error::ParseError,
     object::Object::Name,
     xref::{Xref, XrefEntry, XrefType},
+    Error, Result,
 };
+use crate::{parser, Dictionary, Object, ObjectId, Stream};
 use std::{
     collections::BTreeMap,
     io::{Cursor, Read},
@@ -19,6 +19,11 @@ impl Content<Vec<Operation>> {
     /// Decode content operations.
     pub fn decode(data: &[u8]) -> Result<Self> {
         parser::content(data).ok_or(ParseError::InvalidContentStream.into())
+    }
+
+    /// Strict decode content operations.
+    pub fn decode_strict(data: &[u8]) -> Result<Self> {
+        parser::content_strict(data).map_err(|e| e.into())
     }
 }
 
@@ -580,8 +585,8 @@ mod tests {
     #[cfg(not(feature = "async"))]
     #[test]
     fn load_and_save() {
-        use crate::Document;
         use crate::creator::tests::{create_document, save_document};
+        use crate::Document;
 
         // test load_from() and save_to()
         use std::fs::File;
@@ -650,9 +655,9 @@ mod tests {
     /// recover the string operand and emit a line break before it.
     #[test]
     fn extract_text_handles_apostrophe_show_text_op() {
-        use crate::Object;
         use crate::content::Operation;
         use crate::creator::tests::create_document_with_operations;
+        use crate::Object;
 
         let doc = create_document_with_operations(vec![
             Operation::new("BT", vec![]),
@@ -676,9 +681,9 @@ mod tests {
     /// rendering spacing and don't affect the extracted character sequence.
     #[test]
     fn extract_text_handles_quote_show_text_op() {
-        use crate::Object;
         use crate::content::Operation;
         use crate::creator::tests::create_document_with_operations;
+        use crate::Object;
 
         let doc = create_document_with_operations(vec![
             Operation::new("BT", vec![]),
@@ -698,9 +703,9 @@ mod tests {
     /// newline rather than running together.
     #[test]
     fn extract_text_preserves_line_breaks_for_t_star() {
-        use crate::Object;
         use crate::content::Operation;
         use crate::creator::tests::create_document_with_operations;
+        use crate::Object;
 
         let doc = create_document_with_operations(vec![
             Operation::new("BT", vec![]),


### PR DESCRIPTION
I am using lopdf in preflight workflows and would like to add `Content::decode_strict`in order to enforce a strict parsing without a lenient early return of operationst when a corrupted operation occurs. Short list of changes (see more in my commit bodies):

- Fix trimming of trail whitespaces by escaping whitespaces  (updated test contents in parser/mod.rs)
- Add Content::decode_strict method to prevent silent early returns of operations when corrupted content is parsed
- Consume trailing comments in content streams in order to support strict decoding