### PR TITLE
Fix cross-reference stream omitting its own xref entry

### DIFF
--- a/src/xref.rs
+++ b/src/xref.rs
@@ -52,6 +52,13 @@ impl Xref {
 
     pub fn insert(&mut self, id: u32, entry: XrefEntry) {
         self.entries.insert(id, entry);
+        // Maintain the documented invariant: `size` is the highest object
+        // number plus 1. Without this, inserting an object whose id is at or
+        // above the current `size` (e.g. the cross-reference stream's own
+        // object, created late during `write_cross_reference_stream`) leaves
+        // `size` stale, and `create_xref_steam` — which iterates `1..size` —
+        // silently omits that object's entry from the emitted xref stream.
+        self.size = self.size.max(id.saturating_add(1));
     }
 
     /// Combine Xref entries. Only add them if they do not exists already.

--- a/tests/xref_stream_self_entry_test.rs
+++ b/tests/xref_stream_self_entry_test.rs
@@ -1,0 +1,80 @@
+//! Regression test: the cross-reference stream must include an xref entry for
+//! its own object.
+//!
+//! The cross-reference stream object is created late in
+//! `write_cross_reference_stream`, after `Xref::size` was first computed. If
+//! `Xref::insert` doesn't keep `size` up to date (its documented invariant —
+//! "highest object number plus 1"), then `create_xref_steam`, which iterates
+//! `1..size`, silently drops the highest id(s) — including the cross-reference
+//! stream itself. qpdf reports this as:
+//!   "xref entry for the xref stream itself is missing".
+
+use lopdf::{dictionary, Document, Object, Stream};
+
+fn parse_u64_after(text: &str, key: &str) -> Option<i64> {
+    let rest = &text[text.find(key)? + key.len()..];
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse().ok()
+}
+
+fn parse_index(text: &str) -> Option<Vec<i64>> {
+    let open = text.find("/Index[")? + "/Index[".len();
+    let close = text[open..].find(']')? + open;
+    text[open..close]
+        .split_whitespace()
+        .map(|t| t.parse::<i64>().ok())
+        .collect()
+}
+
+#[test]
+fn xref_stream_index_covers_the_xref_stream_itself() {
+    let mut doc = Document::with_version("1.5");
+    let pages_id = doc.new_object_id();
+
+    // A handful of compressible (non-stream) objects plus one stream, so an
+    // ObjStm is created and the max object id grows past the initial size.
+    let font_id = doc.add_object(dictionary! {
+        "Type" => "Font", "Subtype" => "Type1", "BaseFont" => "Helvetica",
+    });
+    let content_id = doc.add_object(Stream::new(dictionary! {}, b"BT ET".to_vec()));
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Parent" => pages_id,
+        "Contents" => content_id,
+        "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+        "Resources" => dictionary! { "Font" => dictionary! { "F1" => font_id } },
+    });
+    doc.objects.insert(
+        pages_id,
+        Object::Dictionary(dictionary! {
+            "Type" => "Pages", "Kids" => vec![page_id.into()], "Count" => 1,
+        }),
+    );
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog", "Pages" => pages_id,
+    });
+    doc.trailer.set("Root", catalog_id);
+
+    let mut buffer = Vec::new();
+    doc.save_modern(&mut buffer).expect("save_modern");
+
+    let text = String::from_utf8_lossy(&buffer);
+    let size = parse_u64_after(&text, "/Size ").expect("xref stream /Size");
+    let index = parse_index(&text).expect("xref stream /Index");
+    assert!(!index.is_empty() && index.len() % 2 == 0, "malformed /Index");
+
+    // /Index is a sequence of (first_id, count) subsections. The highest id it
+    // covers must be the highest object number, i.e. /Size - 1 — otherwise the
+    // top object (the cross-reference stream itself) has no xref entry.
+    let max_covered = index
+        .chunks(2)
+        .map(|pair| pair[0] + pair[1] - 1)
+        .max()
+        .unwrap();
+    assert_eq!(
+        max_covered,
+        size - 1,
+        "xref /Index must cover the cross-reference stream's own object: \
+         /Size={size} but /Index only covers up to id {max_covered}"
+    );
+}


### PR DESCRIPTION
### Problem

Saving with cross-reference streams (`save_modern` / `save_with_options(use_xref_streams: true)`) produces output that `qpdf --check` flags:

```
WARNING: xref entry for the xref stream itself is missing -
a common error handled correctly by qpdf and most other applications
```

### Cause

`Xref::insert` doesn't maintain the `size` field's documented invariant ("Total number of entries ... equal to the highest object number plus 1"). The cross-reference stream object is created late in `write_cross_reference_stream` — after `size` was first computed via `Xref::new(self.max_id + 1)` — so its id (and any object-stream ids assigned beyond the original `size`) are never reflected in `size`. `create_xref_steam` then iterates `1..size` and silently omits those objects' entries.

### Fix

Maintain the invariant in `insert`:

```rust
self.size = self.size.max(id.saturating_add(1));
```

One line, no behavior change for any consumer that was already passing a correct `size`; it only grows `size` when an out-of-range id is inserted.

### Test

`tests/xref_stream_self_entry_test.rs` builds a small document, `save_modern`s it, and asserts the emitted `/Index` subsections cover the highest object id (`/Size - 1`). It **fails before** this change (`/Size=8` but `/Index` covers only up to id 6) and **passes after**. Full existing suite stays green.

Verified end-to-end against real PDFs: with this fix, packed output passes `qpdf --check` with exit 0 (zero warnings).