### PR TITLE
feat: make ttf-parser optional behind font_embedding feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ time = { version = "0.3", features = [
 ], optional = true }
 tokio = { version = "1", features = ["fs", "io-util"], optional = true }
 weezl = "0.2"
-ttf-parser = "0.25.1"
+ttf-parser = { version = "0.25.1", optional = true }
 
 [dev-dependencies]
 clap = { version = "4.6", features = ["derive"] }
@@ -66,6 +66,7 @@ async = ["tokio/rt-multi-thread", "tokio/macros"]
 chrono = ["dep:chrono"]
 default = ["chrono", "jiff", "rayon", "time"]
 embed_image = ["image"]
+font_embedding = ["dep:ttf-parser"]
 jiff = ["dep:jiff"]
 wasm_js = ["getrandom/wasm_js"]
 serde = ["dep:serde"]

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -1,5 +1,7 @@
 use crate::Result;
-use crate::{Dictionary, Document, FontData, Object, ObjectId, Stream};
+use crate::{Dictionary, Document, Object, ObjectId};
+#[cfg(feature = "font_embedding")]
+use crate::{FontData, Stream};
 
 impl Document {
     /// Create new PDF document with version.
@@ -154,6 +156,7 @@ impl Document {
     ///     },
     /// });
     /// ```
+    #[cfg(feature = "font_embedding")]
     pub fn add_font(&mut self, font_data: FontData) -> Result<ObjectId> {
         // Create embedded font stream
         let font_stream = Stream::new(
@@ -202,7 +205,9 @@ pub mod tests {
     use std::path::PathBuf;
 
     use crate::content::*;
-    use crate::{Document, FontData, Object, Stream};
+    use crate::{Document, Object, Stream};
+    #[cfg(feature = "font_embedding")]
+    use crate::FontData;
 
     #[cfg(not(feature = "time"))]
     pub fn get_timestamp() -> Object {
@@ -352,6 +357,7 @@ pub mod tests {
         assert!(file_path.exists());
     }
 
+    #[cfg(feature = "font_embedding")]
     #[test]
     fn test_add_font_embeds_font_correctly() {
         // Create a dummy TTF font in memory (fake content, just to test structure)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ mod parser_aux;
 mod reader;
 mod save_options;
 
+#[cfg(feature = "font_embedding")]
 mod font;
 
 pub use document::Document;
@@ -55,4 +56,5 @@ pub use toc::Toc;
 pub use parser_aux::substr;
 pub use parser_aux::substring;
 
+#[cfg(feature = "font_embedding")]
 pub use font::FontData;


### PR DESCRIPTION
## Motivation

`ttf-parser` has been marked unmaintained by its author ([RUSTSEC-2026-0192](https://rustsec.org/advisories/RUSTSEC-2026-0192)). The suggested replacement (`skrifa`) is not yet wired into lopdf or pdf-extract, so there is no drop-in upgrade path.

`ttf-parser` is only used in two places in lopdf:
- `FontData::new()` in `src/font.rs` — parsing TTF metrics for PDF font embedding
- `Document::add_font()` in `src/creator.rs` — the PDF-creation / font-embedding API

Read-only consumers (most notably `pdf-extract`, which already declares `default-features = false` for lopdf) never call these methods and should not be forced to carry the dependency.

## What this changes

- `ttf-parser` becomes an optional dependency
- A new `font_embedding` feature gates it
- `mod font` / `pub use font::FontData` in `lib.rs` are guarded by `#[cfg(feature = "font_embedding")]`
- `Document::add_font` and its imports in `creator.rs` are guarded by the same feature
- The `test_add_font_embeds_font_correctly` test is also gated

## Compatibility

- **Existing users who call `add_font`** will need to add `features = ["font_embedding"]` to their lopdf dependency — a one-line change.
- **Read-only users** (e.g. `pdf-extract` with `default-features = false`) automatically stop pulling `ttf-parser` with no changes on their end.
- Default features are unchanged — `font_embedding` is intentionally not added to `default` to avoid a silent behaviour change.

## Testing

```
cargo check                              # without font_embedding — clean
cargo check --features font_embedding   # with font_embedding — clean
```