### PR TITLE
Release 0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 
+<a name="v0.42.0"></a>
+## [v0.42.0](https://github.com/J-F-Liu/lopdf/compare/v0.41.0...v0.42.0) (2026-06-23)
+
+### Feat
+
+* Add Content::decode_strict method for strict parsing
+
+### Fix
+
+* Limit array and dictionary nesting depth
+* Include subsequent ObjStm objects in xref stream range
+* Insert newline between concatenated content streams
+* Consume trailing comments in content streams
+
+### Test
+
+* Escape trailing whitespace in parser tests
+
+
 <a name="v0.41.0"></a>
 ## [v0.41.0](https://github.com/J-F-Liu/lopdf/compare/v0.40.0...v0.41.0) (2026-06-04)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 name = "lopdf"
 readme = "README.md"
 repository = "https://github.com/J-F-Liu/lopdf.git"
-version = "0.41.0"
+version = "0.42.0"
 rust-version = "1.85"
 
 [dependencies]


### PR DESCRIPTION
Cuts a `0.42.0` release so the unreleased fixes on `main` reach crates.io.

- Bumps `Cargo.toml` to `0.42.0`
- Adds the `v0.42.0` CHANGELOG section (matching the existing `git-chglog` style; regenerate at tag time if preferred)

Changes covered since `0.41.0`:
- feat(parser): add `Content::decode_strict` method for strict parsing
- fix(parser): limit array and dictionary nesting depth
- fix(writer): include subsequent ObjStm objects in xref stream range
- fix(document): insert newline between concatenated content streams
- fix(parser): consume trailing comments in content streams

After merge, the remaining release steps need maintainer access: tag `v0.42.0`, `cargo publish`, and create the GitHub release. (The GitHub releases page is also still at 0.39.0 and there's no `v0.41.0` tag, per #489.)

Refs #489