### PR TITLE
Update crypto APIs, fix Clippy lints, and improve benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
                       features: "--all-features"
 
         steps:
-            - uses: actions/checkout@v2
-            - uses: hecrj/setup-rust-action@v1
+            - uses: actions/checkout@v7
+            - uses: hecrj/setup-rust-action@v2
               with:
                   rust-version: ${{ matrix.rust || 'stable' }}
 
@@ -44,8 +44,8 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
-            - uses: hecrj/setup-rust-action@v1
+            - uses: actions/checkout@v7
+            - uses: hecrj/setup-rust-action@v2
 
             - name: Build
               run: cargo build --verbose --manifest-path pdfutil/Cargo.toml
@@ -54,8 +54,8 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
-            - uses: hecrj/setup-rust-action@v1
+            - uses: actions/checkout@v7
+            - uses: hecrj/setup-rust-action@v2
 
             - name: clippy for lopdf
               run: cargo clippy
@@ -66,7 +66,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v7
 
             - name: Install
               run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -85,10 +85,10 @@ jobs:
                 target: [wasm32-wasip1, wasm32-wasip2]
 
         steps:
-            - uses: actions/checkout@v2
-            - uses: hecrj/setup-rust-action@v1
+            - uses: actions/checkout@v7
+            - uses: hecrj/setup-rust-action@v2
               with:
