### PR TITLE
Add API to limit decompressed size to prevent decompression bombs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ ttf-parser = { version = "0.25.1", optional = true }
 [dev-dependencies]
 clap = { version = "4.6", features = ["derive"] }
 env_logger = "0.11"
+flate2 = "1.1"
 serde_json = "1.0"
 shellexpand = "3.1"
 tempfile = "3.27"

--- a/examples/decompression_bomb.rs
+++ b/examples/decompression_bomb.rs
@@ -1,0 +1,120 @@
+//! Demonstrates bounding stream decompression to reject decompression bombs.
+//!
+//! Run with:  cargo run --example decompression_bomb
+//!
+//! A decompression bomb is a tiny compressed stream that inflates to an enormous
+//! size. This example builds one and decodes it with a size limit, for a direct
+//! stream, a chained-filter stream, and a bomb embedded in a PDF that is decoded
+//! during `Document::load`.
+
+use std::io::Write;
+use std::time::Instant;
+
+use flate2::write::ZlibEncoder;
+use flate2::Compression;
+use lopdf::{Dictionary, Document, LoadOptions, Object, Stream};
+
+const MIB: usize = 1024 * 1024;
+
+/// A zlib stream that decodes to `target` zero-bytes, built by streaming zeros
+/// through the compressor so this process never holds `target` bytes at once.
+fn flate_bomb(target: usize) -> Vec<u8> {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::best());
+    let zeros = [0u8; 64 * 1024];
+    let mut remaining = target;
+    while remaining > 0 {
+        let n = remaining.min(zeros.len());
+        encoder.write_all(&zeros[..n]).unwrap();
+        remaining -= n;
+    }
+    encoder.finish().unwrap()
+}
+
+fn zlib_compress(data: &[u8]) -> Vec<u8> {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::best());
+    encoder.write_all(data).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn main() {
+    println!("== lopdf decompression-bomb guard ==\n");
+
+    // ---- 1. A single-filter bomb -----------------------------------------
+    let logical_output = 256 * MIB;
+    let bomb = flate_bomb(logical_output);
+    println!(
+        "Built a FlateDecode bomb: {} bytes compressed -> {} bytes decompressed ({}x amplification).",
+        bomb.len(),
+        logical_output,
+        logical_output / bomb.len().max(1)
+    );
+
+    let mut dict = Dictionary::new();
+    dict.set("Filter", "FlateDecode");
+    let stream = Stream::new(dict, bomb.clone());
+
+    let limit = 8 * MIB;
+    let start = Instant::now();
+    match stream.decompressed_content_with_limit(limit) {
+        Ok(data) => println!("  UNEXPECTED: decompressed {} bytes", data.len()),
+        Err(e) => println!(
+            "  decompressed_content_with_limit({} MiB) rejected it in {:?}: {e}",
+            limit / MIB,
+            start.elapsed()
+        ),
+    }
+    println!(
+        "  (The default decompressed_content() has NO limit and would allocate all {} MiB.)\n",
+        logical_output / MIB
+    );
+
+    // ---- 2. A chained-filter bomb: [FlateDecode FlateDecode] -------------
+    // Each layer amplifies ~1000x, so two layers reach ~1,000,000x. The guard
+    // bounds every layer, so the bomb is caught at the second one.
+    let inner = flate_bomb(256 * MIB);
+    let outer = zlib_compress(&inner);
+    let mut dict = Dictionary::new();
+    dict.set("Filter", vec![Object::from("FlateDecode"), Object::from("FlateDecode")]);
+    let chained = Stream::new(dict, outer.clone());
+    println!(
+        "Built a chained [FlateDecode FlateDecode] bomb: {} bytes -> ~256 MiB after two layers.",
+        outer.len()
+    );
+    match chained.decompressed_content_with_limit(limit) {
+        Ok(data) => println!("  UNEXPECTED: decompressed {} bytes", data.len()),
+        Err(e) => println!("  rejected at a filter layer with an {} MiB limit: {e}\n", limit / MIB),
+    }
+
+    // ---- 3. A bomb inside a PDF's cross-reference stream ----------------
+    // The xref stream is decoded during Document::load to build the xref
+    // table, so the limit is supplied through LoadOptions.
+    let pdf = xref_stream_bomb_pdf(&bomb);
+    println!("Loading a PDF whose cross-reference stream is the bomb...");
+    match Document::load_mem(&pdf) {
+        Ok(_) => println!("  load_mem (no limit): parsed after decoding the full output"),
+        Err(e) => println!("  load_mem (no limit): {e}"),
+    }
+    match Document::load_mem_with_options(&pdf, LoadOptions::with_max_decompressed_size(limit)) {
+        Ok(_) => println!("  UNEXPECTED: guarded load succeeded"),
+        Err(e) => println!("  load_mem_with_options(max_decompressed_size = {} MiB): {e}", limit / MIB),
+    }
+}
+
+fn xref_stream_bomb_pdf(bomb: &[u8]) -> Vec<u8> {
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.5\n");
+    let obj_offset = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n");
+    pdf.extend_from_slice(
+        format!(
+            "<< /Type /XRef /Size 1 /W [1 1 1] /Root 1 0 R /Filter /FlateDecode /Length {} >>\n",
+            bomb.len()
+        )
+        .as_bytes(),
+    );
+    pdf.extend_from_slice(b"stream\n");
+    pdf.extend_from_slice(bomb);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+    pdf.extend_from_slice(format!("startxref\n{obj_offset}\n%%EOF").as_bytes());
+    pdf
+}

--- a/src/document.rs
+++ b/src/document.rs
@@ -4,7 +4,7 @@ use crate::encryption::crypt_filters::*;
 use crate::encryption::{self, EncryptionState, PasswordAlgorithm};
 use crate::xobject::PdfImage;
 use crate::xref::{Xref, XrefType};
-use crate::{Error, ObjectStream, Result, Stream};
+use crate::{DecompressError, Error, ObjectStream, Result, Stream};
 use log::debug;
 use std::cmp::max;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -598,6 +598,58 @@ impl Document {
             }
         }
         content
