### PR TITLE
ci: fix wasm test failure from too many locals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,11 @@ jobs:
               run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
             - run: cargo test
-            - run: RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack test --headless --chrome --features wasm_js
-            - run: RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack test --headless --firefox --features wasm_js
+            # opt-level=1 keeps the test wasm under the validator's per-function
+            # local limit; unoptimized debug codegen overflows it ("too many
+            # locals: locals exceed maximum").
+            - run: RUSTFLAGS='--cfg getrandom_backend="wasm_js" -C opt-level=1' wasm-pack test --headless --chrome --features wasm_js
+            - run: RUSTFLAGS='--cfg getrandom_backend="wasm_js" -C opt-level=1' wasm-pack test --headless --firefox --features wasm_js
 
     wasi:
         runs-on: ubuntu-latest


### PR DESCRIPTION
The `wasm` CI job fails on `main` with:

```
Error: failed to deserialize Wasm module
  1: too many locals: locals exceed maximum (at offset 0x169728)
```

`wasm-pack test` builds the test binary in debug, and unoptimized codegen produces a function whose local count exceeds the wasm validator's per-function limit. Building the wasm tests with `-C opt-level=1` coalesces locals back under the limit while keeping the build cheap.

The failure is independent of any source change — it reproduces on `main` (e.g. run 28071350698) with the same offset.