### PR TITLE
ci: actually exercise the no-default-features build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
                       rust: nightly
                       continue-on-error: true
 
+                    - name: "feat: no default features"
+                      features: "--no-default-features"
+
                     - name: "feat: all features"
                       features: "--all-features"
 


### PR DESCRIPTION
The CI matrix lists a `feat: no default features` cell, but there is no `include` entry mapping that name to a `features` value. As a result `matrix.features` is empty for that cell, so it runs:

```
cargo build --verbose
cargo test --verbose -- --test-threads=1
```

i.e. with **default** features — identical to the `stable` cell. The no-default-features path is therefore never actually built or tested.

This adds the missing `include` entry so the cell runs with `--no-default-features`. Verified locally that `cargo build --no-default-features` and `cargo test --no-default-features` succeed on current `main`.