-                targets: ${{ matrix.target }}
+                  targets: ${{ matrix.target }}
 
             - name: Build
               run: cargo build --verbose --target ${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,48 +14,49 @@ name = "lopdf"
 readme = "README.md"
 repository = "https://github.com/J-F-Liu/lopdf.git"
 version = "0.41.0"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [dependencies]
-aes = "0.8.4"
-bitflags = "2.8.0"
-cbc = "0.1.2"
+aes = "0.9"
+bitflags = "2.13"
+cbc = "0.2"
 chrono = { version = "0.4", optional = true, default-features = false, features = [
     "std",
     "clock",
 ] }
-ecb = "0.1.2"
-encoding_rs = "0.8.32"
-flate2 = "1.0"
+ecb = "0.2"
+encoding_rs = "0.8"
+flate2 = "1.1"
 image = { version = "0.25", optional = true }
-indexmap = "2.2.3"
+indexmap = "2.14"
 itoa = "1.0"
 jiff = { version = "0.2", optional = true }
 getrandom = "0.4"
 log = "0.4"
-md-5 = "0.10"
+md-5 = "0.11"
 nom = "8.0"
 rand = { version = "0.10" }
-rangemap = "1.5"
-rayon = { version = "1.6", optional = true }
+rangemap = "1.7"
+rayon = { version = "1.12", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-sha2 = "0.10.8"
+sha2 = "0.11"
 stringprep = "0.1.5"
-thiserror = "2.0.3"
+thiserror = "2.0"
 time = { version = "0.3", features = [
     "formatting",
     "parsing",
 ], optional = true }
 tokio = { version = "1", features = ["fs", "io-util"], optional = true }
-weezl = "0.1"
+weezl = "0.2"
 ttf-parser = "0.25.1"
 
 [dev-dependencies]
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
+criterion = "0.8"
 env_logger = "0.11"
 serde_json = "1.0"
-shellexpand = "3.0"
-tempfile = "3.3"
+shellexpand = "3.1"
+tempfile = "3.27"
 wasm-bindgen-test = "0.3"
 ttf-parser = "0.25.1"
 
@@ -83,6 +84,14 @@ required-features = ["default"]
 
 [[example]]
 name = "rotate"
+
+[[bench]]
+name = "datetime"
+harness = false
+
+[[bench]]
+name = "parse"
+harness = false
 
 [badges]
 travis-ci = { repository = "J-F-Liu/lopdf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "lopdf"
 readme = "README.md"
 repository = "https://github.com/J-F-Liu/lopdf.git"
 version = "0.42.0"
-rust-version = "1.85"
+rust-version = "1.88"
 exclude = ["/tests", "/benches", "/assets", "/.vscode", "/.github"]
 
 [dependencies]

--- a/benches/datetime.rs
+++ b/benches/datetime.rs
@@ -1,46 +1,56 @@
-#![feature(test)]
-extern crate test;
-use test::Bencher;
-
 use chrono::prelude::{Local, Timelike};
+use criterion::{Criterion, criterion_group, criterion_main};
 use lopdf::Object;
 
-#[bench]
-fn create_and_parse_datetime(b: &mut Bencher) {
-    b.iter(|| {
-        let time = Local::now().with_nanosecond(0).unwrap();
-        let text: Object = time.into();
-        let time2 = text.as_datetime();
-        assert!(time2.is_some());
+fn create_and_parse_datetime(c: &mut Criterion) {
+    c.bench_function("create_and_parse_datetime", |b| {
+        b.iter(|| {
+            let time = Local::now().with_nanosecond(0).unwrap();
+            let text: Object = time.into();
+            let time2 = text.as_datetime();
+            assert!(time2.is_some());
+        });
     });
 }
 
-#[bench]
-fn bench_integer_write(b: &mut test::Bencher) {
-    b.iter(|| {
-        let mut buf = ::std::io::Cursor::new(Vec::<u8>::new());
-        let mut doc = lopdf::Document::new();
-        doc.add_object(Object::Integer(5));
-        doc.save_to(&mut buf).unwrap();
-    })
+fn integer_write(c: &mut Criterion) {
+    c.bench_function("integer_write", |b| {
+        b.iter(|| {
+            let mut buf = std::io::Cursor::new(Vec::<u8>::new());
+            let mut doc = lopdf::Document::new();
+            doc.add_object(Object::Integer(5));
+            doc.save_to(&mut buf).unwrap();
+        });
+    });
 }
 
-#[bench]
-fn bench_floating_point_write(b: &mut test::Bencher) {
-    b.iter(|| {
-        let mut buf = ::std::io::Cursor::new(Vec::<u8>::new());
-        let mut doc = lopdf::Document::new();
-        doc.add_object(Object::Real(5.0));
-        doc.save_to(&mut buf).unwrap();
-    })
+fn floating_point_write(c: &mut Criterion) {
+    c.bench_function("floating_point_write", |b| {
+        b.iter(|| {
+            let mut buf = std::io::Cursor::new(Vec::<u8>::new());
+            let mut doc = lopdf::Document::new();
+            doc.add_object(Object::Real(5.0));
+            doc.save_to(&mut buf).unwrap();
+        });
+    });
 }
 
-#[bench]
-fn bench_boolean_write(b: &mut test::Bencher) {
-    b.iter(|| {
-        let mut buf = ::std::io::Cursor::new(Vec::<u8>::new());
-        let mut doc = lopdf::Document::new();
-        doc.add_object(Object::Boolean(false));
-        doc.save_to(&mut buf).unwrap();
-    })
+fn boolean_write(c: &mut Criterion) {
+    c.bench_function("boolean_write", |b| {
+        b.iter(|| {
+            let mut buf = std::io::Cursor::new(Vec::<u8>::new());
+            let mut doc = lopdf::Document::new();
+            doc.add_object(Object::Boolean(false));
+            doc.save_to(&mut buf).unwrap();
+        });
+    });
 }
+
+criterion_group!(
+    benches,
+    create_and_parse_datetime,
+    integer_write,
+    floating_point_write,
+    boolean_write
+);
+criterion_main!(benches);

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,34 +1,47 @@
-#![feature(test)]
-#![cfg(not(feature = "async"))]
-
+#[cfg(not(feature = "async"))]
 use std::fs::File;
+#[cfg(not(feature = "async"))]
 use std::io::{Cursor, Read};
 
-extern crate test;
+#[cfg(not(feature = "async"))]
+use criterion::{Criterion, criterion_group, criterion_main};
+#[cfg(not(feature = "async"))]
 use lopdf::Document;
 
-#[bench]
-fn bench_load(b: &mut test::test::Bencher) {
+#[cfg(not(feature = "async"))]
+fn bench_load(c: &mut Criterion) {
     let mut buffer = Vec::new();
     File::open("assets/example.pdf")
         .unwrap()
         .read_to_end(&mut buffer)
         .unwrap();
 
-    b.iter(|| {
-        Document::load_from(Cursor::new(&buffer)).unwrap();
-    })
+    c.bench_function("load_example_pdf", |b| {
+        b.iter(|| {
+            Document::load_from(Cursor::new(&buffer)).unwrap();
+        });
+    });
 }
 
-#[bench]
-fn bench_load_incremental_pdf(b: &mut test::test::Bencher) {
+#[cfg(not(feature = "async"))]
+fn bench_load_incremental_pdf(c: &mut Criterion) {
     let mut buffer = Vec::new();
     File::open("assets/Incremental.pdf")
         .unwrap()
         .read_to_end(&mut buffer)
         .unwrap();
 
-    b.iter(|| {
-        Document::load_from(Cursor::new(&buffer)).unwrap();
-    })
+    c.bench_function("load_incremental_pdf", |b| {
+        b.iter(|| {
+            Document::load_from(Cursor::new(&buffer)).unwrap();
+        });
+    });
 }
+
+#[cfg(not(feature = "async"))]
+criterion_group!(benches, bench_load, bench_load_incremental_pdf);
+#[cfg(not(feature = "async"))]
+criterion_main!(benches);
+
+#[cfg(feature = "async")]
+fn main() {}

--- a/examples/add_barcode.rs
+++ b/examples/add_barcode.rs
@@ -1,7 +1,7 @@
 use lopdf::Document;
 use lopdf::xobject;
 use std::fmt::Write;
-use std::io::{Error, ErrorKind};
+use std::io::Error;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -70,16 +70,15 @@ fn generate_operations(rects: Vec<(f64, f64, f64, f64, u8)>) -> String {
 
 #[cfg(not(feature = "async"))]
 fn load_pdf<P: AsRef<Path>>(path: P) -> Result<Document, Error> {
-    Document::load(path).map_err(|e| Error::new(ErrorKind::Other, e.to_string()))
+    Document::load(path).map_err(|e| Error::other(e.to_string()))
 }
 
 #[cfg(feature = "async")]
 fn load_pdf<P: AsRef<Path>>(path: P) -> Result<Document, Error> {
-    Ok(Builder::new_current_thread().build().unwrap().block_on(async move {
-        Document::load(path)
-            .await
-            .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))
-    })?)
+    Builder::new_current_thread()
+        .build()
+        .unwrap()
+        .block_on(async move { Document::load(path).await.map_err(|e| Error::other(e.to_string())) })
 }
 
 #[allow(non_upper_case_globals)]

--- a/examples/analyze_object_streams.rs
+++ b/examples/analyze_object_streams.rs
@@ -50,78 +50,73 @@ fn analyze_document(doc: &Document) {
     let mut compressed_objects = HashMap::new();
 
     for (id, obj) in &doc.objects {
-        if let Object::Stream(stream) = obj {
-            if let Ok(type_obj) = stream.dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    if type_name == b"ObjStm" {
-                        object_streams.push(id);
+        if let Object::Stream(stream) = obj
+            && let Ok(type_obj) = stream.dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+            && type_name == b"ObjStm"
+        {
+            object_streams.push(id);
 
-                        // Get info about this object stream
-                        if let Ok(n) = stream.dict.get(b"N") {
-                            if let Ok(count) = n.as_i64() {
-                                println!("\nObject Stream {} 0 R:", id.0);
-                                println!("  Contains {} objects", count);
+            // Get info about this object stream
+            if let Ok(n) = stream.dict.get(b"N")
+                && let Ok(count) = n.as_i64()
+            {
+                println!("\nObject Stream {} 0 R:", id.0);
+                println!("  Contains {} objects", count);
 
-                                if let Ok(first) = stream.dict.get(b"First") {
-                                    if let Ok(first_offset) = first.as_i64() {
-                                        println!("  First object at offset: {}", first_offset);
-                                    }
-                                }
+                if let Ok(first) = stream.dict.get(b"First")
+                    && let Ok(first_offset) = first.as_i64()
+                {
+                    println!("  First object at offset: {}", first_offset);
+                }
 
-                                // Try to parse the stream content
-                                match stream.decompressed_content() {
-                                    Ok(decompressed) => {
-                                        println!("  Decompressed size: {} bytes", decompressed.len());
+                // Try to parse the stream content
+                match stream.decompressed_content() {
+                    Ok(decompressed) => {
+                        println!("  Decompressed size: {} bytes", decompressed.len());
 
-                                        // Parse the offset table
-                                        if let Ok(first_offset) = stream.dict.get(b"First").and_then(|o| o.as_i64()) {
-                                            if first_offset as usize <= decompressed.len() {
-                                                let offset_table = &decompressed[..first_offset as usize];
-                                                if let Ok(offset_str) = std::str::from_utf8(offset_table) {
-                                                    let numbers: Vec<_> = offset_str.split_whitespace().collect();
-                                                    println!("  Objects in stream:");
-                                                    for chunk in numbers.chunks(2) {
-                                                        if chunk.len() == 2 {
-                                                            println!("    - Object {}: offset {}", chunk[0], chunk[1]);
-                                                            if let Ok(obj_num) = chunk[0].parse::<u32>() {
-                                                                compressed_objects.insert(obj_num, id.0);
-                                                            }
-                                                        }
-                                                    }
-                                                } else {
-                                                    println!("  ERROR: Could not parse offset table as UTF-8");
-                                                    println!(
-                                                        "  First 100 bytes: {:?}",
-                                                        &offset_table[..offset_table.len().min(100)]
-                                                    );
-                                                }
-                                            } else {
-                                                println!(
-                                                    "  ERROR: First offset {} exceeds decompressed size {}",
-                                                    first_offset,
-                                                    decompressed.len()
-                                                );
+                        // Parse the offset table
+                        if let Ok(first_offset) = stream.dict.get(b"First").and_then(|o| o.as_i64()) {
+                            if first_offset as usize <= decompressed.len() {
+                                let offset_table = &decompressed[..first_offset as usize];
+                                if let Ok(offset_str) = std::str::from_utf8(offset_table) {
+                                    let numbers: Vec<_> = offset_str.split_whitespace().collect();
+                                    println!("  Objects in stream:");
+                                    for chunk in numbers.chunks(2) {
+                                        if chunk.len() == 2 {
+                                            println!("    - Object {}: offset {}", chunk[0], chunk[1]);
+                                            if let Ok(obj_num) = chunk[0].parse::<u32>() {
+                                                compressed_objects.insert(obj_num, id.0);
                                             }
                                         }
                                     }
-                                    Err(e) => {
-                                        println!("  ERROR: Could not decompress stream: {}", e);
-                                        println!("  Stream is compressed: {}", stream.allows_compression);
-                                        if let Ok(filter) = stream.dict.get(b"Filter") {
-                                            println!("  Filter: {:?}", filter);
-                                        } else {
-                                            println!("  No Filter found in dictionary!");
-                                            println!("  Dictionary: {:?}", stream.dict);
-                                        }
-                                        println!("  Raw content size: {} bytes", stream.content.len());
-                                        println!(
-                                            "  First 20 bytes of raw content: {:?}",
-                                            &stream.content[..stream.content.len().min(20)]
-                                        );
-                                    }
+                                } else {
+                                    println!("  ERROR: Could not parse offset table as UTF-8");
+                                    println!("  First 100 bytes: {:?}", &offset_table[..offset_table.len().min(100)]);
                                 }
+                            } else {
+                                println!(
+                                    "  ERROR: First offset {} exceeds decompressed size {}",
+                                    first_offset,
+                                    decompressed.len()
+                                );
                             }
                         }
+                    }
+                    Err(e) => {
+                        println!("  ERROR: Could not decompress stream: {}", e);
+                        println!("  Stream is compressed: {}", stream.allows_compression);
+                        if let Ok(filter) = stream.dict.get(b"Filter") {
+                            println!("  Filter: {:?}", filter);
+                        } else {
+                            println!("  No Filter found in dictionary!");
+                            println!("  Dictionary: {:?}", stream.dict);
+                        }
+                        println!("  Raw content size: {} bytes", stream.content.len());
+                        println!(
+                            "  First 20 bytes of raw content: {:?}",
+                            &stream.content[..stream.content.len().min(20)]
+                        );
                     }
                 }
             }
@@ -166,13 +161,10 @@ fn analyze_document(doc: &Document) {
                             Object::Array(refs) => {
                                 println!("  Contents array with {} elements", refs.len());
                                 for (i, content_ref) in refs.iter().enumerate() {
-                                    if let Object::Reference(ref_id) = content_ref {
-                                        if compressed_objects.contains_key(&ref_id.0) {
-                                            println!(
-                                                "    ⚠️  Content[{}] {} {} R is compressed!",
-                                                i, ref_id.0, ref_id.1
-                                            );
-                                        }
+                                    if let Object::Reference(ref_id) = content_ref
+                                        && compressed_objects.contains_key(&ref_id.0)
+                                    {
+                                        println!("    ⚠️  Content[{}] {} {} R is compressed!", i, ref_id.0, ref_id.1);
                                     }
                                 }
                             }
@@ -181,12 +173,11 @@ fn analyze_document(doc: &Document) {
                     }
 
                     // Check resources
-                    if let Ok(resources) = page_dict.get(b"Resources") {
-                        if let Object::Reference(ref_id) = resources {
-                            if compressed_objects.contains_key(&ref_id.0) {
-                                println!("  ⚠️  Resources {} {} R is compressed!", ref_id.0, ref_id.1);
-                            }
-                        }
+                    if let Ok(resources) = page_dict.get(b"Resources")
+                        && let Object::Reference(ref_id) = resources
+                        && compressed_objects.contains_key(&ref_id.0)
+                    {
+                        println!("  ⚠️  Resources {} {} R is compressed!", ref_id.0, ref_id.1);
                     }
                 }
             }
@@ -208,13 +199,13 @@ fn analyze_document(doc: &Document) {
     println!("\n{}", "=".repeat(80));
     println!("Critical Objects Check:");
 
-    if let Ok(root) = doc.trailer.get(b"Root") {
-        if let Object::Reference(root_id) = root {
-            if compressed_objects.contains_key(&root_id.0) {
-                println!("⚠️  WARNING: Catalog (Root) object {} is compressed!", root_id.0);
-            } else {
-                println!("✓ Catalog (Root) object {} is not compressed", root_id.0);
-            }
+    if let Ok(root) = doc.trailer.get(b"Root")
+        && let Object::Reference(root_id) = root
+    {
+        if compressed_objects.contains_key(&root_id.0) {
+            println!("⚠️  WARNING: Catalog (Root) object {} is compressed!", root_id.0);
+        } else {
+            println!("✓ Catalog (Root) object {} is not compressed", root_id.0);
         }
     }
 }

--- a/examples/analyze_page_contents.rs
+++ b/examples/analyze_page_contents.rs
@@ -47,14 +47,12 @@ fn analyze_pages(doc: &Document) {
     // Check if we have object streams
     let mut obj_streams = Vec::new();
     for (id, obj) in &doc.objects {
-        if let Object::Stream(stream) = obj {
-            if let Ok(type_obj) = stream.dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    if type_name == b"ObjStm" {
-                        obj_streams.push(id.0);
-                    }
-                }
-            }
+        if let Object::Stream(stream) = obj
+            && let Ok(type_obj) = stream.dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+            && type_name == b"ObjStm"
+        {
+            obj_streams.push(id.0);
         }
     }
 
@@ -78,14 +76,14 @@ fn analyze_pages(doc: &Document) {
                 match page_dict.get(b"Contents") {
                     Ok(Object::Reference(content_id)) => {
                         println!("  Contents: {} {} R", content_id.0, content_id.1);
-                        check_content_stream(&doc, *content_id);
+                        check_content_stream(doc, *content_id);
                     }
                     Ok(Object::Array(contents)) => {
                         println!("  Contents array with {} elements:", contents.len());
                         for (i, content_ref) in contents.iter().enumerate() {
                             if let Object::Reference(content_id) = content_ref {
                                 println!("    [{}] {} {} R", i, content_id.0, content_id.1);
-                                check_content_stream(&doc, *content_id);
+                                check_content_stream(doc, *content_id);
                             }
                         }
                     }
@@ -101,7 +99,7 @@ fn analyze_pages(doc: &Document) {
                 match page_dict.get(b"Resources") {
                     Ok(Object::Reference(res_id)) => {
                         println!("  Resources: {} {} R", res_id.0, res_id.1);
-                        check_object_location(&doc, *res_id);
+                        check_object_location(doc, *res_id);
                     }
                     Ok(Object::Dictionary(_)) => {
                         println!("  Resources: Inline dictionary");
@@ -119,7 +117,7 @@ fn analyze_pages(doc: &Document) {
             }
             Err(e) => {
                 println!("  ERROR: Cannot get page object: {}", e);
-                check_object_location(&doc, page_id);
+                check_object_location(doc, page_id);
             }
         }
     }

--- a/examples/analyze_pdf.rs
+++ b/examples/analyze_pdf.rs
@@ -85,10 +85,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Check if already using object streams
     let has_objstm = doc.objects.values().any(|obj| {
-        if let Object::Dictionary(dict) = obj {
-            if let Ok(Object::Name(name)) = dict.get(b"Type") {
-                return name == b"ObjStm";
-            }
+        if let Object::Dictionary(dict) = obj
+            && let Ok(Object::Name(name)) = dict.get(b"Type")
+        {
+            return name == b"ObjStm";
         }
         false
     });

--- a/examples/analyze_references.rs
+++ b/examples/analyze_references.rs
@@ -35,14 +35,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Build reverse mapping
         for ref_id in refs {
-            referenced_by.entry(ref_id).or_insert_with(HashSet::new).insert(id);
+            referenced_by.entry(ref_id).or_default().insert(id);
         }
     }
 
     // Also check trailer references
     let trailer_refs = collect_references_from_dict(&doc.trailer);
     for ref_id in &trailer_refs {
-        referenced_by.entry(*ref_id).or_insert_with(HashSet::new).insert((0, 0));
+        referenced_by.entry(*ref_id).or_default().insert((0, 0));
     }
 
     // Analyze specific problematic objects

--- a/examples/check_raw_objstream.rs
+++ b/examples/check_raw_objstream.rs
@@ -118,17 +118,15 @@ fn main() {
 
     let mut found_objstream = false;
     for (id, obj) in &loaded.objects {
-        if let Object::Stream(stream) = obj {
-            if let Ok(type_obj) = stream.dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    if type_name == b"ObjStm" {
-                        found_objstream = true;
-                        println!("\nLoaded object stream {} 0 R:", id.0);
-                        println!("  Has Filter: {}", stream.dict.get(b"Filter").is_ok());
-                        println!("  Dictionary: {:?}", stream.dict);
-                    }
-                }
-            }
+        if let Object::Stream(stream) = obj
+            && let Ok(type_obj) = stream.dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+            && type_name == b"ObjStm"
+        {
+            found_objstream = true;
+            println!("\nLoaded object stream {} 0 R:", id.0);
+            println!("  Has Filter: {}", stream.dict.get(b"Filter").is_ok());
+            println!("  Dictionary: {:?}", stream.dict);
         }
     }
 

--- a/examples/create_text_heavy_pdf.rs
+++ b/examples/create_text_heavy_pdf.rs
@@ -166,10 +166,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nAnalyzing compressed PDF:");
     let compressed_doc = load_document("text_heavy_compressed.pdf")?;
     let has_objstm = compressed_doc.objects.values().any(|obj| {
-        if let Object::Dictionary(dict) = obj {
-            if let Ok(Object::Name(name)) = dict.get(b"Type") {
-                return name == b"ObjStm";
-            }
+        if let Object::Dictionary(dict) = obj
+            && let Ok(Object::Name(name)) = dict.get(b"Type")
+        {
+            return name == b"ObjStm";
         }
         false
     });

--- a/examples/debug_compression_detailed.rs
+++ b/examples/debug_compression_detailed.rs
@@ -71,32 +71,30 @@ fn main() {
     let mut obj_stream_with_filter = 0;
 
     for (id, obj) in &loaded.objects {
-        if let lopdf::Object::Stream(stream) = obj {
-            if let Ok(type_obj) = stream.dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    if type_name == b"ObjStm" {
-                        obj_stream_count += 1;
-                        let has_filter = stream.dict.get(b"Filter").is_ok();
-                        if has_filter {
-                            obj_stream_with_filter += 1;
-                        }
-
-                        println!("\nObject Stream {} 0 R:", id.0);
-                        println!("  Has Filter: {}", has_filter);
-                        if let Ok(n) = stream.dict.get(b"N").and_then(|o| o.as_i64()) {
-                            println!("  Contains {} objects", n);
-                        }
-                        if let Ok(first) = stream.dict.get(b"First").and_then(|o| o.as_i64()) {
-                            println!("  First offset: {}", first);
-                        }
-                        println!("  Content size: {} bytes", stream.content.len());
-
-                        // Check if content looks compressed
-                        let looks_compressed = stream.content.iter().take(20).any(|&b| b > 127);
-                        println!("  Content looks compressed: {}", looks_compressed);
-                    }
-                }
+        if let lopdf::Object::Stream(stream) = obj
+            && let Ok(type_obj) = stream.dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+            && type_name == b"ObjStm"
+        {
+            obj_stream_count += 1;
+            let has_filter = stream.dict.get(b"Filter").is_ok();
+            if has_filter {
+                obj_stream_with_filter += 1;
             }
+
+            println!("\nObject Stream {} 0 R:", id.0);
+            println!("  Has Filter: {}", has_filter);
+            if let Ok(n) = stream.dict.get(b"N").and_then(|o| o.as_i64()) {
+                println!("  Contains {} objects", n);
+            }
+            if let Ok(first) = stream.dict.get(b"First").and_then(|o| o.as_i64()) {
+                println!("  First offset: {}", first);
+            }
+            println!("  Content size: {} bytes", stream.content.len());
+
+            // Check if content looks compressed
+            let looks_compressed = stream.content.iter().take(20).any(|&b| b > 127);
+            println!("  Content looks compressed: {}", looks_compressed);
         }
     }
 

--- a/examples/debug_compression_full.rs
+++ b/examples/debug_compression_full.rs
@@ -4,6 +4,9 @@ use std::env;
 use std::fs::File;
 use std::io::Write;
 
+type ObjectId = (u32, u16);
+type ReferenceLocations = HashMap<ObjectId, (String, ObjectId)>;
+
 #[cfg(feature = "async")]
 use tokio::runtime::Builder;
 
@@ -82,14 +85,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Log why it's not compressible
             if matches!(obj, Object::Stream(_)) {
                 writeln!(debug_log, "    Reason: Is a stream object")?;
-            } else if let Object::Dictionary(dict) = obj {
-                if let Ok(type_obj) = dict.get(b"Type") {
-                    if let Ok(type_name) = type_obj.as_name() {
-                        if type_name == b"Page" || type_name == b"Pages" {
-                            writeln!(debug_log, "    Reason: Is a Page/Pages object")?;
-                        }
-                    }
-                }
+            } else if let Object::Dictionary(dict) = obj
+                && let Ok(type_obj) = dict.get(b"Type")
+                && let Ok(type_name) = type_obj.as_name()
+                && (type_name == b"Page" || type_name == b"Pages")
+            {
+                writeln!(debug_log, "    Reason: Is a Page/Pages object")?;
             }
 
             // Check if in trailer
@@ -186,7 +187,7 @@ fn analyze_document(doc: &Document) -> DocumentAnalysis {
     };
 
     // Count compressed objects
-    for (_id, xref_entry) in &doc.reference_table.entries {
+    for xref_entry in doc.reference_table.entries.values() {
         if let lopdf::xref::XrefEntry::Compressed { .. } = xref_entry {
             analysis.compressed_objects += 1;
         }
@@ -197,23 +198,22 @@ fn analyze_document(doc: &Document) -> DocumentAnalysis {
         match obj {
             Object::Stream(stream) => {
                 analysis.streams += 1;
-                if let Ok(type_obj) = stream.dict.get(b"Type") {
-                    if let Ok(type_name) = type_obj.as_name() {
-                        if type_name == b"ObjStm" {
-                            analysis.object_streams += 1;
-                        }
-                    }
+                if let Ok(type_obj) = stream.dict.get(b"Type")
+                    && let Ok(type_name) = type_obj.as_name()
+                    && type_name == b"ObjStm"
+                {
+                    analysis.object_streams += 1;
                 }
             }
             Object::Dictionary(dict) => {
                 analysis.dictionaries += 1;
-                if let Ok(type_obj) = dict.get(b"Type") {
-                    if let Ok(type_name) = type_obj.as_name() {
-                        match type_name {
-                            b"Page" => analysis.page_objects.push(id),
-                            b"Font" => analysis.fonts.push(id),
-                            _ => {}
-                        }
+                if let Ok(type_obj) = dict.get(b"Type")
+                    && let Ok(type_name) = type_obj.as_name()
+                {
+                    match type_name {
+                        b"Page" => analysis.page_objects.push(id),
+                        b"Font" => analysis.fonts.push(id),
+                        _ => {}
                     }
                 }
             }
@@ -224,21 +224,21 @@ fn analyze_document(doc: &Document) -> DocumentAnalysis {
 
     // Find content streams
     for &page_id in &analysis.page_objects {
-        if let Ok(page_obj) = doc.get_object(page_id) {
-            if let Object::Dictionary(page_dict) = page_obj {
-                match page_dict.get(b"Contents") {
-                    Ok(Object::Reference(content_id)) => {
-                        analysis.content_streams.push(*content_id);
-                    }
-                    Ok(Object::Array(contents)) => {
-                        for content_ref in contents {
-                            if let Object::Reference(content_id) = content_ref {
-                                analysis.content_streams.push(*content_id);
-                            }
+        if let Ok(page_obj) = doc.get_object(page_id)
+            && let Object::Dictionary(page_dict) = page_obj
+        {
+            match page_dict.get(b"Contents") {
+                Ok(Object::Reference(content_id)) => {
+                    analysis.content_streams.push(*content_id);
+                }
+                Ok(Object::Array(contents)) => {
+                    for content_ref in contents {
+                        if let Object::Reference(content_id) = content_ref {
+                            analysis.content_streams.push(*content_id);
                         }
                     }
-                    _ => {}
                 }
+                _ => {}
             }
         }
     }
@@ -338,14 +338,14 @@ fn verify_critical_objects(doc: &Document, log: &mut File) -> std::io::Result<()
                 )?;
 
                 // Check if it's compressed
-                if let Some(xref) = doc.reference_table.get(page_id.0) {
-                    if let lopdf::xref::XrefEntry::Compressed { container, index } = xref {
-                        writeln!(
-                            log,
-                            "  ERROR: Page is compressed in stream {} at index {}!",
-                            container, index
-                        )?;
-                    }
+                if let Some(xref) = doc.reference_table.get(page_id.0)
+                    && let lopdf::xref::XrefEntry::Compressed { container, index } = xref
+                {
+                    writeln!(
+                        log,
+                        "  ERROR: Page is compressed in stream {} at index {}!",
+                        container, index
+                    )?;
                 }
 
                 // Check page contents
@@ -406,17 +406,17 @@ fn check_orphaned_references(doc: &Document, log: &mut File) -> std::io::Result<
         match doc.get_object(*ref_id) {
             Ok(_) => {
                 // Check if it's in a compressed stream
-                if let Some(xref) = doc.reference_table.get(ref_id.0) {
-                    if let lopdf::xref::XrefEntry::Compressed { container, .. } = xref {
-                        // Make sure the container exists
-                        if doc.get_object((*container, 0)).is_err() {
-                            writeln!(
-                                log,
-                                "ERROR: Reference {} {} R from {} ({} {} R) points to compressed object in non-existent stream {}!",
-                                ref_id.0, ref_id.1, location, from_id.0, from_id.1, container
-                            )?;
-                            orphaned_count += 1;
-                        }
+                if let Some(xref) = doc.reference_table.get(ref_id.0)
+                    && let lopdf::xref::XrefEntry::Compressed { container, .. } = xref
+                {
+                    // Make sure the container exists
+                    if doc.get_object((*container, 0)).is_err() {
+                        writeln!(
+                            log,
+                            "ERROR: Reference {} {} R from {} ({} {} R) points to compressed object in non-existent stream {}!",
+                            ref_id.0, ref_id.1, location, from_id.0, from_id.1, container
+                        )?;
+                        orphaned_count += 1;
                     }
                 }
             }
@@ -437,7 +437,7 @@ fn check_orphaned_references(doc: &Document, log: &mut File) -> std::io::Result<
     Ok(())
 }
 
-fn collect_references(obj: &Object, refs: &mut HashMap<(u32, u16), (String, (u32, u16))>, from_id: (u32, u16)) {
+fn collect_references(obj: &Object, refs: &mut ReferenceLocations, from_id: ObjectId) {
     match obj {
         Object::Reference(ref_id) => {
             refs.insert(*ref_id, ("direct".to_string(), from_id));
@@ -492,7 +492,7 @@ fn validate_with_external_tools(pdf_path: &str) {
 
     // Try to use qpdf if available
     println!("\nTrying qpdf --check...");
-    match std::process::Command::new("qpdf").args(&["--check", pdf_path]).output() {
+    match std::process::Command::new("qpdf").args(["--check", pdf_path]).output() {
         Ok(output) => {
             if output.status.success() {
                 println!("✓ qpdf validation passed");
@@ -508,7 +508,7 @@ fn validate_with_external_tools(pdf_path: &str) {
 
     // Try to use mutool if available
     println!("\nTrying mutool info...");
-    match std::process::Command::new("mutool").args(&["info", pdf_path]).output() {
+    match std::process::Command::new("mutool").args(["info", pdf_path]).output() {
         Ok(output) => {
             if output.status.success() {
                 println!("✓ mutool validation passed");

--- a/examples/debug_save_with_objstreams.rs
+++ b/examples/debug_save_with_objstreams.rs
@@ -59,27 +59,25 @@ fn main() {
 
     // Find object streams
     for (id, obj) in &loaded.objects {
-        if let Object::Stream(stream) = obj {
-            if let Ok(type_obj) = stream.dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    if type_name == b"ObjStm" {
-                        println!("\nFound object stream {} 0 R:", id.0);
-                        println!("  Dictionary: {:?}", stream.dict);
-                        println!("  Has Filter: {}", stream.dict.get(b"Filter").is_ok());
-                        println!("  Content size: {} bytes", stream.content.len());
+        if let Object::Stream(stream) = obj
+            && let Ok(type_obj) = stream.dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+            && type_name == b"ObjStm"
+        {
+            println!("\nFound object stream {} 0 R:", id.0);
+            println!("  Dictionary: {:?}", stream.dict);
+            println!("  Has Filter: {}", stream.dict.get(b"Filter").is_ok());
+            println!("  Content size: {} bytes", stream.content.len());
 
-                        // Check if it looks compressed
-                        let looks_compressed = stream.content.iter().take(10).any(|&b| b > 127 || b < 32);
-                        println!("  Content looks compressed: {}", looks_compressed);
+            // Check if it looks compressed
+            let looks_compressed = stream.content.iter().take(10).any(|&b| !(32..=127).contains(&b));
+            println!("  Content looks compressed: {}", looks_compressed);
 
-                        if !looks_compressed {
-                            println!(
-                                "  First 50 bytes: {:?}",
-                                &stream.content[..stream.content.len().min(50)]
-                            );
-                        }
-                    }
-                }
+            if !looks_compressed {
+                println!(
+                    "  First 50 bytes: {:?}",
+                    &stream.content[..stream.content.len().min(50)]
+                );
             }
         }
     }

--- a/examples/extract_text.rs
+++ b/examples/extract_text.rs
@@ -9,8 +9,6 @@ use clap::Parser;
 use lopdf::{Document, LoadOptions, Object};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
-use serde_json;
-use shellexpand;
 
 #[cfg(feature = "async")]
 use tokio::runtime::Builder;
@@ -104,11 +102,11 @@ fn load_pdf<P: AsRef<Path>>(path: P) -> Result<Document, Error> {
 
 #[cfg(feature = "async")]
 fn load_pdf<P: AsRef<Path>>(path: P) -> Result<Document, Error> {
-    Ok(Builder::new_current_thread().build().unwrap().block_on(async move {
+    Builder::new_current_thread().build().unwrap().block_on(async move {
         Document::load_with_options(path, LoadOptions::with_filter(filter_func))
             .await
-            .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))
-    })?)
+            .map_err(|e| Error::other(e.to_string()))
+    })
 }
 
 fn get_pdf_text(doc: &Document) -> Result<PdfText, Error> {
@@ -122,10 +120,9 @@ fn get_pdf_text(doc: &Document) -> Result<PdfText, Error> {
         .map(
             |(page_num, page_id): (u32, (u32, u16))| -> Result<(u32, Vec<String>), Error> {
                 let text = doc.extract_text(&[page_num]).map_err(|e| {
-                    Error::new(
-                        ErrorKind::Other,
-                        format!("Failed to extract text from page {page_num} id={page_id:?}: {e:}"),
-                    )
+                    Error::other(format!(
+                        "Failed to extract text from page {page_num} id={page_id:?}: {e:}"
+                    ))
                 })?;
                 Ok((
                     page_num,

--- a/examples/extract_toc.rs
+++ b/examples/extract_toc.rs
@@ -6,8 +6,6 @@ use std::time::Instant;
 
 use clap::Parser;
 use lopdf::{Document, LoadOptions, Object};
-use serde_json;
-use shellexpand;
 
 #[cfg(feature = "async")]
 use tokio::runtime::Builder;
@@ -95,11 +93,11 @@ fn load_pdf<P: AsRef<Path>>(path: P) -> Result<Document, Error> {
 
 #[cfg(feature = "async")]
 fn load_pdf<P: AsRef<Path>>(path: P) -> Result<Document, Error> {
-    Ok(Builder::new_current_thread().build().unwrap().block_on(async move {
+    Builder::new_current_thread().build().unwrap().block_on(async move {
         Document::load_with_options(path, LoadOptions::with_filter(filter_func))
             .await
-            .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))
-    })?)
+            .map_err(|e| Error::other(e.to_string()))
+    })
 }
 
 fn pdf2toc<P: AsRef<Path> + Debug>(path: P, output: P, pretty: bool) -> Result<(), Error> {
@@ -108,7 +106,7 @@ fn pdf2toc<P: AsRef<Path> + Debug>(path: P, output: P, pretty: bool) -> Result<(
     if doc.is_encrypted() {
         return Err(Error::new(ErrorKind::InvalidInput, "Password missing!"));
     }
-    let toc = doc.get_toc().map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
+    let toc = doc.get_toc().map_err(|e| Error::other(e.to_string()))?;
     if !toc.errors.is_empty() {
         eprintln!("{path:?} has {} errors:", toc.errors.len());
         for error in &toc.errors[..toc.errors.len().min(10)] {

--- a/examples/final_compression_test.rs
+++ b/examples/final_compression_test.rs
@@ -85,19 +85,17 @@ fn main() {
     let mut obj_stream_count = 0;
     let mut compressed_count = 0;
 
-    for (_id, obj) in &loaded.objects {
-        if let Object::Stream(stream) = obj {
-            if let Ok(type_obj) = stream.dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    if type_name == b"ObjStm" {
-                        obj_stream_count += 1;
+    for obj in loaded.objects.values() {
+        if let Object::Stream(stream) = obj
+            && let Ok(type_obj) = stream.dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+            && type_name == b"ObjStm"
+        {
+            obj_stream_count += 1;
 
-                        // Count objects in stream
-                        if let Ok(n) = stream.dict.get(b"N").and_then(|o| o.as_i64()) {
-                            compressed_count += n as usize;
-                        }
-                    }
-                }
+            // Count objects in stream
+            if let Ok(n) = stream.dict.get(b"N").and_then(|o| o.as_i64()) {
+                compressed_count += n as usize;
             }
         }
     }
@@ -109,19 +107,18 @@ fn main() {
     println!("\nVerifying critical objects:");
 
     // Check catalog
-    if let Ok(root_ref) = loaded.trailer.get(b"Root") {
-        if let Object::Reference(cat_id) = root_ref {
-            check_not_compressed(&loaded, *cat_id, "Catalog");
-        }
+    if let Ok(root_ref) = loaded.trailer.get(b"Root")
+        && let Object::Reference(cat_id) = root_ref
+    {
+        check_not_compressed(&loaded, *cat_id, "Catalog");
     }
 
     // Check pages tree
-    if let Ok(catalog) = loaded.catalog() {
-        if let Ok(pages_ref) = catalog.get(b"Pages") {
-            if let Object::Reference(pages_id) = pages_ref {
-                check_not_compressed(&loaded, *pages_id, "Pages tree");
-            }
-        }
+    if let Ok(catalog) = loaded.catalog()
+        && let Ok(pages_ref) = catalog.get(b"Pages")
+        && let Object::Reference(pages_id) = pages_ref
+    {
+        check_not_compressed(&loaded, *pages_id, "Pages tree");
     }
 
     // Check page objects

--- a/examples/inspect_object_stream.rs
+++ b/examples/inspect_object_stream.rs
@@ -37,8 +37,7 @@ fn main() {
 
                         // List first 20 objects
                         println!("\nFirst 20 objects in stream:");
-                        let mut count = 0;
-                        for ((id, generation), obj) in &obj_stream.objects {
+                        for (count, ((id, generation), obj)) in obj_stream.objects.iter().enumerate() {
                             if count >= 20 {
                                 break;
                             }
@@ -49,22 +48,17 @@ fn main() {
                                 let key_count = dict.len();
                                 println!("    Dictionary with {} keys", key_count);
                             }
-                            count += 1;
                         }
 
                         // Check if any page-related objects are in there
                         println!("\nChecking for page-related objects:");
                         for ((id, generation), obj) in &obj_stream.objects {
                             if let Object::Dictionary(dict) = obj {
-                                if let Ok(type_obj) = dict.get(b"Type") {
-                                    if let Ok(type_name) = type_obj.as_name() {
-                                        if type_name == b"Page" {
-                                            println!(
-                                                "  WARNING: Page object {} {} R is in object stream!",
-                                                id, generation
-                                            );
-                                        }
-                                    }
+                                if let Ok(type_obj) = dict.get(b"Type")
+                                    && let Ok(type_name) = type_obj.as_name()
+                                    && type_name == b"Page"
+                                {
+                                    println!("  WARNING: Page object {} {} R is in object stream!", id, generation);
                                 }
 
                                 // Check for font descriptors
@@ -86,19 +80,18 @@ fn main() {
             println!("\n\nChecking critical object locations:");
 
             // Check catalog
-            if let Ok(root_ref) = doc.trailer.get(b"Root") {
-                if let Object::Reference(root_id) = root_ref {
-                    check_object_status(&doc, *root_id, "Catalog (Root)");
-                }
+            if let Ok(root_ref) = doc.trailer.get(b"Root")
+                && let Object::Reference(root_id) = root_ref
+            {
+                check_object_status(&doc, *root_id, "Catalog (Root)");
             }
 
             // Check pages tree
-            if let Ok(catalog) = doc.catalog() {
-                if let Ok(pages_ref) = catalog.get(b"Pages") {
-                    if let Object::Reference(pages_id) = pages_ref {
-                        check_object_status(&doc, *pages_id, "Pages tree root");
-                    }
-                }
+            if let Ok(catalog) = doc.catalog()
+                && let Ok(pages_ref) = catalog.get(b"Pages")
+                && let Object::Reference(pages_id) = pages_ref
+            {
+                check_object_status(&doc, *pages_id, "Pages tree root");
             }
 
             // Check specific page objects

--- a/examples/merge.rs
+++ b/examples/merge.rs
@@ -188,10 +188,10 @@ fn main() {
                 // We have also to merge all dictionaries of the old and the new "Pages" object
                 if let Ok(dictionary) = object.as_dict() {
                     let mut dictionary = dictionary.clone();
-                    if let Some((_, ref object)) = pages_object {
-                        if let Ok(old_dictionary) = object.as_dict() {
-                            dictionary.extend(old_dictionary);
-                        }
+                    if let Some((_, ref object)) = pages_object
+                        && let Ok(old_dictionary) = object.as_dict()
+                    {
+                        dictionary.extend(old_dictionary);
                     }
 
                     pages_object = Some((
@@ -250,10 +250,7 @@ fn main() {
         // Set new "Kids" list (collected from documents pages) for "Pages"
         dictionary.set(
             "Kids",
-            documents_pages
-                .into_keys()
-                .map(|object_id| Object::Reference(object_id))
-                .collect::<Vec<_>>(),
+            documents_pages.into_keys().map(Object::Reference).collect::<Vec<_>>(),
         );
 
         document.objects.insert(page_id, Object::Dictionary(dictionary));
@@ -281,10 +278,10 @@ fn main() {
     document.adjust_zero_pages();
 
     //Set all bookmarks to the PDF Object tree then set the Outlines to the Bookmark content map.
-    if let Some(outline_id) = document.build_outline() {
-        if let Ok(Object::Dictionary(dict)) = document.get_object_mut(catalog_id) {
-            dict.set("Outlines", Object::Reference(outline_id));
-        }
+    if let Some(outline_id) = document.build_outline()
+        && let Ok(Object::Dictionary(dict)) = document.get_object_mut(catalog_id)
+    {
+        dict.set("Outlines", Object::Reference(outline_id));
     }
 
     // Most of the time this does nothing unless there are a lot of streams

--- a/examples/print_annotations.rs
+++ b/examples/print_annotations.rs
@@ -16,7 +16,7 @@ fn args() -> Vec<String> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() != 2 {
-        eprintln!("Usage: {} <pdf-file>", &args[0]);
+        eprintln!("Usage: {} <pdf-file>", args[0]);
         process::exit(1);
     }
 
@@ -38,29 +38,29 @@ fn handle_pdf_page(doc: Document) -> u32 {
             if let Ok(Object::String(c, _)) = a.get_deref(b"Contents", &doc) {
                 println!("  Contents: {:.60}", String::from_utf8_lossy(c).lines().next().unwrap());
             }
-            if subtype == b"Link" {
-                if let Ok(ahref) = a.get_deref(b"A", &doc).and_then(Object::as_dict) {
-                    print!(
-                        "  {} -> ",
-                        ahref
-                            .get_deref(b"S", &doc)
-                            .and_then(Object::as_name)
-                            .map(str::from_utf8)
-                            .unwrap()
-                            .unwrap()
-                    );
-                    if let Ok(d) = ahref.get_deref(b"D", &doc).and_then(Object::as_array) {
-                        println!("{:?}", d);
-                    } else if let Ok(Object::String(u, _)) = ahref.get_deref(b"URI", &doc) {
-                        println!("{}", String::from_utf8_lossy(u));
-                    } else if let Ok(n) = ahref
-                        .get_deref(b"N", &doc)
+            if subtype == b"Link"
+                && let Ok(ahref) = a.get_deref(b"A", &doc).and_then(Object::as_dict)
+            {
+                print!(
+                    "  {} -> ",
+                    ahref
+                        .get_deref(b"S", &doc)
                         .and_then(Object::as_name)
                         .map(str::from_utf8)
                         .unwrap()
-                    {
-                        println!("{}", n);
-                    }
+                        .unwrap()
+                );
+                if let Ok(d) = ahref.get_deref(b"D", &doc).and_then(Object::as_array) {
+                    println!("{:?}", d);
+                } else if let Ok(Object::String(u, _)) = ahref.get_deref(b"URI", &doc) {
+                    println!("{}", String::from_utf8_lossy(u));
+                } else if let Ok(n) = ahref
+                    .get_deref(b"N", &doc)
+                    .and_then(Object::as_name)
+                    .map(str::from_utf8)
+                    .unwrap()
+                {
+                    println!("{}", n);
                 }
             }
         }
@@ -91,6 +91,6 @@ async fn main() {
 
     match Document::load(&args[1]).await {
         Ok(doc) => _ = handle_pdf_page(doc),
-        Err(e) => eprintln!("Error opening {:?}: {:?}", &args[1], e),
+        Err(e) => eprintln!("Error opening {:?}: {:?}", args[1], e),
     }
 }

--- a/examples/test_better_compression.rs
+++ b/examples/test_better_compression.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Simulate compression
     let mut would_compress = Vec::new();
-    for (&id, _obj) in &doc.objects {
+    for &id in doc.objects.keys() {
         if !non_compressible.contains(&id) {
             would_compress.push(id);
         }
@@ -92,18 +92,17 @@ fn find_all_non_compressible_objects(doc: &Document) -> (HashSet<ObjectId>, Hash
         }
 
         // Check object type
-        if let Object::Dictionary(dict) = obj {
-            if let Ok(type_obj) = dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    match type_name {
-                        b"Page" => reason = Some("Is a Page object"),
-                        b"Pages" => reason = Some("Is a Pages object"),
-                        b"Catalog" => reason = Some("Is a Catalog object"),
-                        b"XRef" => reason = Some("Is a cross-reference stream"),
-                        b"ObjStm" => reason = Some("Is an object stream"),
-                        _ => {}
-                    }
-                }
+        if let Object::Dictionary(dict) = obj
+            && let Ok(type_obj) = dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+        {
+            match type_name {
+                b"Page" => reason = Some("Is a Page object"),
+                b"Pages" => reason = Some("Is a Pages object"),
+                b"Catalog" => reason = Some("Is a Catalog object"),
+                b"XRef" => reason = Some("Is a cross-reference stream"),
+                b"ObjStm" => reason = Some("Is an object stream"),
+                _ => {}
             }
         }
 

--- a/examples/test_decryption.rs
+++ b/examples/test_decryption.rs
@@ -79,7 +79,7 @@ async fn main() {
     println!("Number of pages: {}", pages.len());
 
     // Try to extract text
-    if pages.len() > 0 {
+    if !pages.is_empty() {
         let page_numbers: Vec<u32> = pages.keys().cloned().collect();
         match doc.extract_text(&page_numbers) {
             Ok(text) => {

--- a/examples/test_direct_objstream.rs
+++ b/examples/test_direct_objstream.rs
@@ -68,18 +68,16 @@ fn main() {
     let loaded = load_document("test_direct_objstream.pdf");
 
     for (id, obj) in &loaded.objects {
-        if let Object::Stream(stream) = obj {
-            if let Ok(type_obj) = stream.dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    if type_name == b"ObjStm" {
-                        println!("Found object stream {} 0 R", id.0);
-                        println!("  Dict: {:?}", stream.dict);
-                        println!("  Has Filter: {}", stream.dict.get(b"Filter").is_ok());
-                        if let Ok(filter) = stream.dict.get(b"Filter") {
-                            println!("  Filter value: {:?}", filter);
-                        }
-                    }
-                }
+        if let Object::Stream(stream) = obj
+            && let Ok(type_obj) = stream.dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+            && type_name == b"ObjStm"
+        {
+            println!("Found object stream {} 0 R", id.0);
+            println!("  Dict: {:?}", stream.dict);
+            println!("  Has Filter: {}", stream.dict.get(b"Filter").is_ok());
+            if let Ok(filter) = stream.dict.get(b"Filter") {
+                println!("  Filter value: {:?}", filter);
             }
         }
     }

--- a/examples/test_object_stream_creation.rs
+++ b/examples/test_object_stream_creation.rs
@@ -97,20 +97,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut objstm_count = 0;
     let mut compressed_count = 0;
 
-    for (_id, obj) in &compressed_doc.objects {
-        if let Object::Stream(stream) = obj {
-            if let Ok(type_obj) = stream.dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    if type_name == b"ObjStm" {
-                        objstm_count += 1;
-                        // Count objects in this stream
-                        if let Ok(n) = stream.dict.get(b"N") {
-                            if let Ok(n_val) = n.as_i64() {
-                                compressed_count += n_val as usize;
-                            }
-                        }
-                    }
-                }
+    for obj in compressed_doc.objects.values() {
+        if let Object::Stream(stream) = obj
+            && let Ok(type_obj) = stream.dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+            && type_name == b"ObjStm"
+        {
+            objstm_count += 1;
+            // Count objects in this stream
+            if let Ok(n) = stream.dict.get(b"N")
+                && let Ok(n_val) = n.as_i64()
+            {
+                compressed_count += n_val as usize;
             }
         }
     }

--- a/examples/test_object_stream_roundtrip.rs
+++ b/examples/test_object_stream_roundtrip.rs
@@ -94,19 +94,17 @@ fn main() {
     // Check for object streams
     let mut obj_stream_count = 0;
     for (id, obj) in &loaded_doc.objects {
-        if let lopdf::Object::Stream(stream) = obj {
-            if let Ok(type_obj) = stream.dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    if type_name == b"ObjStm" {
-                        obj_stream_count += 1;
-                        println!("Found object stream {} 0 R", id.0);
-                        if let Ok(filter) = stream.dict.get(b"Filter") {
-                            println!("  Has Filter: {:?}", filter);
-                        } else {
-                            println!("  WARNING: No Filter!");
-                        }
-                    }
-                }
+        if let lopdf::Object::Stream(stream) = obj
+            && let Ok(type_obj) = stream.dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+            && type_name == b"ObjStm"
+        {
+            obj_stream_count += 1;
+            println!("Found object stream {} 0 R", id.0);
+            if let Ok(filter) = stream.dict.get(b"Filter") {
+                println!("  Has Filter: {:?}", filter);
+            } else {
+                println!("  WARNING: No Filter!");
             }
         }
     }

--- a/examples/test_structural_compression.rs
+++ b/examples/test_structural_compression.rs
@@ -111,22 +111,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut objstm_found = 0;
     let mut compressed_objects = 0;
 
-    for (_, obj) in &compressed_doc.objects {
-        if let Object::Stream(stream) = obj {
-            if let Ok(type_obj) = stream.dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    if type_name == b"ObjStm" {
-                        objstm_found += 1;
+    for obj in compressed_doc.objects.values() {
+        if let Object::Stream(stream) = obj
+            && let Ok(type_obj) = stream.dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+            && type_name == b"ObjStm"
+        {
+            objstm_found += 1;
 
-                        // Count objects in this stream
-                        if let Ok(n) = stream.dict.get(b"N") {
-                            if let Ok(n_val) = n.as_i64() {
-                                compressed_objects += n_val as usize;
-                                println!("Object stream found with {} objects", n_val);
-                            }
-                        }
-                    }
-                }
+            // Count objects in this stream
+            if let Ok(n) = stream.dict.get(b"N")
+                && let Ok(n_val) = n.as_i64()
+            {
+                compressed_objects += n_val as usize;
+                println!("Object stream found with {} objects", n_val);
             }
         }
     }

--- a/examples/verify_page_compression.rs
+++ b/examples/verify_page_compression.rs
@@ -30,21 +30,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut total_compressed = 0;
 
     for (id, obj) in &doc.objects {
-        if let Object::Stream(stream) = obj {
-            if let Ok(type_obj) = stream.dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    if type_name == b"ObjStm" {
-                        objstm_count += 1;
+        if let Object::Stream(stream) = obj
+            && let Ok(type_obj) = stream.dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+            && type_name == b"ObjStm"
+        {
+            objstm_count += 1;
 
-                        // Get number of objects in this stream
-                        if let Ok(n) = stream.dict.get(b"N") {
-                            if let Ok(n_val) = n.as_i64() {
-                                total_compressed += n_val;
-                                println!("Object stream {} 0 R contains {} objects", id.0, n_val);
-                            }
-                        }
-                    }
-                }
+            // Get number of objects in this stream
+            if let Ok(n) = stream.dict.get(b"N")
+                && let Ok(n_val) = n.as_i64()
+            {
+                total_compressed += n_val;
+                println!("Object stream {} 0 R contains {} objects", id.0, n_val);
             }
         }
     }
@@ -57,17 +55,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut pages_count = 0;
     let mut catalog_count = 0;
 
-    for (_id, obj) in &doc.objects {
-        if let Object::Dictionary(dict) = obj {
-            if let Ok(type_obj) = dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    match type_name {
-                        b"Page" => page_count += 1,
-                        b"Pages" => pages_count += 1,
-                        b"Catalog" => catalog_count += 1,
-                        _ => {}
-                    }
-                }
+    for obj in doc.objects.values() {
+        if let Object::Dictionary(dict) = obj
+            && let Ok(type_obj) = dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+        {
+            match type_name {
+                b"Page" => page_count += 1,
+                b"Pages" => pages_count += 1,
+                b"Catalog" => catalog_count += 1,
+                _ => {}
             }
         }
     }

--- a/examples/verify_pdf.rs
+++ b/examples/verify_pdf.rs
@@ -40,15 +40,13 @@ fn main() {
 
             // Check for object streams
             let mut obj_stream_count = 0;
-            for (_id, obj) in &doc.objects {
-                if let Object::Stream(stream) = obj {
-                    if let Ok(type_obj) = stream.dict.get(b"Type") {
-                        if let Ok(type_name) = type_obj.as_name() {
-                            if type_name == b"ObjStm" {
-                                obj_stream_count += 1;
-                            }
-                        }
-                    }
+            for obj in doc.objects.values() {
+                if let Object::Stream(stream) = obj
+                    && let Ok(type_obj) = stream.dict.get(b"Type")
+                    && let Ok(type_name) = type_obj.as_name()
+                    && type_name == b"ObjStm"
+                {
+                    obj_stream_count += 1;
                 }
             }
 

--- a/pdfutil/Cargo.toml
+++ b/pdfutil/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/J-F-Liu/lopdf.git"
 version = "0.4.0"
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 env_logger = "0.11"
 log = "0.4"
-lopdf = {version = "*", path = "../"}
+lopdf = { version = "*", path = "../" }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -100,7 +100,7 @@ mod time_impl {
             Object::string_literal(
                 format!(
                     "D:{}",
-                    date.format(&FormatItem::Literal("%Y%m%d%H%M%SZ".as_bytes())).unwrap()
+                    date.format(&FormatItem::StringLiteral("%Y%m%d%H%M%SZ")).unwrap()
                 )
                 .into_bytes(),
             )
@@ -111,7 +111,7 @@ mod time_impl {
         fn from(date: OffsetDateTime) -> Self {
             Object::string_literal({
                 // D:%Y%m%d%H%M%S:%z'
-                let format = time::format_description::parse(
+                let format = time::format_description::parse_borrowed::<3>(
                     "D:[year][month][day][hour][minute][second][offset_hour sign:mandatory]'[offset_minute]'",
                 )
                 .unwrap();
@@ -128,7 +128,7 @@ mod time_impl {
         type Error = time::Error;
 
         fn try_from(value: super::DateTime) -> Result<OffsetDateTime, Self::Error> {
-            let format = time::format_description::parse(
+            let format = time::format_description::parse_borrowed::<3>(
                 "[year][month][day][hour][minute][second][offset_hour sign:mandatory][offset_minute]",
             )
             .unwrap();
@@ -158,14 +158,7 @@ impl Object {
     // Parses the `D`, `:` and `\` out of a `Object::String` to parse the date time
     fn datetime_string(&self) -> Option<String> {
         if let Object::String(bytes, _) = self {
-            String::from_utf8(
-                bytes
-                    .iter()
-                    .filter(|b| ![b'D', b':', b'\''].contains(b))
-                    .cloned()
-                    .collect(),
-            )
-            .ok()
+            String::from_utf8(bytes.iter().filter(|b| !b"D:'".contains(b)).cloned().collect()).ok()
         } else {
             None
         }

--- a/src/document.rs
+++ b/src/document.rs
@@ -472,7 +472,7 @@ impl Document {
         // Add the objects from the object streams now that they have been decrypted.
         let mut object_streams = vec![];
 
-        for (_, object) in self.objects.iter_mut() {
+        for object in self.objects.values_mut() {
             let Ok(ref mut stream) = object.as_stream_mut() else {
                 continue;
             };
@@ -830,22 +830,22 @@ impl Iterator for PageTreeIter<'_> {
 
                 self.kids = Some(new_kids);
 
-                if let Ok(kid_id) = kid.as_reference() {
-                    if let Ok(type_name) = self.doc.get_dictionary(kid_id).and_then(Dictionary::get_type) {
-                        match type_name {
-                            b"Page" => {
-                                return Some(kid_id);
-                            }
-                            b"Pages" if self.stack.len() < Self::PAGE_TREE_DEPTH_LIMIT => {
-                                let kids = self.kids.unwrap();
-                                if !kids.is_empty() {
-                                    self.stack.push(kids);
-                                }
-                                self.kids = Self::kids(self.doc, kid_id);
-                            }
-                            b"Pages" => {}
-                            _ => {}
+                if let Ok(kid_id) = kid.as_reference()
+                    && let Ok(type_name) = self.doc.get_dictionary(kid_id).and_then(Dictionary::get_type)
+                {
+                    match type_name {
+                        b"Page" => {
+                            return Some(kid_id);
                         }
+                        b"Pages" if self.stack.len() < Self::PAGE_TREE_DEPTH_LIMIT => {
+                            let kids = self.kids.unwrap();
+                            if !kids.is_empty() {
+                                self.stack.push(kids);
+                            }
+                            self.kids = Self::kids(self.doc, kid_id);
+                        }
+                        b"Pages" => {}
+                        _ => {}
                     }
                 }
             }

--- a/src/encodings/cmap.rs
+++ b/src/encodings/cmap.rs
@@ -129,13 +129,13 @@ impl ToUnicodeCMap {
                         }
                     };
 
-                    if let Some(uni_seq) = unicode_sequence {
-                        if !uni_seq.is_empty() {
-                            rev_map.entry(uni_seq).or_insert_with(Vec::new).push(ReverseCMapEntry {
-                                source_code: src_code,
-                                code_len,
-                            });
-                        }
+                    if let Some(uni_seq) = unicode_sequence
+                        && !uni_seq.is_empty()
+                    {
+                        rev_map.entry(uni_seq).or_insert_with(Vec::new).push(ReverseCMapEntry {
+                            source_code: src_code,
+                            code_len,
+                        });
                     }
                 }
             }

--- a/src/encryption/algorithms.rs
+++ b/src/encryption/algorithms.rs
@@ -3,7 +3,7 @@ use super::rc4::Rc4;
 use crate::encodings;
 use crate::encryption::Permissions;
 use crate::{Document, Error, Object};
-use aes::cipher::{BlockDecryptMut as _, BlockEncryptMut as _, KeyInit as _, KeyIvInit as _};
+use aes::cipher::{BlockModeDecrypt as _, BlockModeEncrypt as _, KeyInit as _, KeyIvInit as _};
 use md5::{Digest as _, Md5};
 use rand::RngExt as _;
 use sha2::{Sha256, Sha384, Sha512};
@@ -14,6 +14,11 @@ type Aes256EbcEnc = ecb::Encryptor<aes::Aes256>;
 
 type Aes256CbcDec = cbc::Decryptor<aes::Aes256>;
 type Aes256EbcDec = ecb::Decryptor<aes::Aes256>;
+type AesBlock = aes::cipher::Block<aes::Aes128>;
+
+fn aes_block_mut(block: &mut [u8]) -> &mut AesBlock {
+    block.try_into().expect("AES block must be 16 bytes")
+}
 
 // If the password string is less than 32 bytes long, pad it by appending the required number of
 // additional bytes from the beginning of the following padding string.
@@ -93,7 +98,7 @@ impl TryFrom<&Document> for PasswordAlgorithm {
             // bits.
             5 => (),
             // Unknown codes.
-            _ => return Err(DecryptionError::UnsupportedVersion)?,
+            _ => Err(DecryptionError::UnsupportedVersion)?,
         }
 
         // The length of the file encryption key shall only be present if V is 2 or 3 (but
@@ -104,32 +109,32 @@ impl TryFrom<&Document> for PasswordAlgorithm {
                 // with a default value of 40.
                 1 => {
                     if length != 40 {
-                        return Err(DecryptionError::InvalidKeyLength)?;
+                        Err(DecryptionError::InvalidKeyLength)?;
                     }
                 }
                 // The length of the file encryption key shall be a multiple of 8 in the range 40
                 // to and including 128.
                 2..=3 => {
                     if length % 8 != 0 || !(40..=128).contains(&length) {
-                        return Err(DecryptionError::InvalidKeyLength)?;
+                        Err(DecryptionError::InvalidKeyLength)?;
                     }
                 }
                 // The Length field should not be present if V is 4. However, if it is present it
                 // must be 128.
                 4 => {
                     if length != 128 {
-                        return Err(DecryptionError::InvalidKeyLength)?;
+                        Err(DecryptionError::InvalidKeyLength)?;
                     }
                 }
                 // The Length field should not be present if V is 5. However, if it is present it
                 // must be 256.
                 5 => {
                     if length != 256 {
-                        return Err(DecryptionError::InvalidKeyLength)?;
+                        Err(DecryptionError::InvalidKeyLength)?;
                     }
                 }
                 // The Length field may not be present otherwise.
-                _ => return Err(DecryptionError::InvalidKeyLength)?,
+                _ => Err(DecryptionError::InvalidKeyLength)?,
             }
         }
 
@@ -150,7 +155,7 @@ impl TryFrom<&Document> for PasswordAlgorithm {
 
         // The owner value is 32 bytes long if the value of R is 4 or less.
         if revision <= 4 && owner_value.len() != 32 {
-            return Err(DecryptionError::InvalidHashLength)?;
+            Err(DecryptionError::InvalidHashLength)?;
         }
 
         // The owner value is 48 bytes long if the value of R is 5 or greater.
@@ -158,7 +163,7 @@ impl TryFrom<&Document> for PasswordAlgorithm {
         // to the spec-required length so these documents are accepted.
         if revision >= 5 {
             if owner_value.len() < 48 {
-                return Err(DecryptionError::InvalidHashLength)?;
+                Err(DecryptionError::InvalidHashLength)?;
             }
             owner_value.truncate(48);
         }
@@ -173,7 +178,7 @@ impl TryFrom<&Document> for PasswordAlgorithm {
         // The owner encrypted blob is required if R is 5 or greater and the blob shall be 32 bytes
         // long.
         if revision >= 5 && owner_encrypted.len() != 32 {
-            return Err(DecryptionError::InvalidCipherTextLength)?;
+            Err(DecryptionError::InvalidCipherTextLength)?;
         }
 
         // Get the user value and user encrypted blobs.
@@ -186,7 +191,7 @@ impl TryFrom<&Document> for PasswordAlgorithm {
 
         // The user value is 32 bytes long if the value of R is 4 or less.
         if revision <= 4 && user_value.len() != 32 {
-            return Err(DecryptionError::InvalidHashLength)?;
+            Err(DecryptionError::InvalidHashLength)?;
         }
 
         // The user value is 48 bytes long if the value of R is 5 or greater.
@@ -194,7 +199,7 @@ impl TryFrom<&Document> for PasswordAlgorithm {
         // to the spec-required length so these documents are accepted.
         if revision >= 5 {
             if user_value.len() < 48 {
-                return Err(DecryptionError::InvalidHashLength)?;
+                Err(DecryptionError::InvalidHashLength)?;
             }
             user_value.truncate(48);
         }
@@ -209,7 +214,7 @@ impl TryFrom<&Document> for PasswordAlgorithm {
         // The user encrypted blob is required if R is 5 or greater and the blob shall be 32 bytes
         // long.
         if revision >= 5 && user_encrypted.len() != 32 {
-            return Err(DecryptionError::InvalidCipherTextLength)?;
+            Err(DecryptionError::InvalidCipherTextLength)?;
         }
 
         // Get the permission value and permission encrypted blobs.
@@ -231,7 +236,7 @@ impl TryFrom<&Document> for PasswordAlgorithm {
         // The permission encrypted blob is required if R is 65 or greater and the blob shall be
         // 16 bytes long.
         if revision >= 5 && permission_encrypted.len() != 16 {
-            return Err(DecryptionError::InvalidCipherTextLength)?;
+            Err(DecryptionError::InvalidCipherTextLength)?;
         }
 
         Ok(Self {
@@ -414,7 +419,7 @@ impl PasswordAlgorithm {
             let mut decryptor = Aes256CbcDec::new(&key.into(), &iv.into());
 
             for block in owner_encrypted.chunks_exact_mut(16) {
-                decryptor.decrypt_block_mut(block.into());
+                decryptor.decrypt_block(aes_block_mut(block));
             }
 
             return Ok(owner_encrypted);
@@ -444,7 +449,7 @@ impl PasswordAlgorithm {
             let mut decryptor = Aes256CbcDec::new(&key.into(), &iv.into());
 
             for block in user_encrypted.chunks_exact_mut(16) {
-                decryptor.decrypt_block_mut(block.into());
+                decryptor.decrypt_block(aes_block_mut(block));
             }
 
             // Decrypt the 16-byte Perms string using AES-256 in EBC mode with an initialization
@@ -522,13 +527,13 @@ impl PasswordAlgorithm {
             //
             // The 64 repetitions of K0 ensure that K1 is a multiple of 64 bytes, thus a multiple
             // of 16 bytes, i.e., it does not require padding.
-            let key = &k[0..][..16];
-            let iv = &k[16..][..16];
+            let key: &[u8; 16] = k[..16].try_into().expect("hash key must be 16 bytes");
+            let iv: &[u8; 16] = k[16..32].try_into().expect("hash IV must be 16 bytes");
 
             let mut encryptor = Aes128CbcEnc::new(key.into(), iv.into());
 
             for block in k1.chunks_exact_mut(16) {
-                encryptor.encrypt_block_mut(block.into());
+                encryptor.encrypt_block(aes_block_mut(block));
             }
 
             let e = k1;
@@ -945,7 +950,7 @@ impl PasswordAlgorithm {
         let mut encryptor = Aes256CbcEnc::new(&key.into(), &iv.into());
 
         for block in user_encrypted.chunks_exact_mut(16) {
-            encryptor.encrypt_block_mut(block.into());
+            encryptor.encrypt_block(aes_block_mut(block));
         }
 
         Ok((user_value.to_vec(), user_encrypted))
@@ -999,7 +1004,7 @@ impl PasswordAlgorithm {
         let mut encryptor = Aes256CbcEnc::new(&key.into(), &iv.into());
 
         for block in owner_encrypted.chunks_exact_mut(16) {
-            encryptor.encrypt_block_mut(block.into());
+            encryptor.encrypt_block(aes_block_mut(block));
         }
 
         Ok((owner_value.to_vec(), owner_encrypted))
@@ -1036,7 +1041,7 @@ impl PasswordAlgorithm {
         let mut encryptor = Aes256EbcEnc::new(&key.into());
 
         for block in bytes.chunks_exact_mut(16) {
-            encryptor.encrypt_block_mut(block.into());
+            encryptor.encrypt_block(aes_block_mut(block));
         }
 
         // The result (16 bytes) is stored as the Perms string, and checked for validity when the
@@ -1130,7 +1135,7 @@ impl PasswordAlgorithm {
         let mut decryptor = Aes256EbcDec::new(&key.into());
 
         for block in bytes.chunks_exact_mut(16) {
-            decryptor.decrypt_block_mut(block.into());
+            decryptor.decrypt_block(aes_block_mut(block));
         }
 
         // Verify that bytes 9-11 of the result are the characters "a", "d", "b".

--- a/src/encryption/crypt_filters.rs
+++ b/src/encryption/crypt_filters.rs
@@ -2,7 +2,7 @@ use super::DecryptionError;
 use super::pkcs5::Pkcs5;
 use super::rc4::Rc4;
 use crate::ObjectId;
-use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+use aes::cipher::{BlockModeDecrypt, BlockModeEncrypt, KeyIvInit};
 use md5::{Digest as _, Md5};
 use rand::RngExt as _;
 
@@ -120,6 +120,7 @@ impl CryptFilter for Aes128CryptFilter {
         if key.len() != 16 {
             return Err(DecryptionError::InvalidKeyLength);
         }
+        let key: &[u8; 16] = key.try_into().map_err(|_| DecryptionError::InvalidKeyLength)?;
 
         // The ciphertext needs to be a multiple of 16 bytes to include the padding.
         let ciphertext_len = (plaintext.len() + 16) / 16 * 16;
@@ -145,7 +146,7 @@ impl CryptFilter for Aes128CryptFilter {
         // see the Bibliography. For an original message length of M, the pad shall consist of 16 -
         // (M mod 16) bytes whose value shall also be 16 - (M mod 16).
         Aes128CbcEnc::new(key.into(), &iv.into())
-            .encrypt_padded_mut::<Pkcs5>(&mut ciphertext[16..], plaintext.len())
+            .encrypt_padded::<Pkcs5>(&mut ciphertext[16..], plaintext.len())
             // Padding errors should not occur when encrypting, but avoid causing a panic.
             .map_err(|_| DecryptionError::Padding)?;
 
@@ -157,9 +158,10 @@ impl CryptFilter for Aes128CryptFilter {
         if key.len() != 16 {
             return Err(DecryptionError::InvalidKeyLength);
         }
+        let key: &[u8; 16] = key.try_into().map_err(|_| DecryptionError::InvalidKeyLength)?;
 
         // Ensure that the ciphertext length is a multiple of 16 bytes.
-        if ciphertext.len() % 16 != 0 {
+        if !ciphertext.len().is_multiple_of(16) {
             return Err(DecryptionError::InvalidCipherTextLength);
         }
 
@@ -180,7 +182,7 @@ impl CryptFilter for Aes128CryptFilter {
         let data = &mut ciphertext[16..].to_vec();
 
         Ok(Aes128CbcDec::new(key.into(), &iv.into())
-            .decrypt_padded_mut::<Pkcs5>(data)
+            .decrypt_padded::<Pkcs5>(data)
             .map_err(|_| DecryptionError::Padding)?
             .to_vec())
     }
@@ -204,6 +206,7 @@ impl CryptFilter for Aes256CryptFilter {
         if key.len() != 32 {
             return Err(DecryptionError::InvalidKeyLength);
         }
+        let key: &[u8; 32] = key.try_into().map_err(|_| DecryptionError::InvalidKeyLength)?;
 
         // The ciphertext needs to be a multiple of 16 bytes to include the padding.
         let ciphertext_len = (plaintext.len() + 16) / 16 * 16;
@@ -229,7 +232,7 @@ impl CryptFilter for Aes256CryptFilter {
         // see the Bibliography. For an original message length of M, the pad shall consist of 16 -
         // (M mod 16) bytes whose value shall also be 16 - (M mod 16).
         Aes256CbcEnc::new(key.into(), &iv.into())
-            .encrypt_padded_mut::<Pkcs5>(&mut ciphertext[16..], plaintext.len())
+            .encrypt_padded::<Pkcs5>(&mut ciphertext[16..], plaintext.len())
             // Padding errors should not occur when encrypting, but avoid causing a panic.
             .map_err(|_| DecryptionError::Padding)?;
 
@@ -241,9 +244,10 @@ impl CryptFilter for Aes256CryptFilter {
         if key.len() != 32 {
             return Err(DecryptionError::InvalidKeyLength);
         }
+        let key: &[u8; 32] = key.try_into().map_err(|_| DecryptionError::InvalidKeyLength)?;
 
         // Ensure that the ciphertext length is a multiple of 16 bytes.
-        if ciphertext.len() % 16 != 0 {
+        if !ciphertext.len().is_multiple_of(16) {
             return Err(DecryptionError::InvalidCipherTextLength);
         }
 
@@ -264,7 +268,7 @@ impl CryptFilter for Aes256CryptFilter {
         let data = &mut ciphertext[16..].to_vec();
 
         Ok(Aes256CbcDec::new(key.into(), &iv.into())
-            .decrypt_padded_mut::<Pkcs5>(data)
+            .decrypt_padded::<Pkcs5>(data)
             .map_err(|_| DecryptionError::Padding)?
             .to_vec())
     }

--- a/src/encryption/pkcs5.rs
+++ b/src/encryption/pkcs5.rs
@@ -1,4 +1,4 @@
-use aes::cipher::block_padding::{PadType, RawPadding, UnpadError};
+use aes::cipher::block_padding::{Error as PaddingError, Padding};
 
 /// Pad block with bytes with value equal to the number of bytes added.
 ///
@@ -8,7 +8,7 @@ pub struct Pkcs5;
 
 impl Pkcs5 {
     #[inline]
-    fn unpad(block: &[u8], strict: bool) -> Result<&[u8], UnpadError> {
+    fn unpad(block: &[u8], strict: bool) -> Result<&[u8], PaddingError> {
         // TODO: use bounds to check it at compile time
         if block.len() > 16 {
             panic!("block size is too big for PKCS#5");
@@ -16,19 +16,17 @@ impl Pkcs5 {
         let bs = block.len();
         let n = block[bs - 1];
         if n == 0 || n as usize > bs {
-            return Err(UnpadError);
+            return Err(PaddingError);
         }
         let s = bs - n as usize;
         if strict && block[s..bs - 1].iter().any(|&v| v != n) {
-            return Err(UnpadError);
+            return Err(PaddingError);
         }
         Ok(&block[..s])
     }
 }
 
-impl RawPadding for Pkcs5 {
-    const TYPE: PadType = PadType::Reversible;
-
+impl Padding for Pkcs5 {
     #[inline]
     fn raw_pad(block: &mut [u8], pos: usize) {
         // TODO: use bounds to check it at compile time for Padding<B>
@@ -45,7 +43,7 @@ impl RawPadding for Pkcs5 {
     }
 
     #[inline]
-    fn raw_unpad(block: &[u8]) -> Result<&[u8], UnpadError> {
+    fn raw_unpad(block: &[u8]) -> Result<&[u8], PaddingError> {
         Pkcs5::unpad(block, true)
     }
 }

--- a/src/object_stream.rs
+++ b/src/object_stream.rs
@@ -253,31 +253,30 @@ impl ObjectStream {
         }
 
         // Rule 3: Only encryption dictionary cannot be compressed from trailer references
-        if let Ok(Object::Reference(encrypt_ref)) = doc.trailer.get(b"Encrypt") {
-            if id == *encrypt_ref {
-                return false;
-            }
+        if let Ok(Object::Reference(encrypt_ref)) = doc.trailer.get(b"Encrypt")
+            && id == *encrypt_ref
+        {
+            return false;
         }
 
         // Rule 4: Specific object types that cannot be compressed
-        if let Object::Dictionary(dict) = obj {
-            if let Ok(type_obj) = dict.get(b"Type") {
-                if let Ok(type_name) = type_obj.as_name() {
-                    match type_name {
-                        // Cross-reference streams and object streams cannot be compressed
-                        b"XRef" => return false,
-                        b"ObjStm" => return false,
+        if let Object::Dictionary(dict) = obj
+            && let Ok(type_obj) = dict.get(b"Type")
+            && let Ok(type_name) = type_obj.as_name()
+        {
+            match type_name {
+                // Cross-reference streams and object streams cannot be compressed
+                b"XRef" => return false,
+                b"ObjStm" => return false,
 
-                        // Catalog can only be excluded in linearized PDFs
-                        b"Catalog" if Self::is_linearized(doc) => {
-                            return false;
-                        }
-                        b"Catalog" => {}
-
-                        // Page, Pages, and all other types CAN be compressed
-                        _ => {}
-                    }
+                // Catalog can only be excluded in linearized PDFs
+                b"Catalog" if Self::is_linearized(doc) => {
+                    return false;
                 }
+                b"Catalog" => {}
+
+                // Page, Pages, and all other types CAN be compressed
+                _ => {}
             }
         }
 
@@ -291,10 +290,10 @@ impl ObjectStream {
         // linearization dictionary with /Linearized entry
         // For simplicity, we check if any object has a /Linearized entry
         for obj in doc.objects.values() {
-            if let Object::Dictionary(dict) = obj {
-                if dict.has(b"Linearized") {
-                    return true;
-                }
+            if let Object::Dictionary(dict) = obj
+                && dict.has(b"Linearized")
+            {
+                return true;
             }
         }
         false

--- a/src/outlines.rs
+++ b/src/outlines.rs
@@ -68,20 +68,19 @@ impl Document {
             Err(_) => self.get_object(node.as_reference()?)?.as_dict()?,
         };
         loop {
-            if let Ok(Some(outline)) = self.get_outline(node, named_destinations) {
-                if let Some(ref mut outlines) = outlines {
-                    outlines.push(outline);
-                }
+            if let Ok(Some(outline)) = self.get_outline(node, named_destinations)
+                && let Some(ref mut outlines) = outlines
+            {
+                outlines.push(outline);
             }
             if let Ok(first) = node.get(b"First") {
                 let sub_outlines = Vec::new();
                 let sub_outlines = self.get_outlines(Some(first.clone()), Some(sub_outlines), named_destinations)?;
-                if let Some(sub_outlines) = sub_outlines {
-                    if !sub_outlines.is_empty() {
-                        if let Some(ref mut outlines) = outlines {
-                            outlines.push(Outline::SubOutlines(sub_outlines));
-                        }
-                    }
+                if let Some(sub_outlines) = sub_outlines
+                    && !sub_outlines.is_empty()
+                    && let Some(ref mut outlines) = outlines
+                {
+                    outlines.push(Outline::SubOutlines(sub_outlines));
                 }
             }
             node = match self.get_dict_in_dict(node, b"Next") {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,13 +1,13 @@
 use super::{Dictionary, Object, ObjectId, Reader, Stream, StringFormat};
+use crate::Error;
 use crate::content::*;
 use crate::error;
 use crate::xref::*;
-use crate::Error;
 use std::collections::HashSet;
 use std::str::{self, FromStr};
 
 use nom::branch::alt;
-use nom::bytes::complete::{tag, take, take_while, take_while1, take_while_m_n};
+use nom::bytes::complete::{tag, take, take_while, take_while_m_n, take_while1};
 use nom::character::complete::multispace1;
 use nom::character::complete::{digit0, digit1, one_of};
 use nom::character::complete::{space0, space1};
@@ -435,10 +435,10 @@ fn _indirect_object<'a>(
     let (i, (_, object_id)) = terminated((space, object_id), pair(tag(&b"obj"[..]), space))
         .parse(input)
         .map_err(|_| Error::IndirectObject { offset })?;
-    if let Some(expected_id) = expected_id {
-        if object_id != expected_id {
-            return Err(crate::error::Error::ObjectIdMismatch);
-        }
+    if let Some(expected_id) = expected_id
+        && object_id != expected_id
+    {
+        return Err(crate::error::Error::ObjectIdMismatch);
     }
 
     let object_offset = input.len() - i.len();
@@ -512,10 +512,8 @@ fn xref(input: ParserInput) -> NomResult<Xref> {
             || -> Xref { Xref::new(0, XrefType::CrossReferenceTable) },
             |mut xref, ((start, _count), entries)| {
                 for (index, ((offset, generation), is_normal)) in entries.into_iter().enumerate() {
-                    if is_normal {
-                        if let Ok(generation) = generation.try_into() {
-                            xref.insert((start + index) as u32, XrefEntry::Normal { offset, generation });
-                        }
+                    if is_normal && let Ok(generation) = generation.try_into() {
+                        xref.insert((start + index) as u32, XrefEntry::Normal { offset, generation });
                     }
                 }
                 xref

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -1,15 +1,15 @@
 use log::warn;
 
+use crate::{Dictionary, Object, ObjectId, Stream, parser};
 use crate::{
+    Error, Result,
     content::{Content, Operation},
     document::Document,
     encodings::Encoding,
     error::ParseError,
     object::Object::Name,
     xref::{Xref, XrefEntry, XrefType},
-    Error, Result,
 };
-use crate::{parser, Dictionary, Object, ObjectId, Stream};
 use std::{
     collections::BTreeMap,
     io::{Cursor, Read},
@@ -585,8 +585,8 @@ mod tests {
     #[cfg(not(feature = "async"))]
     #[test]
     fn load_and_save() {
-        use crate::creator::tests::{create_document, save_document};
         use crate::Document;
+        use crate::creator::tests::{create_document, save_document};
 
         // test load_from() and save_to()
         use std::fs::File;
@@ -655,9 +655,9 @@ mod tests {
     /// recover the string operand and emit a line break before it.
     #[test]
     fn extract_text_handles_apostrophe_show_text_op() {
+        use crate::Object;
         use crate::content::Operation;
         use crate::creator::tests::create_document_with_operations;
-        use crate::Object;
 
         let doc = create_document_with_operations(vec![
             Operation::new("BT", vec![]),
@@ -681,9 +681,9 @@ mod tests {
     /// rendering spacing and don't affect the extracted character sequence.
     #[test]
     fn extract_text_handles_quote_show_text_op() {
+        use crate::Object;
         use crate::content::Operation;
         use crate::creator::tests::create_document_with_operations;
-        use crate::Object;
 
         let doc = create_document_with_operations(vec![
             Operation::new("BT", vec![]),
@@ -703,9 +703,9 @@ mod tests {
     /// newline rather than running together.
     #[test]
     fn extract_text_preserves_line_breaks_for_t_star() {
+        use crate::Object;
         use crate::content::Operation;
         use crate::creator::tests::create_document_with_operations;
-        use crate::Object;
 
         let doc = create_document_with_operations(vec![
             Operation::new("BT", vec![]),

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -7,25 +7,25 @@ use std::io::Write;
 impl Document {
     /// Change producer of document information dictionary.
     pub fn change_producer(&mut self, producer: &str) {
-        if let Ok(info) = self.trailer.get_mut(b"Info") {
-            if let Some(dict) = match info {
+        if let Ok(info) = self.trailer.get_mut(b"Info")
+            && let Some(dict) = match info {
                 Object::Dictionary(dict) => Some(dict),
                 Object::Reference(id) => self.objects.get_mut(id).and_then(|o| o.as_dict_mut().ok()),
                 _ => None,
-            } {
-                dict.set("Producer", Object::string_literal(producer));
             }
+        {
+            dict.set("Producer", Object::string_literal(producer));
         }
     }
 
     /// Compress PDF stream objects.
     pub fn compress(&mut self) {
         for object in self.objects.values_mut() {
-            if let Object::Stream(stream) = object {
-                if stream.allows_compression {
-                    // Ignore any error and continue to compress other streams.
-                    let _ = stream.compress();
-                }
+            if let Object::Stream(stream) = object
+                && stream.allows_compression
+            {
+                // Ignore any error and continue to compress other streams.
+                let _ = stream.compress();
             }
         }
     }
@@ -208,10 +208,10 @@ impl Document {
             }
 
             let action = |object: &mut Object| {
-                if let Object::Reference(id) = object {
-                    if replace.contains_key(id) {
-                        *id = replace[id];
-                    }
+                if let Object::Reference(id) = object
+                    && let Some(new_id) = replace.get(id)
+                {
+                    *id = *new_id;
                 }
             };
 
@@ -249,10 +249,10 @@ impl Document {
         }
 
         let action = |object: &mut Object| {
-            if let Object::Reference(id) = object {
-                if replace.contains_key(id) {
-                    *id = replace[id];
-                }
+            if let Object::Reference(id) = object
+                && let Some(new_id) = replace.get(id)
+            {
+                *id = *new_id;
             }
         };
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -708,12 +708,11 @@ impl Reader<'_> {
         match pages_dict.get_type() {
             Ok(type_name) if type_name == b"Page" => Ok(1),
             Ok(type_name) if type_name == b"Pages" => {
-                if let Ok(count_obj) = pages_dict.get(b"Count") {
-                    if let Ok(count) = count_obj.as_i64() {
-                        if count >= 0 {
-                            return Ok(count as u32);
-                        }
-                    }
+                if let Ok(count_obj) = pages_dict.get(b"Count")
+                    && let Ok(count) = count_obj.as_i64()
+                    && count >= 0
+                {
+                    return Ok(count as u32);
                 }
 
                 let kids = match pages_dict.get(b"Kids").and_then(Object::as_array) {
@@ -723,10 +722,10 @@ impl Reader<'_> {
 
                 let mut total = 0u32;
                 for kid in kids.iter() {
-                    if let Ok(kid_ref) = kid.as_reference() {
-                        if let Ok(count) = self.get_pages_tree_count(kid_ref, seen) {
-                            total += count;
-                        }
+                    if let Ok(kid_ref) = kid.as_reference()
+                        && let Ok(count) = self.get_pages_tree_count(kid_ref, seen)
+                    {
+                        total += count;
                     }
                 }
                 Ok(total)
@@ -746,12 +745,11 @@ impl Reader<'_> {
 
         //The binary_mark is in line 2 after the pdf version. If at other line number, then will be declared as invalid
         // pdf.
-        if let Some(pos) = self.buffer.iter().position(|&byte| byte == b'\n') {
-            if let Some(binary_mark) = parser::binary_mark(&self.buffer[pos + 1..]) {
-                if binary_mark.iter().all(|&byte| byte >= 128) {
-                    self.document.binary_mark = binary_mark;
-                }
-            }
+        if let Some(pos) = self.buffer.iter().position(|&byte| byte == b'\n')
+            && let Some(binary_mark) = parser::binary_mark(&self.buffer[pos + 1..])
+            && binary_mark.iter().all(|&byte| byte >= 128)
+        {
+            self.document.binary_mark = binary_mark;
         }
 
         let xref_start = Self::get_xref_start(self.buffer)?;
@@ -862,10 +860,10 @@ impl Reader<'_> {
                 .and_then(|o| o.as_reference().ok());
 
             for (obj_id, raw_bytes) in &self.raw_objects {
-                if let Some(enc_ref) = encrypt_ref {
-                    if *obj_id == enc_ref {
-                        continue;
-                    }
+                if let Some(enc_ref) = encrypt_ref
+                    && *obj_id == enc_ref
+                {
+                    continue;
                 }
 
                 if let Ok((id, mut obj)) = self.parse_raw_object(raw_bytes) {
@@ -884,19 +882,19 @@ impl Reader<'_> {
             }
 
             for (container_id, objects_in_stream) in streams_to_process {
-                if let Some(container_obj) = self.document.objects.get_mut(&(container_id, 0)) {
-                    if let Ok(stream) = container_obj.as_stream_mut() {
-                        match ObjectStream::new(stream) {
-                            Ok(object_stream) => {
-                                for (obj_num, _index) in objects_in_stream {
-                                    let obj_id = (obj_num, 0);
-                                    if let Some(obj) = object_stream.objects.get(&obj_id) {
-                                        self.document.objects.insert(obj_id, obj.clone());
-                                    }
+                if let Some(container_obj) = self.document.objects.get_mut(&(container_id, 0))
+                    && let Ok(stream) = container_obj.as_stream_mut()
+                {
+                    match ObjectStream::new(stream) {
+                        Ok(object_stream) => {
+                            for (obj_num, _index) in objects_in_stream {
+                                let obj_id = (obj_num, 0);
+                                if let Some(obj) = object_stream.objects.get(&obj_id) {
+                                    self.document.objects.insert(obj_id, obj.clone());
                                 }
                             }
-                            Err(_e) => {}
                         }
+                        Err(_e) => {}
                     }
                 }
             }
@@ -1103,10 +1101,10 @@ impl Reader<'_> {
         }
         already_seen.insert(id);
 
-        if let Some(entry) = self.document.reference_table.get(id.0) {
-            if matches!(entry, XrefEntry::Compressed { .. }) {
-                return self.get_compressed_object(id);
-            }
+        if let Some(entry) = self.document.reference_table.get(id.0)
+            && matches!(entry, XrefEntry::Compressed { .. })
+        {
+            return self.get_compressed_object(id);
         }
 
         let offset = self.get_offset(id)?;
@@ -1119,10 +1117,10 @@ impl Reader<'_> {
                 .get(b"Encrypt")
                 .ok()
                 .and_then(|o| o.as_reference().ok());
-            if let Some(enc_ref) = encrypt_ref {
-                if id != enc_ref {
-                    encryption::decrypt_object(state, id, &mut obj).map_err(Error::Decryption)?;
-                }
+            if let Some(enc_ref) = encrypt_ref
+                && id != enc_ref
+            {
+                encryption::decrypt_object(state, id, &mut obj).map_err(Error::Decryption)?;
             }
         }
 
@@ -1135,10 +1133,10 @@ impl Reader<'_> {
                 let offset = self.get_offset(encrypt_ref)?;
                 let (_, encrypt_obj) = self.read_object(offset as usize, Some(encrypt_ref), &mut HashSet::new())?;
                 self.document.objects.insert(encrypt_ref, encrypt_obj);
-            } else if let Some(raw_bytes) = self.raw_objects.get(&encrypt_ref) {
-                if let Ok((_, obj)) = self.parse_raw_object(raw_bytes) {
-                    self.document.objects.insert(encrypt_ref, obj);
-                }
+            } else if let Some(raw_bytes) = self.raw_objects.get(&encrypt_ref)
+                && let Ok((_, obj)) = self.parse_raw_object(raw_bytes)
+            {
+                self.document.objects.insert(encrypt_ref, obj);
             }
         }
         Ok(())
@@ -1262,7 +1260,7 @@ impl Reader<'_> {
     fn get_xref_start(buffer: &[u8]) -> Result<usize> {
         let seek_pos = buffer.len() - cmp::min(buffer.len(), 512);
         Self::search_substring(buffer, b"%%EOF", seek_pos)
-            .and_then(|eof_pos| if eof_pos > 25 { Some(eof_pos) } else { None })
+            .filter(|&eof_pos| eof_pos > 25)
             .and_then(|eof_pos| Self::search_substring(&buffer[..eof_pos], b"startxref", eof_pos - 25))
             .ok_or(Error::Xref(XrefError::Start))
             .and_then(|xref_pos| {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -114,14 +114,12 @@ impl Document {
         // Categorize objects
         for (&(id, generation), object) in &self.objects {
             // Skip existing object streams - we'll create new ones
-            if let Object::Stream(stream) = object {
-                if let Ok(type_obj) = stream.dict.get(b"Type") {
-                    if let Ok(type_name) = type_obj.as_name() {
-                        if type_name == b"ObjStm" {
-                            continue; // Skip existing object streams
-                        }
-                    }
-                }
+            if let Object::Stream(stream) = object
+                && let Ok(type_obj) = stream.dict.get(b"Type")
+                && let Ok(type_name) = type_obj.as_name()
+                && type_name == b"ObjStm"
+            {
+                continue; // Skip existing object streams
             }
 
             if generation == 0 && ObjectStream::can_be_compressed((id, generation), object, self) {
@@ -294,11 +292,11 @@ impl IncrementalDocument {
             self.get_prev_documents().reference_table.cross_reference_type,
         );
 
-        if let Some(last_byte) = prev_document_bytes.last() {
-            if *last_byte != b'\n' {
-                // Add a newline if it was not already present
-                writeln!(target)?;
-            }
+        if let Some(last_byte) = prev_document_bytes.last()
+            && *last_byte != b'\n'
+        {
+            // Add a newline if it was not already present
+            writeln!(target)?;
         }
         writeln!(target, "%PDF-{}", self.new_document.version)?;
 

--- a/tests/decryption.rs
+++ b/tests/decryption.rs
@@ -1,6 +1,9 @@
 use lopdf::{Document, Object};
 
 #[cfg(not(feature = "async"))]
+use lopdf::LoadOptions;
+
+#[cfg(not(feature = "async"))]
 #[test]
 fn test_load_encrypted_pdf_from_assets() {
     // Test loading the existing encrypted.pdf file
@@ -849,7 +852,7 @@ fn test_load_mem_with_password() {
     let mut buffer = Vec::new();
     doc.save_to(&mut buffer).unwrap();
 
-    let loaded_doc = Document::load_mem_with_password(&buffer, "mem_user").unwrap();
+    let loaded_doc = Document::load_mem_with_options(&buffer, LoadOptions::with_password("mem_user")).unwrap();
     assert!(
         !loaded_doc.is_encrypted(),
         "Should not appear encrypted after decryption"

--- a/tests/document_load_performance.rs
+++ b/tests/document_load_performance.rs
@@ -1,4 +1,6 @@
+#[cfg(not(feature = "async"))]
 use lopdf::Document;
+#[cfg(not(feature = "async"))]
 use std::time::Instant;
 
 #[cfg(not(feature = "async"))]

--- a/tests/load_options_test.rs
+++ b/tests/load_options_test.rs
@@ -1,8 +1,6 @@
-use lopdf::{Document, LoadOptions, Object};
-
 #[cfg(not(feature = "async"))]
 mod sync_tests {
-    use super::*;
+    use lopdf::{Document, LoadOptions, Object};
     use std::fs::File;
 
     #[test]

--- a/tests/modify.rs
+++ b/tests/modify.rs
@@ -87,9 +87,7 @@ mod tests_with_parsing {
         assert_eq!(text, "🔧🔨\n🔧\n🔨\n");
     }
 
-    fn build_doc_with_tj_array(
-        content_bytes: Vec<u8>,
-    ) -> Document {
+    fn build_doc_with_tj_array(content_bytes: Vec<u8>) -> Document {
         use lopdf::dictionary;
 
         let mut doc = Document::with_version("1.5");
@@ -139,8 +137,7 @@ mod tests_with_parsing {
     fn replace_text_in_tj_array_doc() -> Result<Document> {
         // Content uses the TJ operator with a single-string array containing
         // all 12 characters of "Hello World!".
-        let content =
-            b"BT\n/F1 12 Tf\n100 700 Td\n[(Hello World!)] TJ\nET\n".to_vec();
+        let content = b"BT\n/F1 12 Tf\n100 700 Td\n[(Hello World!)] TJ\nET\n".to_vec();
         let mut doc = build_doc_with_tj_array(content);
         doc.replace_text(1, "Hello World!", "Modified text!", None)?;
         Ok(doc)

--- a/tests/object_stream_edge_cases_test.rs
+++ b/tests/object_stream_edge_cases_test.rs
@@ -98,7 +98,7 @@ fn test_trailer_with_all_pdf_types() {
     doc.trailer.set("Null", Object::Null);
     doc.trailer.set("Bool", Object::Boolean(true));
     doc.trailer.set("Int", Object::Integer(42));
-    doc.trailer.set("Real", Object::Real(3.14159));
+    doc.trailer.set("Real", Object::Real(1.25));
     doc.trailer
         .set("String", Object::String(b"test".to_vec(), lopdf::StringFormat::Literal));
     doc.trailer.set("Name", Object::Name(b"Test".to_vec()));

--- a/tests/object_stream_methods_test.rs
+++ b/tests/object_stream_methods_test.rs
@@ -414,10 +414,7 @@ fn test_loads_catalog_from_later_generated_object_stream() {
 
     let content = String::from_utf8_lossy(&buffer);
     let objstm_count = content.matches("/ObjStm").count();
-    assert!(
-        objstm_count >= 2,
-        "should have multiple object streams"
-    );
+    assert!(objstm_count >= 2, "should have multiple object streams");
 
     let loaded = Document::load_mem(&buffer).unwrap();
     loaded

--- a/tests/object_stream_performance_test.rs
+++ b/tests/object_stream_performance_test.rs
@@ -28,10 +28,10 @@ fn test_can_be_compressed_performance() {
     let mut compressible_count = 0;
 
     for &id in &object_ids {
-        if let Some(obj) = doc.objects.get(&id) {
-            if ObjectStream::can_be_compressed(id, obj, &doc) {
-                compressible_count += 1;
-            }
+        if let Some(obj) = doc.objects.get(&id)
+            && ObjectStream::can_be_compressed(id, obj, &doc)
+        {
+            compressible_count += 1;
         }
     }
 

--- a/tests/page_content.rs
+++ b/tests/page_content.rs
@@ -1,4 +1,4 @@
-use lopdf::{content::Content, dictionary, Document, Stream};
+use lopdf::{Document, Stream, content::Content, dictionary};
 
 #[test]
 fn get_page_content_separates_streams_at_token_boundary() {

--- a/tests/unicode.rs
+++ b/tests/unicode.rs
@@ -120,10 +120,9 @@ end"
 fn get_text_from_first_page(doc: &Document) -> String {
     let mut pages = doc.get_pages();
     let first_page = pages.first_entry().expect("Expected pages to be non empty");
-    let extracted_text = doc
-        .extract_text(&[*first_page.key()])
-        .expect("Expected to find text on the first page");
-    extracted_text
+
+    doc.extract_text(&[*first_page.key()])
+        .expect("Expected to find text on the first page")
 }
 
 #[cfg(not(feature = "async"))]

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -8,8 +8,11 @@ where
     P: AsRef<Path> + Display,
 {
     #[cfg(feature = "async")]
-    let doc = tokio::runtime::Runtime::new()?
-        .block_on(async move { Document::load(&path).await.expect(&*format!("Failed to load {}", path)) });
+    let doc = tokio::runtime::Runtime::new()?.block_on(async move {
+        Document::load(&path)
+            .await
+            .unwrap_or_else(|_| panic!("Failed to load {}", path))
+    });
     #[cfg(not(feature = "async"))]
     let doc = Document::load(path)?;
 
@@ -25,7 +28,7 @@ where
     let doc = tokio::runtime::Runtime::new()?.block_on(async move {
         IncrementalDocument::load(&path)
             .await
-            .expect(&*format!("Failed to load {}", path))
+            .unwrap_or_else(|_| panic!("Failed to load {}", path))
     });
     #[cfg(not(feature = "async"))]
     let doc = IncrementalDocument::load(path)?;


### PR DESCRIPTION
This pull request updates the `lopdf` crate with several improvements focused on dependency upgrades, benchmarking infrastructure, and code modernization. The most significant changes are grouped below:

**Dependency and Tooling Upgrades:**

* Updated the minimum Rust version to 1.88 and upgraded many dependencies in `Cargo.toml` to their latest versions, including `aes`, `cbc`, `flate2`, `indexmap`, `md-5`, `rangemap`, `rayon`, `sha2`, `thiserror`, `weezl`, `clap`, `shellexpand`, and `tempfile`. This ensures better compatibility, security, and access to new features.
* Added `criterion` as a benchmarking dependency and registered two new benchmarks (`datetime`, `parse`) in the manifest.

**Benchmarking Modernization:**

* Migrated all benchmarks from the deprecated nightly-only `test` crate to the stable `criterion` crate. This includes rewriting the logic in `benches/datetime.rs` and `benches/parse.rs` to use `criterion`'s API, enabling more robust and accessible benchmarking. [[1]](diffhunk://#diff-bd308f63647082cb574965a44e6f1354ed58ff2c880e08340a77bbffb14bf03aL1-R56) [[2]](diffhunk://#diff-cfe0cced39d405eb42df6925ae25f7ea2efd083ee3fe050d3d7c01eb6de5f366L1-R47)

**Idiomatic Rust and Code Simplification:**

* Refactored many conditional checks throughout the example files to use Rust's new let-chaining (`if let ... && let ...`) for cleaner, more readable code, especially when pattern-matching nested structures. [[1]](diffhunk://#diff-5178f3d57d1165d513f88e2a97a30bd4eea14623225457a0c7d74b92e98349f9L53-L69) [[2]](diffhunk://#diff-7afced8da2871fa4fb9b3f2101e247e85729c7f804f50c8a57d876ad08bb6e95L50-L59) [[3]](diffhunk://#diff-cb0d5a6d1351c401f69547607e726af876560730e4894c825bfc967ab99f139aL88-L92) [[4]](diffhunk://#diff-06576c1a6ecee75581e1737439fa3550805f4488d9cc3405587ea039f5266058L121-L133) [[5]](diffhunk://#diff-f8c3a24f08c03a5d3dc2e7882e46db34c5b2f81b873377d59ccc067d5124f488L169-L173) [[6]](diffhunk://#diff-5b9e767f61032321ac6571fcb5938aad8c4715f18a1c83e67945d17bf05804d2L74-R78)
* Simplified error handling by using `Error::other(...)` instead of manually constructing `ErrorKind::Other` in the `add_barcode.rs` example. [[1]](diffhunk://#diff-4e0284bf4bd9bbfd89bf625b7f889333138d0bea6c111aac2e6cbd4bee2a1178L4-R4) [[2]](diffhunk://#diff-4e0284bf4bd9bbfd89bf625b7f889333138d0bea6c111aac2e6cbd4bee2a1178L73-R81)
* Used `.or_default()` in place of `.or_insert_with(HashSet::new)` for brevity when building reverse mappings in `analyze_references.rs`.