### PR TITLE
Release 0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 
+<a name="v0.43.0"></a>
+## [v0.43.0](https://github.com/J-F-Liu/lopdf/compare/v0.42.0...v0.43.0) (2026-06-25)
+
+### Feat
+
+* Report encryption status in PdfMetadata
+
+
 <a name="v0.42.0"></a>
 ## [v0.42.0](https://github.com/J-F-Liu/lopdf/compare/v0.41.0...v0.42.0) (2026-06-23)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 name = "lopdf"
 readme = "README.md"
 repository = "https://github.com/J-F-Liu/lopdf.git"
-version = "0.42.0"
+version = "0.43.0"
 rust-version = "1.85"
 exclude = ["/tests", "/benches", "/assets", "/.vscode", "/.github"]
 


### PR DESCRIPTION
Bumps the version to 0.43.0 so the next release includes the encryption-status reporting in `PdfMetadata`, which merged after 0.42.0 was published to crates.io.

## Changes
- `Cargo.toml`: `0.42.0` → `0.43.0`
- `CHANGELOG.md`: add `v0.43.0` entry