### PR TITLE
feat(reader): report encryption status in PdfMetadata

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -487,6 +487,12 @@ pub struct PdfMetadata {
     pub page_count: u32,
     /// PDF version
     pub version: String,
+    /// Whether the document declares encryption (an `/Encrypt` entry in the
+    /// trailer). When `true`, string and stream contents are encrypted; the
+    /// standard Info fields above are populated only if the document could be
+    /// decrypted — e.g. an empty user password, or a password supplied via a
+    /// `*_with_password` loader.
+    pub encrypted: bool,
 }
 
 struct InfoMetadata {
@@ -588,12 +594,31 @@ impl Reader<'_> {
         self.document.reference_table = xref;
         self.document.trailer = trailer.clone();
 
-        if self.document.trailer.get(b"Encrypt").is_ok() {
-            self.setup_encryption_for_metadata()?;
-        }
+        let encrypted = self.document.trailer.get(b"Encrypt").is_ok();
+        // For encrypted PDFs, set up decryption so the Info dictionary can be
+        // read. If the document is protected by a password we cannot supply,
+        // still report what we have (notably `encrypted`) rather than failing
+        // the whole call; callers needing the Info fields should use a
+        // `*_with_password` loader.
+        let needs_password = if encrypted {
+            match self.setup_encryption_for_metadata() {
+                Ok(()) => false,
+                // No usable password was available (empty password failed and
+                // none was supplied): report `encrypted` without the Info
+                // fields. A wrong supplied password still surfaces as an error.
+                Err(Error::Unimplemented(_)) => true,
+                Err(e) => return Err(e),
+            }
+        } else {
+            false
+        };
 
-        let info_metadata = self.extract_info_metadata()?;
-        let page_count = self.extract_page_count()?;
+        let info_metadata = if needs_password {
+            InfoMetadata::empty()
+        } else {
+            self.extract_info_metadata()?
+        };
+        let page_count = if needs_password { 0 } else { self.extract_page_count()? };
 
         Ok(PdfMetadata {
             title: info_metadata.title,
@@ -607,6 +632,7 @@ impl Reader<'_> {
             custom: info_metadata.custom,
             page_count,
             version,
+            encrypted,
         })
     }
 

--- a/tests/metadata_test.rs
+++ b/tests/metadata_test.rs
@@ -7,6 +7,7 @@ fn test_metadata_extraction_basic() {
 
     assert_eq!(metadata.version, "1.5");
     assert!(metadata.page_count > 0);
+    assert!(!metadata.encrypted);
 }
 
 #[test]
@@ -115,6 +116,7 @@ fn test_metadata_extraction_encrypted_empty_password() {
     assert_eq!(metadata.author, Some("Test Author".to_string()));
     assert_eq!(metadata.subject, Some("Test Subject".to_string()));
     assert_eq!(metadata.page_count, 1);
+    assert!(metadata.encrypted);
 }
 
 #[cfg(not(feature = "async"))]
@@ -185,6 +187,15 @@ fn test_metadata_extraction_encrypted_with_password() {
     assert_eq!(metadata_mem.title, Some("Password Protected PDF".to_string()));
     assert_eq!(metadata_mem.author, Some("Protected Author".to_string()));
     assert_eq!(metadata_mem.page_count, 1);
+    assert!(metadata.encrypted);
+    assert!(metadata_mem.encrypted);
+
+    // Without the password, the loader no longer fails: it reports `encrypted`
+    // and omits the (undecryptable) Info fields rather than erroring.
+    let metadata_no_pw = Document::load_metadata_mem(&buffer).unwrap();
+    assert!(metadata_no_pw.encrypted);
+    assert_eq!(metadata_no_pw.title, None);
+    assert_eq!(metadata_no_pw.author, None);
 }
 
 #[cfg(not(feature = "async"))]


### PR DESCRIPTION
## Summary

Adds a `PdfMetadata.encrypted` field so the metadata-only loaders (`load_metadata*`) can report whether a document is encrypted, without a full `Document::load_mem` parse.

The field is set from the trailer's `/Encrypt` entry. This pairs naturally with the recently added `custom` field — both let `load_metadata_mem` answer common questions (custom Info keys, encryption status) cheaply, which previously required loading the entire object graph.

## Behavior change

When a PDF is encrypted but no usable password is available (the empty password fails and none was supplied), `read_metadata` now returns `PdfMetadata { encrypted: true, .. }` with empty Info fields instead of returning `Error::Unimplemented`. This lets callers learn the document is encrypted from a single cheap call.

- Empty user password (or correct supplied password): full Info fields populated, `encrypted = true`.
- No usable password: best-effort metadata, `encrypted = true`, Info fields empty.
- Wrong supplied password: still `Err(Error::InvalidPassword)` (unchanged).
- Unencrypted: `encrypted = false` (unchanged).

## Tests

`tests/metadata_test.rs`: asserts `encrypted` across the unencrypted, empty-password, and password-protected cases, plus a new assertion that loading a password-protected PDF *without* a password yields `Ok` with `encrypted = true` and no Info fields. Full suite passes (242 passed, 3 ignored).