### PR TITLE
refactor(document): make Document::get_page_content return Vec<u8>

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -8,7 +8,6 @@ use crate::{Error, ObjectStream, Result, Stream};
 use log::debug;
 use std::cmp::max;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::io::Write;
 use std::str;
 use std::sync::Arc;
 
@@ -586,19 +585,19 @@ impl Document {
     }
 
     /// Get content of a page.
-    pub fn get_page_content(&self, page_id: ObjectId) -> Result<Vec<u8>> {
+    pub fn get_page_content(&self, page_id: ObjectId) -> Vec<u8> {
         let mut content = Vec::new();
         let content_streams = self.get_page_contents(page_id);
         for object_id in content_streams {
             if let Ok(content_stream) = self.get_object(object_id).and_then(Object::as_stream) {
                 match content_stream.decompressed_content() {
-                    Ok(data) => content.write_all(&data)?,
-                    Err(_) => content.write_all(&content_stream.content)?,
+                    Ok(data) => content.extend_from_slice(&data),
+                    Err(_) => content.extend_from_slice(&content_stream.content),
                 };
                 content.push(b'\n');
             }
         }
-        Ok(content)
+        content
     }
 
     /// Get resources used by a page.

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -37,7 +37,7 @@ impl Stream {
 impl Document {
     /// Get decoded page content;
     pub fn get_and_decode_page_content(&self, page_id: ObjectId) -> Result<Content<Vec<Operation>>> {
-        let content_data = self.get_page_content(page_id)?;
+        let content_data = self.get_page_content(page_id);
         Content::decode(&content_data)
     }
 
@@ -90,7 +90,7 @@ impl Document {
                 }
             })
             .collect();
-        let content_data = self.get_page_content(page_id)?;
+        let content_data = self.get_page_content(page_id);
         let content = Content::decode(&content_data)?;
 
         // each text with different encoding is extracted as separate chunk
@@ -191,7 +191,7 @@ impl Document {
             .into_iter()
             .map(|(name, font)| font.get_font_encoding(self).map(|it| (name, it)))
             .collect::<Result<BTreeMap<Vec<u8>, Encoding>>>()?;
-        let content_data = self.get_page_content(page_id)?;
+        let content_data = self.get_page_content(page_id);
         let mut content = Content::decode(&content_data)?;
         let mut current_encoding = None;
         for operation in &mut content.operations {
@@ -234,7 +234,7 @@ impl Document {
             .map(|(name, font)| font.get_font_encoding(self).map(|it| (name, it)))
             .collect::<Result<BTreeMap<Vec<u8>, Encoding>>>()?;
 
-        let content_data = self.get_page_content(page_id)?;
+        let content_data = self.get_page_content(page_id);
         let mut content = Content::decode(&content_data)?;
         let mut current_encoding = None;
         let mut replacement_count = 0;

--- a/tests/page_content.rs
+++ b/tests/page_content.rs
@@ -11,7 +11,7 @@ fn get_page_content_separates_streams_at_token_boundary() {
         "Contents" => vec![s1.into(), s2.into()],
     });
 
-    let bytes = doc.get_page_content(page_id).unwrap();
+    let bytes = doc.get_page_content(page_id);
     let content = Content::decode(&bytes).unwrap();
 
     assert_eq!(content.operations.len(), 1);
@@ -33,7 +33,7 @@ fn get_page_content_terminates_trailing_comment() {
         "Contents" => vec![s1.into(), s2.into()],
     });
 
-    let bytes = doc.get_page_content(page_id).unwrap();
+    let bytes = doc.get_page_content(page_id);
     let content = Content::decode(&bytes).unwrap();
 
     assert_eq!(content.operations.len(), 1);


### PR DESCRIPTION
`Document::get_page_content` is infallible and so doesn't need to return a result. This patches it to return `Vec<u8>`.

Closes #464 