### PR TITLE
fix(writer): reject incremental save of encrypted documents

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -276,6 +276,15 @@ impl IncrementalDocument {
     }
 
     fn save_internal<W: Write>(&mut self, target: &mut W) -> Result<()> {
+        if self.get_prev_documents().was_encrypted() || self.get_prev_documents().is_encrypted() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "incremental update of an encrypted PDF is not supported yet: \
+                 saving would write unencrypted objects into an encrypted file and corrupt it \
+                 (see https://github.com/J-F-Liu/lopdf/issues/520)",
+            ));
+        }
+
         let mut target = CountingWrite {
             inner: target,
             bytes_written: 0,

--- a/tests/incremental_document.rs
+++ b/tests/incremental_document.rs
@@ -1,4 +1,5 @@
-use lopdf::Result;
+use lopdf::{Document, EncryptionState, EncryptionVersion, IncrementalDocument, Object, Permissions, Result};
+use std::io;
 use tempfile::tempdir;
 
 mod utils;
@@ -22,4 +23,86 @@ fn load_incremental_file() -> Result<()> {
     doc.save(file_path)?;
 
     Ok(())
+}
+
+/// Build a minimal document that has everything `EncryptionVersion::V1`
+/// needs to derive an encryption key (a `Root` entry and a file `ID`).
+fn minimal_encryptable_document() -> Document {
+    let mut doc = Document::with_version("1.5");
+    let catalog_id = doc.add_object(lopdf::dictionary! { "Type" => "Catalog" });
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+    doc.trailer.set(
+        "ID",
+        Object::Array(vec![
+            Object::string_literal(vec![1u8; 16]),
+            Object::string_literal(vec![2u8; 16]),
+        ]),
+    );
+    doc
+}
+
+/// Incremental save of a *decrypted* document (regression test for
+/// https://github.com/J-F-Liu/lopdf/issues/520): the appended trailer would
+/// lack `/Encrypt` while the original bytes remain ciphertext, so this must
+/// be rejected rather than silently producing a corrupt file.
+#[test]
+fn incremental_save_of_decrypted_document_is_rejected() {
+    let mut doc = minimal_encryptable_document();
+
+    let encryption_version = EncryptionVersion::V1 {
+        document: &doc,
+        owner_password: "owner",
+        user_password: "user",
+        permissions: Permissions::all(),
+    };
+    let encryption_state = EncryptionState::try_from(encryption_version).unwrap();
+    doc.encrypt(&encryption_state).unwrap();
+
+    let mut prev_bytes = Vec::new();
+    doc.save_to(&mut prev_bytes).unwrap();
+
+    let mut loaded = Document::load_mem(&prev_bytes).unwrap();
+    loaded.decrypt("user").unwrap();
+    assert!(!loaded.is_encrypted());
+    assert!(loaded.was_encrypted());
+
+    let mut incremental = IncrementalDocument::create_from(prev_bytes, loaded);
+    incremental.new_document.add_object(Object::Integer(42));
+
+    let mut out = Vec::new();
+    let err = incremental.save_to(&mut out).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+}
+
+/// Incremental save of a still-*encrypted* (never decrypted) document must
+/// also be rejected: the trailer still carries `/Encrypt`, but any newly
+/// appended objects would be written as plaintext, which readers would
+/// misinterpret as ciphertext.
+#[test]
+fn incremental_save_of_still_encrypted_document_is_rejected() {
+    let mut doc = minimal_encryptable_document();
+
+    let encryption_version = EncryptionVersion::V1 {
+        document: &doc,
+        owner_password: "owner",
+        user_password: "user",
+        permissions: Permissions::all(),
+    };
+    let encryption_state = EncryptionState::try_from(encryption_version).unwrap();
+    doc.encrypt(&encryption_state).unwrap();
+
+    let mut prev_bytes = Vec::new();
+    doc.save_to(&mut prev_bytes).unwrap();
+
+    // Load without decrypting: `is_encrypted()` stays true.
+    let loaded = Document::load_mem(&prev_bytes).unwrap();
+    assert!(loaded.is_encrypted());
+    assert!(!loaded.was_encrypted());
+
+    let mut incremental = IncrementalDocument::create_from(prev_bytes, loaded);
+    incremental.new_document.add_object(Object::Integer(42));
+
+    let mut out = Vec::new();
+    let err = incremental.save_to(&mut out).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
 }


### PR DESCRIPTION
Fixes the silent-corruption half of #520.

When a password-protected PDF is loaded and decrypted, `decrypt_raw()` strips `/Encrypt` from the trailer and leaves the decrypted parameters in `Document::encryption_state`. Saving an `IncrementalDocument` built from such a document appends plaintext objects and a trailer without `/Encrypt` on top of the still-encrypted original bytes, producing a file that readers cannot interpret consistently. The symmetric case (still-encrypted document, plaintext new objects under a trailer that *does* carry `/Encrypt`) is equally corrupt.

This PR makes both cases fail fast with `io::ErrorKind::Unsupported` instead of silently writing a corrupt file. Actual support for encrypted incremental updates (re-encrypting appended objects with the existing `EncryptionState` and restoring the `/Encrypt` reference in the appended trailer) is prepared as a follow-up PR; this guard is intentionally minimal so the dangerous path is closed immediately.

No public API changes: `save`/`save_to` already return `std::io::Result`.

Note: `Document::save` (full save) also has an analogous issue when writing an already-decrypted document back out; that is out of scope here and tracked separately (see #479).