+    }
+
+    /// Get the content of a page, bounding the total decompressed output to
+    /// `max_decompressed_size` bytes.
+    ///
+    /// This is the decompression-bomb-safe counterpart to
+    /// [`Document::get_page_content`]. A page's content can be split across
+    /// several streams; the whole concatenated result is bounded to roughly
+    /// `max_decompressed_size` bytes (each stream is decoded against the
+    /// *remaining* budget, so N streams cannot sum to N times the limit), which
+    /// stops a small compressed page stream from inflating without limit when
+    /// processing untrusted PDFs. Use it (and
+    /// [`Document::extract_text_with_limit`]) instead of the unbounded variants
+    /// for input you do not control.
+    ///
+    /// Returns [`DecompressError::MemoryLimitExceeded`](crate::DecompressError::MemoryLimitExceeded)
+    /// if the page content would exceed the limit. Like
+    /// [`Document::get_page_content`], a stream that fails to decode for a reason
+    /// *other* than the size limit falls back to its raw bytes, but that fallback
+    /// is also kept within the remaining budget.
+    pub fn get_page_content_with_limit(&self, page_id: ObjectId, max_decompressed_size: usize) -> Result<Vec<u8>> {
+        let mut content = Vec::new();
+        let content_streams = self.get_page_contents(page_id);
+        for object_id in content_streams {
+            if let Ok(content_stream) = self.get_object(object_id).and_then(Object::as_stream) {
+                let remaining = max_decompressed_size.saturating_sub(content.len());
+                match content_stream.decompressed_content_with_limit(remaining) {
+                    Ok(data) => content.extend_from_slice(&data),
+                    Err(Error::Decompress(DecompressError::MemoryLimitExceeded { .. })) => {
+                        return Err(DecompressError::MemoryLimitExceeded {
+                            limit: max_decompressed_size,
+                        }
+                        .into());
+                    }
+                    // Mirror `get_page_content`'s lenient fallback to the raw
+                    // (still-compressed) bytes when a stream can't be decoded, but
+                    // keep that fallback within the page's remaining budget so a
+                    // large raw stream can't bypass the guard.
+                    Err(_) => {
+                        if content_stream.content.len() > remaining {
+                            return Err(DecompressError::MemoryLimitExceeded {
+                                limit: max_decompressed_size,
+                            }
+                            .into());
+                        }
+                        content.extend_from_slice(&content_stream.content);
+                    }
+                }
+                content.push(b'\n');
+            }
+        }
+        Ok(content)
     }
 
     /// Get resources used by a page.

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,6 +125,12 @@ pub enum Error {
 pub enum DecompressError {
     #[error("decoding ASCII85 failed: {0}")]
     Ascii85(&'static str),
+    /// The decompressed output exceeded the allowed size limit. This guards
+    /// against decompression bombs: a small compressed stream that inflates to
+    /// an enormous size (potentially exhausting memory). The `limit` is the
+    /// maximum number of output bytes that were permitted.
+    #[error("decompressed output exceeded the {limit}-byte limit (possible decompression bomb)")]
+    MemoryLimitExceeded { limit: usize },
 }
 
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use common_data_structures::{decode_text_string, text_string};
 pub use destinations::Destination;
 pub use encodings::{Encoding, encode_utf8, encode_utf16_be};
 pub use encryption::{EncryptionState, EncryptionVersion, Permissions};
-pub use error::{Error, Result};
+pub use error::{DecompressError, Error, Result};
 pub use incremental_document::IncrementalDocument;
 pub use load_options::{FilterFunc, LoadOptions};
 pub use object_stream::{ObjectStream, ObjectStreamBuilder, ObjectStreamConfig};

--- a/src/load_options.rs
+++ b/src/load_options.rs
@@ -37,6 +37,18 @@ pub struct LoadOptions {
     /// When `true`, reject non-conforming PDFs instead of silently accepting them.
     /// Defaults to `false` (lenient parsing).
     pub strict: bool,
+    /// Maximum number of bytes any single stream may decompress to during
+    /// loading (object streams and cross-reference streams).
+    ///
+    /// Compression filters can inflate a tiny input into an enormous output (a
+    /// "decompression bomb"). Because object and xref streams are decoded eagerly
+    /// while the document is loaded, an unbounded stream can exhaust memory
+    /// before any of your code runs. Set this to bound that per-stream cost when
+    /// loading untrusted PDFs; a stream that would exceed it fails with
+    /// [`crate::DecompressError::MemoryLimitExceeded`].
+    ///
+    /// `None` (the default) applies no limit.
+    pub max_decompressed_size: Option<usize>,
 }
 
 impl std::fmt::Debug for LoadOptions {
@@ -45,6 +57,7 @@ impl std::fmt::Debug for LoadOptions {
             .field("password", &self.password.as_ref().map(|_| "***"))
             .field("filter", &self.filter.map(|_| "fn(..)"))
             .field("strict", &self.strict)
+            .field("max_decompressed_size", &self.max_decompressed_size)
             .finish()
     }
 }
@@ -62,6 +75,16 @@ impl LoadOptions {
     pub fn with_filter(filter: FilterFunc) -> Self {
         Self {
             filter: Some(filter),
+            ..Default::default()
+        }
+    }
+
+    /// Create options that bound how large any single stream may decompress to
+    /// during loading, to defend against decompression bombs in untrusted PDFs.
+    /// See [`LoadOptions::max_decompressed_size`].
+    pub fn with_max_decompressed_size(max_decompressed_size: usize) -> Self {
+        Self {
+            max_decompressed_size: Some(max_decompressed_size),
             ..Default::default()
         }
     }

--- a/src/object.rs
+++ b/src/object.rs
@@ -712,6 +712,43 @@ impl<K: Into<Vec<u8>>> FromIterator<(K, Object)> for Dictionary {
     }
 }
 
+/// A [`std::io::Write`] adapter that appends to a `Vec<u8>` but refuses to grow
+/// it past `limit` bytes. Used to bound decoders (e.g. LZW) that write into a
+/// sink rather than being read from, so a decompression bomb cannot allocate an
+/// unbounded amount of memory. On overflow it fills up to exactly `limit` bytes
+/// and then returns an error, so the caller can detect the overflow by length.
+struct LimitedWriter<'a> {
+    inner: &'a mut Vec<u8>,
+    limit: usize,
+}
+
+impl<'a> LimitedWriter<'a> {
+    fn new(inner: &'a mut Vec<u8>, limit: usize) -> Self {
+        LimitedWriter { inner, limit }
+    }
+}
+
+impl std::io::Write for LimitedWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let remaining = self.limit.saturating_sub(self.inner.len());
+        if buf.len() > remaining {
+            // Fill up to the limit so the caller's `len() > max` check trips,
+            // then signal that no more may be written.
+            self.inner.extend_from_slice(&buf[..remaining]);
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "decompression output exceeded limit",
+            ));
+        }
+        self.inner.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 impl Stream {
     pub fn new(mut dict: Dictionary, content: Vec<u8>) -> Stream {
         dict.set("Length", content.len() as i64);
@@ -791,12 +828,66 @@ impl Stream {
         Ok(())
     }
 
+    /// Decode this stream's content, applying its filters in order.
+    ///
+    /// # Warning: unbounded output
+    ///
+    /// This method places **no limit** on the size of the decompressed output.
+    /// A small compressed stream can inflate to an enormous size (a
+    /// "decompression bomb"), so calling this on untrusted input can exhaust
+    /// all available memory. When processing PDFs from an untrusted source,
+    /// prefer [`Stream::decompressed_content_with_limit`] or
+    /// [`Stream::decompress_to_writer`], and load documents with
+    /// [`crate::LoadOptions::max_decompressed_size`] set.
     pub fn decompressed_content(&self) -> Result<Vec<u8>> {
+        self.decode_filters(None)
+    }
+
+    /// Decode this stream's content, rejecting the stream with
+    /// [`DecompressError::MemoryLimitExceeded`] if the decoded output would
+    /// exceed `max_output` bytes.
+    ///
+    /// This is the bomb-safe counterpart to [`Stream::decompressed_content`].
+    /// Each filter in the chain is bounded individually, so a stream with nested
+    /// filters (e.g. `/Filter [FlateDecode FlateDecode]`) can never allocate
+    /// more than roughly `max_output` bytes per layer before being rejected,
+    /// rather than expanding without limit.
+    pub fn decompressed_content_with_limit(&self, max_output: usize) -> Result<Vec<u8>> {
+        self.decode_filters(Some(max_output))
+    }
+
+    /// Decode this stream's content into a caller-provided writer, rejecting the
+    /// stream if the decoded output would exceed `max_output` bytes.
+    ///
+    /// The result is decoded with the same bomb-safe bound as
+    /// [`Stream::decompressed_content_with_limit`] (internal buffering is capped
+    /// at roughly `max_output` bytes) and then written to `writer`, which lets
+    /// callers direct the output straight into a file or a fixed-capacity buffer
+    /// of their choosing. Returns the number of bytes written on success, or
+    /// [`DecompressError::MemoryLimitExceeded`] if the limit would be exceeded.
+    pub fn decompress_to_writer<W: std::io::Write>(&self, writer: &mut W, max_output: usize) -> Result<usize> {
+        let data = self.decompressed_content_with_limit(max_output)?;
+        writer.write_all(&data)?;
+        Ok(data.len())
+    }
+
+    /// Shared decoder for [`Stream::decompressed_content`] and its bounded
+    /// variants. `limit` is `None` to decode without a size limit, or
+    /// `Some(max)` to cap the decoded output at `max` bytes per filter layer.
+    fn decode_filters(&self, limit: Option<usize>) -> Result<Vec<u8>> {
         let params = self.dict.get(b"DecodeParms").and_then(Object::as_dict).ok();
         let filters = match self.filters() {
             Ok(f) => f,
-            // No /Filter key means the stream is uncompressed
-            Err(_) => return Ok(self.content.clone()),
+            // No /Filter key means the stream is uncompressed. The raw content is
+            // already in memory, but still honor the caller's limit.
+            Err(_) => {
+                if let Some(max) = limit
+                    && self.content.len() > max
+                {
+                    return Err(DecompressError::MemoryLimitExceeded { limit: max }.into());
+                }
+                return Ok(self.content.clone());
+            }
         };
 
         let mut input = self.content.as_slice();
@@ -805,17 +896,39 @@ impl Stream {
         // Filters are in decoding order.
         for filter in filters {
             output = match filter {
-                b"FlateDecode" => Self::decompress_zlib(input, params)?,
-                b"LZWDecode" => Self::decompress_lzw(input, params)?,
-                b"ASCII85Decode" => Self::decode_ascii85(input)?,
+                b"FlateDecode" => Self::decompress_zlib(input, params, limit)?,
+                b"LZWDecode" => Self::decompress_lzw(input, params, limit)?,
+                b"ASCII85Decode" => Self::decode_ascii85(input, limit)?,
                 _ => return Err(Error::Unimplemented("decompression algorithms")),
             };
+            if let Some(max) = limit
+                && output.len() > max
+            {
+                return Err(DecompressError::MemoryLimitExceeded { limit: max }.into());
+            }
             input = &output;
         }
         Ok(output)
     }
 
-    fn decompress_lzw(input: &[u8], params: Option<&Dictionary>) -> Result<Vec<u8>> {
+    /// Read `reader` to end, appending to `output`. When `limit` is `Some(max)`,
+    /// at most `max + 1` bytes are read, so an oversized (bomb) stream is
+    /// detected via the `> max` check by the caller without ever allocating the
+    /// full decompressed output.
+    fn read_capped<R: std::io::Read>(reader: R, output: &mut Vec<u8>, limit: Option<usize>) -> std::io::Result<()> {
+        use std::io::Read;
+        match limit {
+            Some(max) => Read::take(reader, (max as u64).saturating_add(1))
+                .read_to_end(output)
+                .map(|_| ()),
+            None => {
+                let mut reader = reader;
+                reader.read_to_end(output).map(|_| ())
+            }
+        }
+    }
+
+    fn decompress_lzw(input: &[u8], params: Option<&Dictionary>, limit: Option<usize>) -> Result<Vec<u8>> {
         use weezl::{BitOrder, decode::Decoder};
         const MIN_BITS: u8 = 9;
 
@@ -831,47 +944,70 @@ impl Stream {
             Decoder::new(BitOrder::Msb, MIN_BITS - 1)
         };
 
-        let output = Self::decompress_lzw_loop(input, &mut decoder);
+        let output = Self::decompress_lzw_loop(input, &mut decoder, limit);
+        if let Some(max) = limit
+            && output.len() > max
+        {
+            return Err(DecompressError::MemoryLimitExceeded { limit: max }.into());
+        }
         Self::decompress_predictor(output, params)
     }
 
-    fn decompress_lzw_loop(input: &[u8], decoder: &mut weezl::decode::Decoder) -> Vec<u8> {
+    fn decompress_lzw_loop(input: &[u8], decoder: &mut weezl::decode::Decoder, limit: Option<usize>) -> Vec<u8> {
         let mut output = vec![];
 
-        let result = decoder.into_stream(&mut output).decode_all(input);
-        if let Err(err) = result.status {
+        // When a limit is set, decode into a writer that stops accepting bytes
+        // once `max + 1` have been produced, so a bomb cannot allocate the full
+        // (potentially enormous) output; the caller rejects it via the `> max`
+        // check. Without a limit, decode straight into the output vector.
+        let status = match limit {
+            Some(max) => {
+                let mut sink = LimitedWriter::new(&mut output, max.saturating_add(1));
+                decoder.into_stream(&mut sink).decode_all(input).status
+            }
+            None => decoder.into_stream(&mut output).decode_all(input).status,
+        };
+        if let Err(err) = status {
             warn!("{err}");
         }
 
         output
     }
 
-    fn decompress_zlib(input: &[u8], params: Option<&Dictionary>) -> Result<Vec<u8>> {
+    fn decompress_zlib(input: &[u8], params: Option<&Dictionary>, limit: Option<usize>) -> Result<Vec<u8>> {
         use flate2::read::ZlibDecoder;
-        use std::io::prelude::*;
 
-        let mut output = Vec::with_capacity(input.len() * 2);
+        // Reserve a starting capacity, but never pre-allocate beyond the limit so
+        // a bomb cannot force a huge allocation up front.
+        let initial_capacity = match limit {
+            Some(max) => input.len().saturating_mul(2).min(max.saturating_add(1)),
+            None => input.len().saturating_mul(2),
+        };
+        let mut output = Vec::with_capacity(initial_capacity);
 
-        if !input.is_empty() {
-            let mut decoder = ZlibDecoder::new(input);
-            if let Err(err) = decoder.read_to_end(&mut output) {
-                warn!("{err}");
-                // Zlib decompression failed (e.g. corrupt adler32 checksum in
-                // encrypted PDFs). Retry with raw deflate, skipping the 2-byte
-                // zlib header and ignoring the checksum.
-                if output.is_empty() && input.len() > 2 {
-                    use flate2::read::DeflateDecoder;
-                    let mut raw_decoder = DeflateDecoder::new(&input[2..]);
-                    if let Err(raw_err) = raw_decoder.read_to_end(&mut output) {
-                        warn!("raw deflate fallback also failed: {raw_err}");
-                    }
+        if !input.is_empty()
+            && let Err(err) = Self::read_capped(ZlibDecoder::new(input), &mut output, limit)
+        {
+            warn!("{err}");
+            // Zlib decompression failed (e.g. corrupt adler32 checksum in
+            // encrypted PDFs). Retry with raw deflate, skipping the 2-byte
+            // zlib header and ignoring the checksum.
+            if output.is_empty() && input.len() > 2 {
+                use flate2::read::DeflateDecoder;
+                if let Err(raw_err) = Self::read_capped(DeflateDecoder::new(&input[2..]), &mut output, limit) {
+                    warn!("raw deflate fallback also failed: {raw_err}");
                 }
             }
+        }
+        if let Some(max) = limit
+            && output.len() > max
+        {
+            return Err(DecompressError::MemoryLimitExceeded { limit: max }.into());
         }
         Self::decompress_predictor(output, params)
     }
 
-    fn decode_ascii85(input: &[u8]) -> Result<Vec<u8>> {
+    fn decode_ascii85(input: &[u8], limit: Option<usize>) -> Result<Vec<u8>> {
         let mut output = vec![];
         let mut buffer: u32 = 0;
         let mut count = 0;
@@ -883,6 +1019,14 @@ impl Stream {
             input
         };
         for &ch in input_no_eod {
+            // ASCII85 can amplify up to 4x (each `z` expands to four zero bytes),
+            // so bound the output here rather than only after the fact; each
+            // iteration appends at most 4 bytes, so output never exceeds max + 4.
+            if let Some(max) = limit
+                && output.len() > max
+            {
+                return Err(DecompressError::MemoryLimitExceeded { limit: max }.into());
+            }
             if ch == b'z' {
                 if count != 0 {
                     return Err(DecompressError::Ascii85("z character is not allowed in the middle of a group").into());
@@ -952,6 +1096,18 @@ impl Stream {
         Ok(())
     }
 
+    /// Decompress this stream in place like [`Stream::decompress`], but reject it
+    /// with [`DecompressError::MemoryLimitExceeded`] if the decoded output would
+    /// exceed `max_output` bytes. Used on the load path to bound the memory a
+    /// single object/xref stream can consume.
+    pub fn decompress_with_limit(&mut self, max_output: usize) -> Result<()> {
+        let data = self.decompressed_content_with_limit(max_output)?;
+        self.dict.remove(b"DecodeParms");
+        self.dict.remove(b"Filter");
+        self.set_content(data);
+        Ok(())
+    }
+
     pub fn is_compressed(&self) -> bool {
         self.dict.get(b"Filter").is_ok()
     }
@@ -971,7 +1127,7 @@ mod test {
             DId<j@<?3r@:F%a+D58'ATD4$Bl@l3De:,-DJs`8ARoFb/0JMK@qB4^F!,R<AKZ&-DfTqBG%G>u
             D.RTpAKYo'+CT/5+Cei#DII?(E,9)oF*2M7/c~>"#;
         let expected = "Man is distinguished, not only by his reason, but by this singular passion from other animals, which is a lust of the mind, that by a perseverance of delight in the continued and indefatigable generation of knowledge, exceeds the short vehemence of any carnal pleasure.";
-        let output = Stream::decode_ascii85(input.as_bytes()).unwrap();
+        let output = Stream::decode_ascii85(input.as_bytes(), None).unwrap();
         println!("{}", String::from_utf8(output.clone()).unwrap());
         assert_eq!(&output, expected.as_bytes());
     }
@@ -979,7 +1135,7 @@ mod test {
     #[test]
     fn test_decode_ascii85_overflow() {
         let input = b"uuuuu~>";
-        let output = Stream::decode_ascii85(input);
+        let output = Stream::decode_ascii85(input, None);
         // let expected: Result<Vec<u8>, Error> = Err(Error::ContentDecode);
         assert!(matches!(output, Err(Error::Decompress(DecompressError::Ascii85(_)))));
     }
@@ -1005,7 +1161,7 @@ mod test {
         }
 
         // Normal zlib should fail, but our fallback should recover
-        let result = Stream::decompress_zlib(&compressed, None).unwrap();
+        let result = Stream::decompress_zlib(&compressed, None, None).unwrap();
         assert_eq!(result, original);
     }
 
@@ -1025,5 +1181,85 @@ mod test {
             .decompressed_content()
             .expect("should succeed for uncompressed stream");
         assert_eq!(result, content);
+    }
+
+    #[test]
+    fn test_uncompressed_stream_honors_limit() {
+        use crate::Dictionary;
+
+        // Even with no filter, an over-limit raw stream must be rejected so the
+        // caller's memory bound is never silently exceeded.
+        let content = vec![0u8; 1024];
+        let mut dict = Dictionary::new();
+        dict.set("Length", content.len() as i64);
+        let stream = Stream::new(dict, content);
+
+        assert!(matches!(
+            stream.decompressed_content_with_limit(512),
+            Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit: 512 }))
+        ));
+        assert!(stream.decompressed_content_with_limit(4096).is_ok());
+    }
+
+    #[test]
+    fn test_limited_writer_fills_to_limit_then_errors() {
+        use super::LimitedWriter;
+        use std::io::Write;
+
+        // The push-based (LZW) guard: the sink accepts bytes up to `limit`, then
+        // fills the remaining room and refuses further writes, so the caller can
+        // detect the overflow via `len() > max` without unbounded allocation.
+        let mut buf = Vec::new();
+        let mut writer = LimitedWriter::new(&mut buf, 4);
+
+        assert_eq!(writer.write(b"ab").unwrap(), 2);
+        // This write would cross the limit: it fills to exactly 4 bytes, errors.
+        let err = writer.write(b"cdef").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::WriteZero);
+
+        assert_eq!(buf, b"abcd");
+    }
+
+    #[test]
+    fn test_ascii85_honors_limit() {
+        // Each `z` expands to four zero bytes, so 1 MiB of `z` decodes to 4 MiB.
+        // Without a limit that full 4x amplification is allocated; with a limit
+        // the decoder must stop rather than expand past it (guards the chained
+        // `[FlateDecode ASCII85Decode]` bomb vector on the load path).
+        let mut input = vec![b'z'; 1024 * 1024];
+        input.extend_from_slice(b"~>");
+
+        let full = Stream::decode_ascii85(&input, None).unwrap();
+        assert_eq!(full.len(), 4 * 1024 * 1024, "unbounded ASCII85 amplifies 4x");
+
+        assert!(matches!(
+            Stream::decode_ascii85(&input, Some(1024 * 1024)),
+            Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit })) if limit == 1024 * 1024
+        ));
+    }
+
+    #[test]
+    fn test_lzw_bomb_rejected_with_limit() {
+        use crate::Dictionary;
+        use weezl::{BitOrder, encode::Encoder};
+
+        // A tiny LZW stream that decodes back to 8 MiB of zeros. The encoder must
+        // match lopdf's default decoder (`with_tiff_size_switch`, code size 8).
+        let plain = vec![0u8; 8 * 1024 * 1024];
+        let compressed = Encoder::with_tiff_size_switch(BitOrder::Msb, 8).encode(&plain).unwrap();
+        assert!(compressed.len() < 128 * 1024, "LZW bomb input should be tiny");
+
+        let mut dict = Dictionary::new();
+        dict.set("Filter", "LZWDecode");
+        let stream = Stream::new(dict, compressed);
+
+        // Bounded: the push-based LZW path (LimitedWriter + weezl) rejects it.
+        assert!(matches!(
+            stream.decompressed_content_with_limit(1024 * 1024),
+            Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit })) if limit == 1024 * 1024
+        ));
+        // Unbounded default still round-trips fully (proves the pairing is valid,
+        // so the rejection above is real and not a decode failure).
+        assert_eq!(stream.decompressed_content().unwrap().len(), 8 * 1024 * 1024);
     }
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -406,6 +406,24 @@ impl Dictionary {
     }
 
     pub fn get_font_encoding<'a>(&'a self, doc: &'a Document) -> Result<Encoding<'a>> {
+        self.get_font_encoding_inner(doc, None)
+    }
+
+    /// Resolve this font's encoding, bounding any decompression it performs (for
+    /// example decoding a `/ToUnicode` CMap stream) to `max_decompressed_size`
+    /// bytes. This is the decompression-bomb-safe counterpart to
+    /// [`Dictionary::get_font_encoding`]: it is used by
+    /// [`crate::Document::extract_text_with_limit`] so a crafted font stream
+    /// cannot inflate without limit. Unlike other encoding errors (which fall
+    /// back to standard encoding), a detected size-limit violation is propagated
+    /// as [`DecompressError::MemoryLimitExceeded`].
+    pub fn get_font_encoding_with_limit<'a>(
+        &'a self, doc: &'a Document, max_decompressed_size: usize,
+    ) -> Result<Encoding<'a>> {
+        self.get_font_encoding_inner(doc, Some(max_decompressed_size))
+    }
+
+    fn get_font_encoding_inner<'a>(&'a self, doc: &'a Document, limit: Option<usize>) -> Result<Encoding<'a>> {
         if !self.has_type(b"Font") {
             return Err(Error::DictType {
                 expected: "Font",
@@ -421,11 +439,11 @@ impl Dictionary {
         //   114 in 9.6.6.1 General under `BaseEncoding`).
         let result = (|| {
             if let Ok(object) = self.get(b"Encoding") {
-                return self.get_base_encoding(object, doc);
+                return self.get_base_encoding(object, doc, limit);
             }
 
             if let Ok(stream) = self.get_deref(b"ToUnicode", doc).and_then(Object::as_stream) {
-                return self.get_to_unicode_encoding(stream);
+                return self.get_to_unicode_encoding(stream, limit);
             }
 
             Ok(Encoding::OneByteEncoding(&encodings::STANDARD_ENCODING))
@@ -433,6 +451,10 @@ impl Dictionary {
 
         match result {
             Ok(encoding) => Ok(encoding),
+            // A detected decompression bomb must surface, not be swallowed into a
+            // fallback encoding — otherwise the bounded caller's guard is silently
+            // defeated. Every other encoding error stays lenient, as before.
+            Err(err @ Error::Decompress(DecompressError::MemoryLimitExceeded { .. })) => Err(err),
             Err(err) => {
                 warn!(
                     "Could not parse the encoding, error: {err:#?}\nFont: {self:#?}. Using standard encoding as a fallback!"
@@ -443,14 +465,16 @@ impl Dictionary {
     }
 
     /// Get a simple encoding from the /Encoding entry of a font dictionary.
-    fn get_base_encoding<'a>(&'a self, mut object: &'a Object, doc: &'a Document) -> Result<Encoding<'a>> {
+    fn get_base_encoding<'a>(
+        &'a self, mut object: &'a Object, doc: &'a Document, limit: Option<usize>,
+    ) -> Result<Encoding<'a>> {
         // Set of visited to detect circular references.
         let mut visited = HashSet::new();
 
         loop {
             match *object {
                 Object::Name(ref name) => {
-                    return self.base_encoding(doc, name);
+                    return self.base_encoding(doc, name, limit);
                 }
                 Object::Reference(id) => {
                     if !visited.insert(id) {
@@ -473,7 +497,7 @@ impl Dictionary {
                             if let Ok(base_encoding) = dict.get(b"BaseEncoding")
                                 && let Ok(name) = base_encoding.as_name()
                             {
-                                base = Some(self.base_encoding(doc, name)?);
+                                base = Some(self.base_encoding(doc, name, limit)?);
                             }
 
                             let base = match base {
@@ -503,7 +527,7 @@ impl Dictionary {
         }
     }
 
-    fn base_encoding<'a>(&'a self, doc: &'a Document, name: &'a [u8]) -> Result<Encoding<'a>> {
+    fn base_encoding<'a>(&'a self, doc: &'a Document, name: &'a [u8], limit: Option<usize>) -> Result<Encoding<'a>> {
         match name {
             b"StandardEncoding" => Ok(Encoding::OneByteEncoding(&encodings::STANDARD_ENCODING)),
             b"MacRomanEncoding" => Ok(Encoding::OneByteEncoding(&encodings::MAC_ROMAN_ENCODING)),
@@ -515,7 +539,7 @@ impl Dictionary {
             }
             b"Identity-H" | b"Identity-V" => {
                 let stream = self.get_deref(b"ToUnicode", doc)?.as_stream()?;
-                self.get_to_unicode_encoding(stream)
+                self.get_to_unicode_encoding(stream, limit)
             }
             name => Ok(Encoding::SimpleEncoding(name)),
         }
@@ -562,8 +586,11 @@ impl Dictionary {
         })
     }
 
-    fn get_to_unicode_encoding(&'_ self, stream: &Stream) -> Result<Encoding<'_>> {
-        let content = stream.get_plain_content()?;
+    fn get_to_unicode_encoding(&'_ self, stream: &Stream, limit: Option<usize>) -> Result<Encoding<'_>> {
+        let content = match limit {
+            Some(max) => stream.get_plain_content_with_limit(max)?,
+            None => stream.get_plain_content()?,
+        };
         let cmap = ToUnicodeCMap::parse(content)?;
         Ok(Encoding::UnicodeMapEncoding(cmap))
     }
@@ -808,6 +835,22 @@ impl Stream {
         match self.filters() {
             Ok(vec) if !vec.is_empty() => self.decompressed_content(),
             _ => Ok(self.content.clone()),
+        }
+    }
+
+    /// Bomb-safe counterpart to [`Stream::get_plain_content`]: decode the stream,
+    /// rejecting it with [`DecompressError::MemoryLimitExceeded`] if the output
+    /// would exceed `max_output` bytes. An uncompressed stream whose raw content
+    /// already exceeds the limit is rejected too.
+    pub fn get_plain_content_with_limit(&self, max_output: usize) -> Result<Vec<u8>> {
+        match self.filters() {
+            Ok(vec) if !vec.is_empty() => self.decompressed_content_with_limit(max_output),
+            _ => {
+                if self.content.len() > max_output {
+                    return Err(DecompressError::MemoryLimitExceeded { limit: max_output }.into());
+                }
+                Ok(self.content.clone())
+            }
         }
     }
 

--- a/src/object_stream.rs
+++ b/src/object_stream.rs
@@ -37,9 +37,27 @@ impl Default for ObjectStreamConfig {
 }
 
 impl ObjectStream {
-    /// Parse an existing object stream
+    /// Parse an existing object stream.
+    ///
+    /// This decompresses the stream without any size limit. For untrusted input,
+    /// prefer [`ObjectStream::new_with_limit`] to guard against decompression
+    /// bombs.
     pub fn new(stream: &mut Stream) -> Result<ObjectStream> {
-        let _ = stream.decompress();
+        Self::new_with_limit(stream, None)
+    }
+
+    /// Parse an existing object stream, rejecting it if its decompressed content
+    /// would exceed `max_decompressed_size` bytes. `None` means no limit (the
+    /// behavior of [`ObjectStream::new`]).
+    pub fn new_with_limit(stream: &mut Stream, max_decompressed_size: Option<usize>) -> Result<ObjectStream> {
+        match max_decompressed_size {
+            // Object streams are decompressed while the document is loaded, so
+            // enforcing the limit here bounds the memory a single stream can use.
+            Some(max) => stream.decompress_with_limit(max)?,
+            None => {
+                let _ = stream.decompress();
+            }
+        }
 
         if stream.content.is_empty() {
             return Ok(ObjectStream {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -542,7 +542,7 @@ pub fn xref_and_trailer(input: ParserInput, reader: &Reader) -> crate::Result<(X
             _indirect_object(input, 0, None, reader, &mut HashSet::new())
                 .map(|(_, obj)| {
                     let res = match obj {
-                        Object::Stream(stream) => decode_xref_stream(stream),
+                        Object::Stream(stream) => decode_xref_stream_with_limit(stream, reader.max_decompressed_size),
                         _ => Err(crate::error::ParseError::InvalidXref.into()),
                     };
                     (input, res)

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -49,7 +49,25 @@ impl Document {
     }
 
     pub fn extract_text(&self, page_numbers: &[u32]) -> Result<String> {
-        let text_fragments = self.extract_text_chunks(page_numbers);
+        self.extract_text_inner(page_numbers, None)
+    }
+
+    /// Extract text from the given pages, bounding the total decompressed content
+    /// of each page to `max_decompressed_size` bytes.
+    ///
+    /// This is the decompression-bomb-safe counterpart to
+    /// [`Document::extract_text`]: page content is decoded via
+    /// [`Document::get_page_content_with_limit`], so a small compressed content
+    /// stream cannot inflate without limit. Prefer it over [`Document::extract_text`]
+    /// for PDFs from an untrusted source. Returns
+    /// [`DecompressError::MemoryLimitExceeded`](crate::DecompressError::MemoryLimitExceeded)
+    /// if any requested page's content would exceed the limit.
+    pub fn extract_text_with_limit(&self, page_numbers: &[u32], max_decompressed_size: usize) -> Result<String> {
+        self.extract_text_inner(page_numbers, Some(max_decompressed_size))
+    }
+
+    fn extract_text_inner(&self, page_numbers: &[u32], limit: Option<usize>) -> Result<String> {
+        let text_fragments = self.extract_text_chunks_inner(page_numbers, limit);
         let mut text = String::new();
         for maybe_text_fragment in text_fragments.into_iter() {
             let text_fragment = maybe_text_fragment?;
@@ -60,11 +78,25 @@ impl Document {
     }
 
     pub fn extract_text_chunks(&self, page_numbers: &[u32]) -> Vec<Result<String>> {
+        self.extract_text_chunks_inner(page_numbers, None)
+    }
+
+    /// Bomb-safe counterpart to [`Document::extract_text_chunks`], bounding the
+    /// total decompressed content of each page to `max_decompressed_size` bytes.
+    /// A page whose content exceeds the limit yields an `Err` chunk carrying
+    /// [`DecompressError::MemoryLimitExceeded`](crate::DecompressError::MemoryLimitExceeded).
+    pub fn extract_text_chunks_with_limit(
+        &self, page_numbers: &[u32], max_decompressed_size: usize,
+    ) -> Vec<Result<String>> {
+        self.extract_text_chunks_inner(page_numbers, Some(max_decompressed_size))
+    }
+
+    fn extract_text_chunks_inner(&self, page_numbers: &[u32], limit: Option<usize>) -> Vec<Result<String>> {
         let pages: BTreeMap<u32, (u32, u16)> = self.get_pages();
         page_numbers
             .iter()
             .flat_map(|page_number| {
-                let result = self.extract_text_chunks_from_page(&pages, *page_number);
+                let result = self.extract_text_chunks_from_page(&pages, *page_number, limit);
                 match result {
                     Ok(text_chunks) => text_chunks,
                     Err(err) => vec![Err(err)],
@@ -74,7 +106,7 @@ impl Document {
     }
 
     fn extract_text_chunks_from_page(
-        &self, pages: &BTreeMap<u32, (u32, u16)>, page_number: u32,
+        &self, pages: &BTreeMap<u32, (u32, u16)>, page_number: u32, limit: Option<usize>,
     ) -> Result<Vec<Result<String>>> {
         let mut collected_chunks_and_errs: Vec<std::result::Result<String, Error>> = Vec::new();
 
@@ -82,15 +114,24 @@ impl Document {
         let fonts = self.get_page_fonts(page_id)?;
         let encodings: BTreeMap<Vec<u8>, Encoding> = fonts
             .into_iter()
-            .filter_map(|(name, font)| match font.get_font_encoding(self) {
-                Ok(it) => Some((name, it)),
-                Err(err) => {
-                    collected_chunks_and_errs.push(Err(err));
-                    None
+            .filter_map(|(name, font)| {
+                let encoding = match limit {
+                    Some(max) => font.get_font_encoding_with_limit(self, max),
+                    None => font.get_font_encoding(self),
+                };
+                match encoding {
+                    Ok(it) => Some((name, it)),
+                    Err(err) => {
+                        collected_chunks_and_errs.push(Err(err));
+                        None
+                    }
                 }
             })
             .collect();
-        let content_data = self.get_page_content(page_id);
+        let content_data = match limit {
+            Some(max) => self.get_page_content_with_limit(page_id, max)?,
+            None => self.get_page_content(page_id),
+        };
         let content = Content::decode(&content_data)?;
 
         // each text with different encoding is extracted as separate chunk
@@ -647,6 +688,133 @@ mod tests {
         let doc = create_document_with_texts(&[text1, text2]);
         let extracted_text = doc.extract_text(&[1, 2]);
         assert_eq!(extracted_text.unwrap(), format!("{text1}\n{text2}\n"));
+    }
+
+    const BOMB_MIB: usize = 1024 * 1024;
+
+    /// A FlateDecode-compressed stream that inflates to `target` zero-bytes, built
+    /// by streaming zeros through the compressor so the test process never holds
+    /// `target` bytes at once.
+    fn flate_bomb(target: usize) -> Vec<u8> {
+        use flate2::write::ZlibEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::best());
+        let zeros = [0u8; 64 * 1024];
+        let mut remaining = target;
+        while remaining > 0 {
+            let n = remaining.min(zeros.len());
+            encoder.write_all(&zeros[..n]).unwrap();
+            remaining -= n;
+        }
+        encoder.finish().unwrap()
+    }
+
+    /// A `create_document_with_texts` document whose first page's content stream
+    /// has been swapped for a FlateDecode bomb that inflates to `target` bytes.
+    fn doc_with_page_content_bomb(target: usize) -> crate::Document {
+        use crate::{Dictionary, Object, Stream};
+
+        let mut doc = create_document_with_texts(&["Hello"]);
+        let page_id = *doc.get_pages().get(&1).expect("page 1 exists");
+        let content_id = doc.get_page_contents(page_id)[0];
+        let mut dict = Dictionary::new();
+        dict.set("Filter", "FlateDecode");
+        doc.objects.insert(content_id, Object::Stream(Stream::new(dict, flate_bomb(target))));
+        doc
+    }
+
+    /// A `create_document_with_texts` document whose font carries a `/ToUnicode`
+    /// CMap that is a FlateDecode bomb. Font encodings are resolved (and thus this
+    /// stream is decoded) during text extraction, *before* the page content — so
+    /// this exercises a decompression vector distinct from page content.
+    fn doc_with_tounicode_font_bomb(target: usize) -> crate::Document {
+        use crate::{Dictionary, Object, Stream};
+
+        let mut doc = create_document_with_texts(&["Hello"]);
+        let font_id = doc
+            .objects
+            .iter()
+            .find(|(_, obj)| obj.as_dict().map(|d| d.has_type(b"Font")).unwrap_or(false))
+            .map(|(id, _)| *id)
+            .expect("font object exists");
+
+        let mut tounicode_dict = Dictionary::new();
+        tounicode_dict.set("Filter", "FlateDecode");
+        let tounicode_id = doc.add_object(Object::Stream(Stream::new(tounicode_dict, flate_bomb(target))));
+
+        let font = doc.get_object_mut(font_id).and_then(Object::as_dict_mut).unwrap();
+        font.set("ToUnicode", Object::Reference(tounicode_id));
+        doc
+    }
+
+    use crate::creator::tests::create_document_with_texts;
+
+    /// Under a generous limit, `extract_text_with_limit` returns exactly the same
+    /// text as the unbounded `extract_text`.
+    #[test]
+    fn extract_text_with_limit_matches_unbounded_under_limit() {
+        use crate::creator::tests::create_document_with_texts;
+
+        let text1 = "Hello world!";
+        let text2 = "Ferris is the best!";
+        let doc = create_document_with_texts(&[text1, text2]);
+
+        let bounded = doc.extract_text_with_limit(&[1, 2], BOMB_MIB).unwrap();
+        let unbounded = doc.extract_text(&[1, 2]).unwrap();
+        assert_eq!(bounded, unbounded);
+    }
+
+    /// A page-content decompression bomb is rejected end-to-end by
+    /// `extract_text_with_limit` instead of inflating without bound.
+    #[test]
+    fn extract_text_with_limit_rejects_page_content_bomb() {
+        use crate::{DecompressError, Error};
+
+        let doc = doc_with_page_content_bomb(32 * BOMB_MIB);
+
+        match doc.extract_text_with_limit(&[1], 4 * BOMB_MIB).map(|s| s.len()) {
+            Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit })) => {
+                assert_eq!(limit, 4 * BOMB_MIB);
+            }
+            other => panic!("expected MemoryLimitExceeded, got {other:?}"),
+        }
+    }
+
+    /// The chunked variant surfaces the same bomb as an `Err` chunk rather than
+    /// panicking or silently truncating.
+    #[test]
+    fn extract_text_chunks_with_limit_surfaces_limit_error() {
+        use crate::{DecompressError, Error};
+
+        let doc = doc_with_page_content_bomb(32 * BOMB_MIB);
+        let chunks = doc.extract_text_chunks_with_limit(&[1], 4 * BOMB_MIB);
+
+        assert!(
+            chunks.iter().any(|chunk| matches!(
+                chunk,
+                Err(Error::Decompress(DecompressError::MemoryLimitExceeded { .. }))
+            )),
+            "expected a MemoryLimitExceeded error chunk"
+        );
+    }
+
+    /// A bomb reached through a font's `/ToUnicode` CMap (decoded during encoding
+    /// resolution, before page content) is also bounded by `extract_text_with_limit`
+    /// — otherwise the "safe for untrusted input" guarantee has a hole.
+    #[test]
+    fn extract_text_with_limit_rejects_tounicode_font_bomb() {
+        use crate::{DecompressError, Error};
+
+        let doc = doc_with_tounicode_font_bomb(32 * BOMB_MIB);
+
+        match doc.extract_text_with_limit(&[1], 4 * BOMB_MIB).map(|s| s.len()) {
+            Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit })) => {
+                assert_eq!(limit, 4 * BOMB_MIB);
+            }
+            other => panic!("expected MemoryLimitExceeded from ToUnicode font bomb, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -484,9 +484,20 @@ fn encode_with_fallback(encoding: &Encoding, text: &str, default_char: &str) -> 
 }
 
 /// Decode CrossReferenceStream
-pub fn decode_xref_stream(mut stream: Stream) -> Result<(Xref, Dictionary)> {
+pub fn decode_xref_stream(stream: Stream) -> Result<(Xref, Dictionary)> {
+    decode_xref_stream_with_limit(stream, None)
+}
+
+/// Decode a cross-reference stream, rejecting it if its decompressed content
+/// would exceed `max_decompressed_size` bytes. `None` means no limit (the
+/// behavior of [`decode_xref_stream`]). Cross-reference streams are decoded
+/// early during loading, so this bounds the memory a `/XRef` stream can use.
+pub fn decode_xref_stream_with_limit(mut stream: Stream, max_decompressed_size: Option<usize>) -> Result<(Xref, Dictionary)> {
     if stream.is_compressed() {
-        stream.decompress()?;
+        match max_decompressed_size {
+            Some(max) => stream.decompress_with_limit(max)?,
+            None => stream.decompress()?,
+        }
     }
     let mut dict = stream.dict;
     let mut reader = Cursor::new(stream.content);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -85,6 +85,7 @@ impl Document {
             raw_objects: BTreeMap::new(),
             password: options.password,
             strict: options.strict,
+            max_decompressed_size: options.max_decompressed_size,
         }
         .read(options.filter)
     }
@@ -103,6 +104,7 @@ impl Document {
             raw_objects: BTreeMap::new(),
             password: options.password,
             strict: options.strict,
+            max_decompressed_size: options.max_decompressed_size,
         }
         .read(options.filter)
     }
@@ -152,6 +154,7 @@ impl Document {
             raw_objects: BTreeMap::new(),
             password: None,
             strict: false,
+            max_decompressed_size: None,
         }
         .read_metadata()
     }
@@ -166,6 +169,7 @@ impl Document {
             raw_objects: BTreeMap::new(),
             password: Some(password.to_string()),
             strict: false,
+            max_decompressed_size: None,
         }
         .read_metadata()
     }
@@ -183,6 +187,7 @@ impl Document {
             raw_objects: BTreeMap::new(),
             password,
             strict: false,
+            max_decompressed_size: None,
         }
         .read_metadata()
     }
@@ -225,6 +230,7 @@ impl Document {
             raw_objects: BTreeMap::new(),
             password: options.password,
             strict: options.strict,
+            max_decompressed_size: options.max_decompressed_size,
         }
         .read(options.filter)
     }
@@ -243,6 +249,7 @@ impl Document {
             raw_objects: BTreeMap::new(),
             password: options.password,
             strict: options.strict,
+            max_decompressed_size: options.max_decompressed_size,
         }
         .read(options.filter)
     }
@@ -288,6 +295,7 @@ impl Document {
             raw_objects: BTreeMap::new(),
             password: None,
             strict: false,
+            max_decompressed_size: None,
         }
         .read_metadata()
     }
@@ -302,6 +310,7 @@ impl Document {
             raw_objects: BTreeMap::new(),
             password: Some(password.to_string()),
             strict: false,
+            max_decompressed_size: None,
         }
         .read_metadata()
     }
@@ -321,6 +330,7 @@ impl Document {
             raw_objects: BTreeMap::new(),
             password,
             strict: false,
+            max_decompressed_size: None,
         }
         .read_metadata()
     }
@@ -337,6 +347,7 @@ impl TryInto<Document> for &[u8] {
             raw_objects: BTreeMap::new(),
             password: None,
             strict: false,
+            max_decompressed_size: None,
         }
         .read(None)
     }
@@ -369,6 +380,7 @@ impl IncrementalDocument {
             raw_objects: BTreeMap::new(),
             password: None,
             strict: false,
+            max_decompressed_size: None,
         }
         .read(None)?;
 
@@ -411,6 +423,7 @@ impl IncrementalDocument {
             raw_objects: BTreeMap::new(),
             password: None,
             strict: false,
+            max_decompressed_size: None,
         }
         .read(None)?;
 
@@ -434,6 +447,7 @@ impl TryInto<IncrementalDocument> for &[u8] {
             raw_objects: BTreeMap::new(),
             password: None,
             strict: false,
+            max_decompressed_size: None,
         }
         .read(None)?;
 
@@ -448,6 +462,11 @@ pub struct Reader<'a> {
     pub raw_objects: BTreeMap<ObjectId, Vec<u8>>, // Store raw bytes for encrypted objects
     pub password: Option<String>,                 // Password for encrypted PDFs
     pub strict: bool,                             // Reject non-conforming PDFs when true
+    /// Maximum decompressed size, in bytes, allowed for any single stream
+    /// (object streams and cross-reference streams) decoded during loading.
+    /// `None` (the default) applies no limit; set it to guard against
+    /// decompression bombs. See [`crate::LoadOptions`].
+    pub max_decompressed_size: Option<usize>,
 }
 
 /// Maximum allowed embedding of literal strings.
@@ -911,7 +930,7 @@ impl Reader<'_> {
                 if let Some(container_obj) = self.document.objects.get_mut(&(container_id, 0))
                     && let Ok(stream) = container_obj.as_stream_mut()
                 {
-                    match ObjectStream::new(stream) {
+                    match ObjectStream::new_with_limit(stream, self.max_decompressed_size) {
                         Ok(object_stream) => {
                             for (obj_num, _index) in objects_in_stream {
                                 let obj_id = (obj_num, 0);
@@ -986,7 +1005,7 @@ impl Reader<'_> {
 
                 if let Ok(ref mut stream) = object.as_stream_mut() {
                     if stream.dict.has_type(b"ObjStm") && !is_encrypted {
-                        let obj_stream = ObjectStream::new(stream).ok()?;
+                        let obj_stream = ObjectStream::new_with_limit(stream, self.max_decompressed_size).ok()?;
                         let container_id = object_id.0;
                         let mut object_streams = object_streams.lock().unwrap();
                         if let Some(filter_func) = filter_func {
@@ -1116,7 +1135,7 @@ impl Reader<'_> {
         let mut already_seen = HashSet::new();
         let container_obj = self.get_object(container_id, &mut already_seen)?;
         let mut container_stream = container_obj.as_stream()?.clone();
-        let object_stream = ObjectStream::new(&mut container_stream)?;
+        let object_stream = ObjectStream::new_with_limit(&mut container_stream, self.max_decompressed_size)?;
         object_stream.objects.get(&id).cloned().ok_or(Error::MissingXrefEntry)
     }
 

--- a/src/xref.rs
+++ b/src/xref.rs
@@ -166,7 +166,7 @@ impl XrefSection {
     }
 }
 
-pub use crate::parser_aux::decode_xref_stream;
+pub use crate::parser_aux::{decode_xref_stream, decode_xref_stream_with_limit};
 
 /// Encode a field value as big-endian bytes with specified width
 fn encode_field(value: u64, width: usize, output: &mut Vec<u8>) {

--- a/tests/decompression_bomb.rs
+++ b/tests/decompression_bomb.rs
@@ -1,0 +1,77 @@
+//! Tests demonstrating that PDF stream decompression is unbounded.
+//!
+//! `Stream::decompressed_content` inflates `FlateDecode` data into an unbounded
+//! `Vec`, so a small compressed stream can expand to an arbitrarily large
+//! output (a decompression bomb). Nested filters multiply the amplification.
+//!
+//! Bombs are built by streaming zeros through the compressor, so the test
+//! process itself never allocates the full (large) plaintext.
+
+use flate2::write::ZlibEncoder;
+use flate2::Compression;
+use std::io::Write;
+
+use lopdf::{Dictionary, Object, Stream};
+
+const MIB: usize = 1024 * 1024;
+
+/// A zlib stream that decodes to `target` zero-bytes, built without ever holding
+/// `target` bytes in memory at once.
+fn flate_bomb(target: usize) -> Vec<u8> {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::best());
+    let zeros = [0u8; 64 * 1024];
+    let mut remaining = target;
+    while remaining > 0 {
+        let n = remaining.min(zeros.len());
+        encoder.write_all(&zeros[..n]).unwrap();
+        remaining -= n;
+    }
+    encoder.finish().unwrap()
+}
+
+/// Compress arbitrary bytes with zlib (always emits a valid stream).
+fn zlib_compress(data: &[u8]) -> Vec<u8> {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::best());
+    encoder.write_all(data).unwrap();
+    encoder.finish().unwrap()
+}
+
+/// A single `FlateDecode` stream inflates ~32 KiB of input to 32 MiB of output
+/// (~1000x) with no cap — the library materializes the whole thing.
+#[test]
+fn single_filter_bomb_expands_without_limit() {
+    let mut dict = Dictionary::new();
+    dict.set("Filter", "FlateDecode");
+    let bomb = Stream::new(dict, flate_bomb(32 * MIB));
+
+    assert!(
+        bomb.content.len() < 128 * 1024,
+        "input should be tiny: {} bytes",
+        bomb.content.len()
+    );
+
+    let output = bomb.decompressed_content().expect("decodes");
+    assert_eq!(output.len(), 32 * MIB, "the full output was materialized with no cap");
+}
+
+/// Chained filters multiply the amplification: under 8 KiB of input expands to
+/// 32 MiB through `[FlateDecode FlateDecode]`. Additional layers reach petabyte
+/// scale — an instant out-of-memory kill.
+#[test]
+fn chained_filter_bomb_expands_without_limit() {
+    let inner = flate_bomb(32 * MIB); // layer 2 decodes this -> 32 MiB
+    let outer = zlib_compress(&inner); // layer 1 decodes to `inner` (tiny)
+
+    let mut dict = Dictionary::new();
+    dict.set("Filter", vec![Object::from("FlateDecode"), Object::from("FlateDecode")]);
+    let stream = Stream::new(dict, outer);
+
+    assert!(
+        stream.content.len() < 8 * 1024,
+        "input should be under 8 KiB: {} bytes",
+        stream.content.len()
+    );
+
+    let output = stream.decompressed_content().expect("decodes");
+    assert_eq!(output.len(), 32 * MIB, "nested filters expanded fully, no cap");
+}

--- a/tests/decompression_bomb.rs
+++ b/tests/decompression_bomb.rs
@@ -14,7 +14,7 @@ use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use std::io::Write;
 
-use lopdf::{DecompressError, Dictionary, Document, Error, LoadOptions, Object, ObjectStream, Stream};
+use lopdf::{DecompressError, Dictionary, Document, Error, LoadOptions, Object, ObjectId, ObjectStream, Stream};
 
 const MIB: usize = 1024 * 1024;
 
@@ -203,6 +203,91 @@ fn load_time_xref_stream_bomb_is_rejected_with_limit() {
         Err(other) => panic!("expected MemoryLimitExceeded during load, got {other:?}"),
         Ok(_) => panic!("bomb PDF loaded without hitting the decompression limit"),
     }
+}
+
+// Page content is decompressed on demand by `Document::get_page_content` (and
+// thus `extract_text`), which is unbounded. `get_page_content_with_limit` bounds
+// the whole concatenated page content to a caller-supplied budget.
+
+/// Build a single-page document whose `/Contents` is the given streams, and
+/// return the document plus the page's object id. No page tree / fonts, so this
+/// exercises `get_page_content_with_limit` directly (not the full extract path).
+fn doc_with_page_streams(streams: Vec<Stream>) -> (Document, ObjectId) {
+    let mut doc = Document::with_version("1.5");
+    let content_refs: Vec<Object> = streams.into_iter().map(|s| doc.add_object(s).into()).collect();
+    let mut page = Dictionary::new();
+    page.set("Type", "Page");
+    page.set("Contents", Object::Array(content_refs));
+    let page_id = doc.add_object(page);
+    (doc, page_id)
+}
+
+/// A bomb in a page's content stream is rejected by `get_page_content_with_limit`
+/// before the full output is allocated.
+#[test]
+fn page_content_bomb_is_rejected_with_limit() {
+    let (doc, page_id) = doc_with_page_streams(vec![flate_stream(flate_bomb(32 * MIB))]);
+    assert_limit_err(doc.get_page_content_with_limit(page_id, 4 * MIB), 4 * MIB);
+}
+
+/// A page comfortably under the limit yields exactly the same bytes as the
+/// unbounded `get_page_content` (including the inter-stream `\n` separators).
+#[test]
+fn page_content_under_limit_matches_unbounded() {
+    let (doc, page_id) = doc_with_page_streams(vec![
+        flate_stream(zlib_compress(b"1 0 0 1 50 100 cm")),
+        flate_stream(zlib_compress(b"BT /F1 12 Tf (hi) Tj ET")),
+    ]);
+
+    let bounded = doc
+        .get_page_content_with_limit(page_id, MIB)
+        .expect("small page content should decode under the limit");
+    assert_eq!(bounded, doc.get_page_content(page_id));
+}
+
+/// The limit is a *total-page* budget, not a per-stream one: two streams that are
+/// each individually under the limit but together exceed it are rejected. (A
+/// per-stream bound would have let this through.)
+#[test]
+fn page_content_limit_is_total_across_streams() {
+    let (doc, page_id) = doc_with_page_streams(vec![
+        flate_stream(flate_bomb(3 * MIB)),
+        flate_stream(flate_bomb(3 * MIB)),
+    ]);
+
+    // Each stream (3 MiB) is under 4 MiB, but 3 + 3 > 4, so the page is rejected.
+    assert_limit_err(doc.get_page_content_with_limit(page_id, 4 * MIB), 4 * MIB);
+}
+
+/// A large *uncompressed* (no `/Filter`) content stream is also bounded: the raw
+/// bytes count against the budget, so it can't bypass the guard.
+#[test]
+fn page_content_uncompressed_over_limit_is_rejected() {
+    let raw = Stream::new(Dictionary::new(), vec![b'x'; 2 * MIB]);
+    let (doc, page_id) = doc_with_page_streams(vec![raw]);
+    assert_limit_err(doc.get_page_content_with_limit(page_id, MIB), MIB);
+}
+
+/// When a stream can't be decoded for a reason *other* than the size limit (here
+/// an unimplemented filter), the code falls back to the raw bytes — but that
+/// fallback is still bounded, so oversized raw content is rejected rather than
+/// silently appended.
+#[test]
+fn page_content_raw_fallback_stays_bounded() {
+    let mut dict = Dictionary::new();
+    dict.set("Filter", "DCTDecode"); // not implemented → decode fails with a non-limit error
+    let undecodable = Stream::new(dict, vec![b'x'; 2 * MIB]);
+
+    let (doc, page_id) = doc_with_page_streams(vec![undecodable]);
+    assert_limit_err(doc.get_page_content_with_limit(page_id, MIB), MIB);
+}
+
+/// A zero limit rejects any non-empty page content without panicking (the
+/// `remaining` budget uses `saturating_sub`).
+#[test]
+fn page_content_zero_limit_rejects_nonempty() {
+    let (doc, page_id) = doc_with_page_streams(vec![flate_stream(zlib_compress(b"BT ET"))]);
+    assert_limit_err(doc.get_page_content_with_limit(page_id, 0), 0);
 }
 
 /// An object stream (`/ObjStm`) is decompressed eagerly during load; the bounded

--- a/tests/decompression_bomb.rs
+++ b/tests/decompression_bomb.rs
@@ -1,8 +1,11 @@
-//! Tests demonstrating that PDF stream decompression is unbounded.
+//! Tests for bounded stream decompression (decompression-bomb handling).
 //!
-//! `Stream::decompressed_content` inflates `FlateDecode` data into an unbounded
-//! `Vec`, so a small compressed stream can expand to an arbitrarily large
-//! output (a decompression bomb). Nested filters multiply the amplification.
+//! By default `Stream::decompressed_content` is unbounded, so a small compressed
+//! stream can inflate to an arbitrarily large output (a decompression bomb).
+//! These tests cover both the unbounded behavior and the bounded API
+//! (`decompressed_content_with_limit`, `decompress_to_writer`, and
+//! `LoadOptions::max_decompressed_size`) that rejects oversized output,
+//! including nested filters and streams decoded during `Document::load`.
 //!
 //! Bombs are built by streaming zeros through the compressor, so the test
 //! process itself never allocates the full (large) plaintext.
@@ -11,7 +14,7 @@ use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use std::io::Write;
 
-use lopdf::{Dictionary, Object, Stream};
+use lopdf::{DecompressError, Dictionary, Document, Error, LoadOptions, Object, ObjectStream, Stream};
 
 const MIB: usize = 1024 * 1024;
 
@@ -36,14 +39,29 @@ fn zlib_compress(data: &[u8]) -> Vec<u8> {
     encoder.finish().unwrap()
 }
 
+fn flate_stream(content: Vec<u8>) -> Stream {
+    let mut dict = Dictionary::new();
+    dict.set("Filter", "FlateDecode");
+    Stream::new(dict, content)
+}
+
+/// Assert a result is the memory-limit error for `expected_limit`, without ever
+/// `Debug`-printing a multi-megabyte success value.
+fn assert_limit_err(result: lopdf::Result<Vec<u8>>, expected_limit: usize) {
+    match result.map(|v| v.len()) {
+        Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit })) => {
+            assert_eq!(limit, expected_limit, "error reported the wrong limit");
+        }
+        Ok(n) => panic!("expected MemoryLimitExceeded, but decompressed {n} bytes"),
+        Err(other) => panic!("expected MemoryLimitExceeded, got {other:?}"),
+    }
+}
+
 /// A single `FlateDecode` stream inflates ~32 KiB of input to 32 MiB of output
 /// (~1000x) with no cap — the library materializes the whole thing.
 #[test]
 fn single_filter_bomb_expands_without_limit() {
-    let mut dict = Dictionary::new();
-    dict.set("Filter", "FlateDecode");
-    let bomb = Stream::new(dict, flate_bomb(32 * MIB));
-
+    let bomb = flate_stream(flate_bomb(32 * MIB));
     assert!(
         bomb.content.len() < 128 * 1024,
         "input should be tiny: {} bytes",
@@ -56,7 +74,7 @@ fn single_filter_bomb_expands_without_limit() {
 
 /// Chained filters multiply the amplification: under 8 KiB of input expands to
 /// 32 MiB through `[FlateDecode FlateDecode]`. Additional layers reach petabyte
-/// scale — an instant out-of-memory kill.
+/// scale.
 #[test]
 fn chained_filter_bomb_expands_without_limit() {
     let inner = flate_bomb(32 * MIB); // layer 2 decodes this -> 32 MiB
@@ -74,4 +92,135 @@ fn chained_filter_bomb_expands_without_limit() {
 
     let output = stream.decompressed_content().expect("decodes");
     assert_eq!(output.len(), 32 * MIB, "nested filters expanded fully, no cap");
+}
+
+/// With a limit supplied, the same bomb is rejected before the full 32 MiB is
+/// allocated.
+#[test]
+fn flate_bomb_rejected_with_limit() {
+    let bomb = flate_stream(flate_bomb(32 * MIB));
+    assert_limit_err(bomb.decompressed_content_with_limit(4 * MIB), 4 * MIB);
+}
+
+/// A stream comfortably under the limit still decodes correctly.
+#[test]
+fn legit_stream_decompresses_under_limit() {
+    let payload: Vec<u8> = (0..64 * 1024).map(|i| (i % 251) as u8).collect();
+    let stream = flate_stream(zlib_compress(&payload));
+
+    let output = stream
+        .decompressed_content_with_limit(1 * MIB)
+        .expect("stream under the limit should decode");
+    assert_eq!(output, payload);
+}
+
+/// The same stream passes or fails based on the chosen limit.
+#[test]
+fn custom_limit_is_enforced() {
+    let stream = flate_stream(flate_bomb(2 * MIB));
+
+    // Limit below the output size: rejected.
+    assert_limit_err(stream.decompressed_content_with_limit(1 * MIB), 1 * MIB);
+
+    // Limit above the output size: decoded in full.
+    let output = stream
+        .decompressed_content_with_limit(4 * MIB)
+        .expect("2 MiB output fits under a 4 MiB limit");
+    assert_eq!(output.len(), 2 * MIB);
+}
+
+/// Nested filters (`/Filter [FlateDecode FlateDecode]`) amplify per layer. The
+/// limit bounds each layer, so the bomb is rejected at the second layer instead
+/// of expanding.
+#[test]
+fn chained_flate_filters_are_bounded() {
+    let inner = flate_bomb(32 * MIB); // layer 2 decodes this -> 32 MiB
+    let outer = zlib_compress(&inner); // layer 1 decodes to `inner` (tiny)
+
+    let mut dict = Dictionary::new();
+    dict.set("Filter", vec![Object::from("FlateDecode"), Object::from("FlateDecode")]);
+    let stream = Stream::new(dict, outer);
+
+    assert_limit_err(stream.decompressed_content_with_limit(4 * MIB), 4 * MIB);
+}
+
+/// `decompress_to_writer` enforces the same bound and leaves the caller's sink
+/// untouched on rejection.
+#[test]
+fn decompress_to_writer_bounds_output() {
+    let bomb = flate_stream(flate_bomb(32 * MIB));
+
+    let mut sink: Vec<u8> = Vec::new();
+    let result = bomb.decompress_to_writer(&mut sink, 4 * MIB);
+
+    match result {
+        Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit })) => {
+            assert_eq!(limit, 4 * MIB);
+        }
+        other => panic!("expected MemoryLimitExceeded, got {:?}", other.map(|n| format!("Ok({n})"))),
+    }
+    assert!(sink.is_empty(), "sink should be untouched on rejection, got {} bytes", sink.len());
+}
+
+// Object streams and cross-reference streams are decompressed while the document
+// is loaded, so the limit is supplied through `LoadOptions` to reach them.
+
+/// Build a PDF whose cross-reference stream (`/Type /XRef`) is a FlateDecode
+/// bomb. The reference stream is decoded during `Document::load` to build the
+/// xref table.
+fn xref_stream_bomb_pdf(bomb: &[u8]) -> Vec<u8> {
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.5\n");
+    let obj_offset = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n");
+    pdf.extend_from_slice(
+        format!(
+            "<< /Type /XRef /Size 1 /W [1 1 1] /Root 1 0 R /Filter /FlateDecode /Length {} >>\n",
+            bomb.len()
+        )
+        .as_bytes(),
+    );
+    // Framing matches lopdf's parser: `stream<eol><exactly Length bytes><eol>endstream`.
+    pdf.extend_from_slice(b"stream\n");
+    pdf.extend_from_slice(bomb);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+    pdf.extend_from_slice(format!("startxref\n{obj_offset}\n%%EOF").as_bytes());
+    pdf
+}
+
+/// A bomb in the cross-reference stream is rejected during load when
+/// `max_decompressed_size` is set.
+#[test]
+fn load_time_xref_stream_bomb_is_rejected_with_limit() {
+    let pdf = xref_stream_bomb_pdf(&flate_bomb(64 * MIB));
+
+    let result = Document::load_mem_with_options(&pdf, LoadOptions::with_max_decompressed_size(4 * MIB));
+
+    match result {
+        Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit })) => {
+            assert_eq!(limit, 4 * MIB);
+        }
+        Err(other) => panic!("expected MemoryLimitExceeded during load, got {other:?}"),
+        Ok(_) => panic!("bomb PDF loaded without hitting the decompression limit"),
+    }
+}
+
+/// An object stream (`/ObjStm`) is decompressed eagerly during load; the bounded
+/// constructor rejects an oversized stream.
+#[test]
+fn object_stream_bomb_is_rejected_with_limit() {
+    let mut dict = Dictionary::new();
+    dict.set("Type", "ObjStm");
+    dict.set("N", 1i64);
+    dict.set("First", 0i64);
+    dict.set("Filter", "FlateDecode");
+    let mut stream = Stream::new(dict, flate_bomb(64 * MIB));
+
+    match ObjectStream::new_with_limit(&mut stream, Some(4 * MIB)) {
+        Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit })) => {
+            assert_eq!(limit, 4 * MIB);
+        }
+        Err(other) => panic!("expected MemoryLimitExceeded, got {other:?}"),
+        Ok(_) => panic!("object stream bomb was not caught"),
+    }
 }


### PR DESCRIPTION
I wanted to use this library to parse untrusted PDFs, but there is not currently a way to limit the amount of memory a decompressed PDF could take.

This PR is split into 4 commits: a test demonstrating that a simple decompression bomb can cause it to allocate a huge multiple of the size of the compressed PDF, and then three that extend the API to include options to limit the decompressed size. It might also be worth limiting the decompression factor by default, though I left that out of this PR because it would change the behavior for existing users of this library.

The commits were authored by Claude Code and reviewed by me. If you would prefer not to have AI-authored code in the library, feel free to take the test and fix the problem in another way.