### PR TITLE
fix(document): insert newline between concatenated content streams

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -595,6 +595,7 @@ impl Document {
                     Ok(data) => content.write_all(&data)?,
                     Err(_) => content.write_all(&content_stream.content)?,
                 };
+                content.push(b'\n');
             }
         }
         Ok(content)

--- a/tests/page_content.rs
+++ b/tests/page_content.rs
@@ -1,0 +1,45 @@
+use lopdf::{content::Content, dictionary, Document, Stream};
+
+#[test]
+fn get_page_content_separates_streams_at_token_boundary() {
+    let mut doc = Document::with_version("1.5");
+    // Producer writes stream that ends without trailing whitespace
+    let s1 = doc.add_object(Stream::new(dictionary! {}, b"1 0 0 1 50".to_vec()));
+    let s2 = doc.add_object(Stream::new(dictionary! {}, b"100 cm".to_vec()));
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Contents" => vec![s1.into(), s2.into()],
+    });
+
+    let bytes = doc.get_page_content(page_id).unwrap();
+    let content = Content::decode(&bytes).unwrap();
+
+    assert_eq!(content.operations.len(), 1);
+    let op = &content.operations[0];
+    assert_eq!(op.operator, "cm");
+    let operands: Vec<f32> = op.operands.iter().map(|o| o.as_float().unwrap()).collect();
+
+    assert_eq!(operands, [1.0, 0.0, 0.0, 1.0, 50.0, 100.0]);
+}
+
+#[test]
+fn get_page_content_terminates_trailing_comment() {
+    let mut doc = Document::with_version("1.5");
+    // Producer writes stream that ends with a comment without EOL
+    let s1 = doc.add_object(Stream::new(dictionary! {}, b"% a comment".to_vec()));
+    let s2 = doc.add_object(Stream::new(dictionary! {}, b"1 0 0 1 50 100 cm".to_vec()));
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Contents" => vec![s1.into(), s2.into()],
+    });
+
+    let bytes = doc.get_page_content(page_id).unwrap();
+    let content = Content::decode(&bytes).unwrap();
+
+    assert_eq!(content.operations.len(), 1);
+    let op = &content.operations[0];
+    assert_eq!(op.operator, "cm");
+    let operands: Vec<f32> = op.operands.iter().map(|o| o.as_float().unwrap()).collect();
+
+    assert_eq!(operands, [1.0, 0.0, 0.0, 1.0, 50.0, 100.0]);
+}


### PR DESCRIPTION
When concatenated content streams are not separated by a newline, a trailing comment can silently swallow the start of the next stream.

Example Trailing Comment:

    Stream 1:
    q
    1 0 0 1 50 50 cm
    % some comment here <- stream ends here without EOL

    Stream 2:
    0 0 100 100 re f
    Q

    Concatenated WITHOUT separation:

    q
    1 0 0 1 50 50 cm
    % some comment here0 0 100 100 re f
    Q

    Concatenated WITH newline:

    q
    1 0 0 1 50 50 cm
    % some comment here
    0 0 100 100 re f
    Q

ISO 32000-1:2008 §7.7.3.3 permits (see Contents in the Page Object) also the division between streams only at the boundaries between lexical tokens. A producer that ends a stream without trailing whitespace violates this: in the concatenated stream the division falls inside a token, merging two tokens into one and silently changing the content. This patch repairs these cases as well.

Example Missing Trailing Whitespace:

    Stream 1 ends with:
    1 0 0 1 50 <- stream ends here without trailing whitespace

    Stream 2:
    100 cm

    Concatenated WITHOUT separation:
    1 0 0 1 50100 cm

    Concatenated WITH newline:
    1 0 0 1 50
    100 cm

For a conforming PDF the inserted byte is insignificant whitespace between tokens. The lexical content is unchanged.