### PR TITLE
Fix(test): enable features/deps where needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,13 +53,15 @@ ttf-parser = { version = "0.25.1", optional = true }
 
 [dev-dependencies]
 clap = { version = "4.6", features = ["derive"] }
-criterion = "0.8"
 env_logger = "0.11"
 serde_json = "1.0"
 shellexpand = "3.1"
 tempfile = "3.27"
 wasm-bindgen-test = "0.3"
 ttf-parser = "0.25.1"
+
+[target.'cfg(not(target_family="wasm"))'.dev-dependencies]
+criterion = "0.8"
 
 [features]
 async = ["tokio/rt-multi-thread", "tokio/macros"]

--- a/tests/font_test.rs
+++ b/tests/font_test.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "font_embedding")]
 #[test]
 fn test_font_data_creation() {
     // Load a sample TTF font file from the test resources


### PR DESCRIPTION
Two recent changes have added bugs in the CI tests. This PR addresses them.

### 1.  Criterion Bug
#### Issue
Criterion was added as a dependency in #504 causing the wasm test (`cargo build --tests --target wasm32-unknown-unknown --features wasm_js`) to fail with:
```
   Compiling criterion v0.8.2
error: Rayon cannot be used when targeting wasi32. Try disabling default features.
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/criterion-0.8.2/src/lib.rs:26:1
   |
26 | compile_error!("Rayon cannot be used when targeting wasi32. Try disabling default features.");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
#### Solution
 Move `criterion` under a `[target.'cfg(not(target_family="wasm"))'.dev-dependencies]` flag, so it isn't included for wasm tests.

### 2. Font Flag Bug
#### Issue
The `font_embedding` feature added in #512 caused `cargo test` to fail with:
```
error[E0433]: cannot find `FontData` in `lopdf`
  --> tests/font_test.rs:11:32
   |
11 |     let mut font_data = lopdf::FontData::new(&font_file, "Montserrat-Regular".to_string());
   |                                ^^^^^^^^ could not find `FontData` in `lopdf`
   |
note: found an item that was configured out
  --> src/lib.rs:60:15
   |
59 | #[cfg(feature = "font_embedding")]
   |       -------------------------- the item is gated behind the `font_embedding` feature
60 | pub use font::FontData;
   |               ^^^^^^^^
```
#### Solution
Add ` #[cfg(feature = "font_embedding")]` to `test_font_data_creation`  