### PR TITLE
fix(writer): include subsequent ObjStm objects in xref stream range

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -408,7 +408,7 @@ impl Writer {
         let mut xref_sections = Vec::new();
         let mut xref_section = XrefSection::new(0);
 
-        for obj_id in 1..xref.size + 1 {
+        for obj_id in 1..xref.size {
             // If section is empty change number of starting id.
             if xref_section.is_empty() {
                 xref_section = XrefSection::new(obj_id);

--- a/src/xref.rs
+++ b/src/xref.rs
@@ -52,6 +52,7 @@ impl Xref {
 
     pub fn insert(&mut self, id: u32, entry: XrefEntry) {
         self.entries.insert(id, entry);
+        self.size = self.size.max(id.saturating_add(1));
     }
 
     /// Combine Xref entries. Only add them if they do not exists already.

--- a/tests/object_stream_methods_test.rs
+++ b/tests/object_stream_methods_test.rs
@@ -373,3 +373,55 @@ fn test_multiple_object_streams_in_document() {
         "Should have multiple object streams for 250+ objects"
     );
 }
+
+#[test]
+fn test_loads_catalog_from_later_generated_object_stream() {
+    let mut doc = Document::with_version("1.5");
+    let pages_id = doc.new_object_id();
+
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Parent" => pages_id,
+        "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+    });
+
+    doc.objects.insert(
+        pages_id,
+        Object::Dictionary(dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![page_id.into()],
+            "Count" => 1,
+        }),
+    );
+
+    // Fill the document with enough objects to force multiple object streams.
+    let max_objects_per_stream = lopdf::ObjectStreamConfig::default().max_objects_per_stream;
+    for _ in 0..=max_objects_per_stream {
+        doc.add_object(dictionary! {
+            "Dummy" => true,
+        });
+    }
+
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => pages_id,
+    });
+
+    doc.trailer.set("Root", catalog_id);
+
+    let mut buffer = Vec::new();
+    doc.save_modern(&mut buffer).unwrap();
+
+    let content = String::from_utf8_lossy(&buffer);
+    let objstm_count = content.matches("/ObjStm").count();
+    assert!(
+        objstm_count >= 2,
+        "should have multiple object streams"
+    );
+
+    let loaded = Document::load_mem(&buffer).unwrap();
+    loaded
+        .catalog()
+        .expect("catalog should remain reachable from a later generated object stream");
+    assert_eq!(loaded.get_pages().len(), 1);
+}


### PR DESCRIPTION
Fixes #499.

Updates `Xref::size` on insert and changes the xref stream loop to `1..xref.size`. 
Also adds a regression test for objects compressed into a later generated `/ObjStm`.