### PR TITLE
feat(writer): support incremental save of encrypted documents

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -457,7 +457,7 @@ impl Document {
         // Find the ID of the encryption dict; we'll want to skip it when decrypting
         let encryption_obj_id = self.trailer.get(b"Encrypt").and_then(Object::as_reference)?;
 
-        let state = EncryptionState::decode(&*self, password)?;
+        let mut state = EncryptionState::decode(&*self, password)?;
 
         for (&id, obj) in self.objects.iter_mut() {
             // The encryption dictionary is not encrypted, leave it alone
@@ -496,6 +496,12 @@ impl Document {
 
         let object_id = self.trailer.remove(b"Encrypt").unwrap().as_reference()?;
         self.objects.remove(&object_id);
+
+        // Remember the object id of the original /Encrypt dictionary so that
+        // callers doing an incremental save can point the appended trailer's
+        // /Encrypt back at the (still-intact) dictionary bytes in the previous
+        // revision. See `IncrementalDocument::save_internal`.
+        state.encrypt_object_id = Some(object_id);
 
         self.encryption_state = Some(state);
 

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -216,6 +216,11 @@ pub struct EncryptionState {
     pub(crate) user_encrypted: Vec<u8>,
     pub(crate) permissions: Permissions,
     pub(crate) permission_encrypted: Vec<u8>,
+    /// Object id of the `/Encrypt` dictionary in the previous revision, recorded
+    /// during `Document::decrypt_raw` before the reference is stripped from the
+    /// trailer. Used by `IncrementalDocument` to restore the `/Encrypt` reference
+    /// in the appended trailer.
+    pub(crate) encrypt_object_id: Option<ObjectId>,
 }
 
 impl TryFrom<EncryptionVersion<'_>> for EncryptionState {
@@ -405,6 +410,7 @@ impl TryFrom<EncryptionVersion<'_>> for EncryptionState {
                     user_encrypted: algorithm.user_encrypted,
                     permissions: algorithm.permissions,
                     permission_encrypted: algorithm.permission_encrypted,
+                    encrypt_object_id: None,
                 })
             }
             EncryptionVersion::V5 {
@@ -463,6 +469,7 @@ impl TryFrom<EncryptionVersion<'_>> for EncryptionState {
                     user_encrypted: algorithm.user_encrypted,
                     permissions: algorithm.permissions,
                     permission_encrypted: algorithm.permission_encrypted,
+                    encrypt_object_id: None,
                 })
             }
         }
@@ -524,6 +531,14 @@ impl EncryptionState {
 
     pub fn permission_encrypted(&self) -> &[u8] {
         self.permission_encrypted.as_ref()
+    }
+
+    /// Object id of the original `/Encrypt` dictionary, when known. This is
+    /// recorded during `Document::decrypt_raw`; the dictionary bytes themselves
+    /// are left intact in the previous revision so that an incremental save can
+    /// point back at them via `/Encrypt N G R` without re-emitting the dictionary.
+    pub fn encrypt_object_id(&self) -> Option<ObjectId> {
+        self.encrypt_object_id
     }
 
     pub fn decode<P>(document: &Document, password: P) -> Result<Self, Error>

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -944,7 +944,12 @@ impl Reader<'_> {
                 }
             }
 
-            self.document.encryption_state = Some(state.clone());
+            let mut stored_state = state.clone();
+            // Record the /Encrypt dictionary's object id so that a later
+            // incremental save can restore `/Encrypt N G R` in the appended
+            // trailer. See `IncrementalDocument::save_internal`.
+            stored_state.encrypt_object_id = encrypt_ref;
+            self.document.encryption_state = Some(stored_state);
 
             if let Some(enc_ref) = encrypt_ref {
                 self.document.objects.remove(&enc_ref);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -263,8 +263,13 @@ impl Document {
 
 impl IncrementalDocument {
     /// Save PDF document to specified file path.
+    ///
+    /// The `check_incremental_save_supported` guard is invoked before
+    /// `File::create` so an unsupported input (e.g. a still-encrypted
+    /// previous revision) does not truncate a pre-existing file at `path`.
     #[inline]
     pub fn save<P: AsRef<Path>>(&mut self, path: P) -> Result<File> {
+        self.check_incremental_save_supported()?;
         let mut file = BufWriter::new(File::create(path)?);
         self.save_internal(&mut file)?;
         Ok(file.into_inner()?)

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -5,6 +5,7 @@ use std::vec;
 
 use super::Object::*;
 use super::{Dictionary, Document, Object, Stream, StringFormat};
+use crate::encryption;
 use crate::{IncrementalDocument, xref::*};
 
 impl Document {
@@ -275,15 +276,43 @@ impl IncrementalDocument {
         self.save_internal(target)
     }
 
-    fn save_internal<W: Write>(&mut self, target: &mut W) -> Result<()> {
-        if self.get_prev_documents().was_encrypted() || self.get_prev_documents().is_encrypted() {
+    /// Reject the two cases we still cannot handle: a document that arrived
+    /// still-encrypted (no password was supplied), and the inconsistent case
+    /// of `encryption_state` set but `encrypt_object_id` missing (which should
+    /// not occur in practice — `decrypt_raw` records the id — but we guard
+    /// against it defensively).
+    fn check_incremental_save_supported(&self) -> Result<()> {
+        let prev = self.get_prev_documents();
+        if prev.is_encrypted() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Unsupported,
-                "incremental update of an encrypted PDF is not supported yet: \
-                 saving would write unencrypted objects into an encrypted file and corrupt it \
+                "incremental update of a still-encrypted PDF is not supported: \
+                 call `Document::decrypt` on the previous revision first \
                  (see https://github.com/J-F-Liu/lopdf/issues/520)",
             ));
         }
+        if let Some(state) = prev.encryption_state.as_ref()
+            && state.encrypt_object_id().is_none()
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "cannot incrementally save this decrypted document: \
+                 the /Encrypt object id was not recorded during decryption",
+            ));
+        }
+        Ok(())
+    }
+
+    fn save_internal<W: Write>(&mut self, target: &mut W) -> Result<()> {
+        self.check_incremental_save_supported()?;
+
+        // If the previous revision was encrypted (and successfully decrypted),
+        // we need to re-encrypt every appended object with the same encryption
+        // state and restore the trailer's `/Encrypt` reference.
+        //
+        // Cloning `EncryptionState` (small, mostly `Vec<u8>`) avoids borrow
+        // conflicts between `&self.prev_documents` and `&mut self.new_document`.
+        let encryption_state = self.get_prev_documents().encryption_state.as_ref().cloned();
 
         let mut target = CountingWrite {
             inner: target,
@@ -311,6 +340,10 @@ impl IncrementalDocument {
 
         Writer::write_binary_mark(&mut target, &self.new_document.binary_mark)?;
 
+        // Write each newly added indirect object. When the document is
+        // encrypted, each object is cloned first and the clone is encrypted;
+        // the in-memory objects are left as plaintext so that further edits
+        // and repeated saves do not double-encrypt.
         for (&(id, generation), object) in &self.new_document.objects {
             if object
                 .type_name()
@@ -318,28 +351,60 @@ impl IncrementalDocument {
                 .ok()
                 != Some(true)
             {
-                Writer::write_indirect_object(&mut target, id, generation, object, &mut xref)?;
+                if let Some(state) = encryption_state.as_ref() {
+                    let mut encrypted = object.clone();
+                    encryption::encrypt_object(state, (id, generation), &mut encrypted)
+                        .map_err(std::io::Error::other)?;
+                    Writer::write_indirect_object(&mut target, id, generation, &encrypted, &mut xref)?;
+                } else {
+                    Writer::write_indirect_object(&mut target, id, generation, object, &mut xref)?;
+                }
             }
         }
+
+        // For an encrypted document, install a modified copy of the trailer
+        // that restores the /Encrypt reference. We swap it in temporarily so
+        // that `write_trailer` / `write_cross_reference_stream` — which
+        // already mutate the trailer to update Size/W/Length/etc — operate
+        // on the modified copy, and swap it back afterwards so that the
+        // in-memory `new_document.trailer` stays clean for subsequent saves.
+        let saved_trailer = if let Some(state) = encryption_state.as_ref() {
+            let encrypt_id = state
+                .encrypt_object_id()
+                .expect("encrypt_object_id presence checked by check_incremental_save_supported");
+            let mut modified = self.new_document.trailer.clone();
+            modified.set(b"Encrypt", Object::Reference(encrypt_id));
+            Some(std::mem::replace(&mut self.new_document.trailer, modified))
+        } else {
+            None
+        };
 
         let xref_start = target.bytes_written;
 
         // Pick right cross reference stream.
-        match xref.cross_reference_type {
-            XrefType::CrossReferenceTable => {
-                Writer::write_xref(&mut target, &xref)?;
-                self.new_document.write_trailer(&mut target)?;
+        let write_result: Result<()> = (|| {
+            match xref.cross_reference_type {
+                XrefType::CrossReferenceTable => {
+                    Writer::write_xref(&mut target, &xref)?;
+                    self.new_document.write_trailer(&mut target)?;
+                }
+                XrefType::CrossReferenceStream => {
+                    // Cross Reference Stream instead of XRef and Trailer
+                    self.new_document
+                        .write_cross_reference_stream(&mut target, &mut xref, xref_start as u32)?;
+                }
             }
-            XrefType::CrossReferenceStream => {
-                // Cross Reference Stream instead of XRef and Trailer
-                self.new_document
-                    .write_cross_reference_stream(&mut target, &mut xref, xref_start as u32)?;
-            }
-        }
-        // Write `startxref` part of trailer
-        write!(target, "\nstartxref\n{xref_start}\n%%EOF")?;
+            // Write `startxref` part of trailer
+            write!(target, "\nstartxref\n{xref_start}\n%%EOF")?;
+            Ok(())
+        })();
 
-        Ok(())
+        // Restore the original in-memory trailer even if writing failed.
+        if let Some(saved) = saved_trailer {
+            self.new_document.trailer = saved;
+        }
+
+        write_result
     }
 }
 

--- a/tests/incremental_document.rs
+++ b/tests/incremental_document.rs
@@ -4,6 +4,7 @@ use lopdf::{
     Stream, dictionary,
 };
 use std::collections::BTreeMap;
+use std::fs;
 use std::io;
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -313,4 +314,42 @@ fn incremental_save_of_still_encrypted_document_is_rejected() {
     let mut out = Vec::new();
     let err = incremental.save_to(&mut out).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+}
+
+/// `IncrementalDocument::save(path)` must not truncate a pre-existing file
+/// when the incremental save is unsupported. Prior to this check the guard
+/// ran only after `File::create` had already zeroed the target.
+#[test]
+fn incremental_save_to_path_does_not_truncate_on_unsupported_input() {
+    let mut doc = minimal_encryptable_document();
+    let encryption_state = EncryptionState::try_from(EncryptionVersion::V1 {
+        document: &doc,
+        owner_password: "owner",
+        user_password: "user",
+        permissions: Permissions::all(),
+    })
+    .unwrap();
+    doc.encrypt(&encryption_state).unwrap();
+
+    let mut prev_bytes = Vec::new();
+    doc.save_to(&mut prev_bytes).unwrap();
+
+    // Load without decrypting: this is the still-encrypted (unsupported) case.
+    let loaded = Document::load_mem(&prev_bytes).unwrap();
+    let mut incremental = IncrementalDocument::create_from(prev_bytes, loaded);
+
+    let temp_dir = tempdir().unwrap();
+    let target_path = temp_dir.path().join("existing.pdf");
+    let sentinel: &[u8] = b"do-not-truncate-me";
+    fs::write(&target_path, sentinel).unwrap();
+
+    let err = incremental.save(&target_path).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+
+    // File must be untouched on disk.
+    let on_disk = fs::read(&target_path).unwrap();
+    assert_eq!(
+        on_disk, sentinel,
+        "unsupported save must not truncate or overwrite the target file"
+    );
 }

--- a/tests/incremental_document.rs
+++ b/tests/incremental_document.rs
@@ -41,6 +41,47 @@ fn minimal_encryptable_document() -> Document {
     doc
 }
 
+/// After `decrypt`, `EncryptionState::encrypt_object_id()` must expose the
+/// object id of the `/Encrypt` dictionary that was in the trailer before
+/// decryption — an incremental save needs it to restore `/Encrypt` in the
+/// appended trailer.
+#[test]
+fn decrypt_records_encrypt_object_id() {
+    let mut doc = minimal_encryptable_document();
+
+    let encryption_version = EncryptionVersion::V1 {
+        document: &doc,
+        owner_password: "owner",
+        user_password: "user",
+        permissions: Permissions::all(),
+    };
+    let encryption_state = EncryptionState::try_from(encryption_version).unwrap();
+    doc.encrypt(&encryption_state).unwrap();
+
+    let mut prev_bytes = Vec::new();
+    doc.save_to(&mut prev_bytes).unwrap();
+
+    // Capture the /Encrypt reference id from the on-disk trailer before decrypt.
+    let expected_id = Document::load_mem(&prev_bytes)
+        .unwrap()
+        .trailer
+        .get(b"Encrypt")
+        .unwrap()
+        .as_reference()
+        .unwrap();
+
+    let mut loaded = Document::load_mem(&prev_bytes).unwrap();
+    loaded.decrypt("user").unwrap();
+
+    let recorded = loaded
+        .encryption_state
+        .as_ref()
+        .expect("encryption_state set after decrypt")
+        .encrypt_object_id()
+        .expect("encrypt_object_id recorded during decrypt");
+    assert_eq!(recorded, expected_id);
+}
+
 /// Incremental save of a *decrypted* document (regression test for
 /// https://github.com/J-F-Liu/lopdf/issues/520): the appended trailer would
 /// lack `/Encrypt` while the original bytes remain ciphertext, so this must

--- a/tests/incremental_document.rs
+++ b/tests/incremental_document.rs
@@ -1,4 +1,5 @@
 use lopdf::encryption::crypt_filters::{Aes128CryptFilter, Aes256CryptFilter, CryptFilter};
+use lopdf::xref::XrefType;
 use lopdf::{
     Document, EncryptionState, EncryptionVersion, IncrementalDocument, LoadOptions, Object, Permissions, Result,
     Stream, dictionary,
@@ -196,6 +197,90 @@ fn incremental_save_of_decrypted_document_v2_round_trip() {
     })
     .unwrap();
     encrypted_incremental_round_trip("V2", state);
+}
+
+/// V2 (RC4-128) × `CrossReferenceTable`: exercises the classical
+/// `trailer <<...>>` writer path (`Document::write_trailer`) rather than the
+/// xref-stream path (`Document::write_cross_reference_stream`). Both paths
+/// serialize `self.new_document.trailer`, and the `/Encrypt` swap in
+/// `IncrementalDocument::save_internal` targets exactly that field, so a
+/// table-based prior revision must produce an appended trailer that carries
+/// `/Encrypt` — verified via `read_encrypt_id` plus a byte-level check that
+/// the classical `trailer` keyword appears in the appended region.
+#[test]
+fn incremental_save_of_decrypted_document_v2_cross_reference_table_round_trip() {
+    let mut doc = minimal_encryptable_document();
+    doc.reference_table.cross_reference_type = XrefType::CrossReferenceTable;
+    let state = EncryptionState::try_from(EncryptionVersion::V2 {
+        document: &doc,
+        owner_password: "owner",
+        user_password: "user",
+        key_length: 128,
+        permissions: Permissions::all(),
+    })
+    .unwrap();
+    doc.encrypt(&state).unwrap();
+    let mut prev_bytes = Vec::new();
+    doc.save_to(&mut prev_bytes).unwrap();
+
+    // Sanity check on the fixture: the base revision must use the classical
+    // `trailer` keyword. If this fails, the test setup slipped back to the
+    // xref-stream path and no longer covers what it claims to cover.
+    let trailer_keyword: &[u8] = b"trailer\n";
+    assert!(
+        prev_bytes
+            .windows(trailer_keyword.len())
+            .any(|w| w == trailer_keyword),
+        "base revision must use classical trailer for this test to be meaningful"
+    );
+
+    let original_encrypt_id = read_encrypt_id(&prev_bytes);
+
+    let loaded = load_and_decrypt(&prev_bytes, "user");
+    assert!(
+        matches!(loaded.reference_table.cross_reference_type, XrefType::CrossReferenceTable),
+        "loaded document must retain the CrossReferenceTable format"
+    );
+
+    let mut incremental = IncrementalDocument::create_from(prev_bytes.clone(), loaded);
+    let marker: Vec<u8> = b"PR520-MARKER-V2-Table".to_vec();
+    let stream = Stream::new(dictionary! {}, marker.clone()).with_compression(false);
+    let new_stream_id = incremental.new_document.add_object(Object::Stream(stream));
+
+    let mut out = Vec::new();
+    incremental.save_to(&mut out).unwrap();
+
+    let appended = &out[prev_bytes.len()..];
+
+    // The appended region must go through the classical `trailer` path,
+    // which is where `write_trailer` reads `self.trailer` — the swap target.
+    assert!(
+        appended
+            .windows(trailer_keyword.len())
+            .any(|w| w == trailer_keyword),
+        "appended region must use classical trailer (CrossReferenceTable path)"
+    );
+
+    // Assert A: no plaintext leak in the appended region.
+    assert!(
+        !appended.windows(marker.len()).any(|w| w == marker.as_slice()),
+        "V2/table: plaintext marker leaked in the appended region"
+    );
+
+    // Assert B: round-trip.
+    let reloaded = load_and_decrypt(&out, "user");
+    let stream = reloaded.get_object(new_stream_id).unwrap().as_stream().unwrap();
+    assert_eq!(
+        stream.content, marker,
+        "V2/table: appended stream content mismatch after round-trip"
+    );
+
+    // Assert C: the trailer's /Encrypt reference resolves to the original id.
+    let round_encrypt_id = read_encrypt_id(&out);
+    assert_eq!(
+        round_encrypt_id, original_encrypt_id,
+        "V2/table: trailer /Encrypt reference mismatch after round-trip"
+    );
 }
 
 #[test]

--- a/tests/incremental_document.rs
+++ b/tests/incremental_document.rs
@@ -1,5 +1,11 @@
-use lopdf::{Document, EncryptionState, EncryptionVersion, IncrementalDocument, Object, Permissions, Result};
+use lopdf::encryption::crypt_filters::{Aes128CryptFilter, Aes256CryptFilter, CryptFilter};
+use lopdf::{
+    Document, EncryptionState, EncryptionVersion, IncrementalDocument, LoadOptions, Object, Permissions, Result,
+    Stream, dictionary,
+};
+use std::collections::BTreeMap;
 use std::io;
+use std::sync::Arc;
 use tempfile::tempdir;
 
 mod utils;
@@ -82,37 +88,198 @@ fn decrypt_records_encrypt_object_id() {
     assert_eq!(recorded, expected_id);
 }
 
-/// Incremental save of a *decrypted* document (regression test for
-/// https://github.com/J-F-Liu/lopdf/issues/520): the appended trailer would
-/// lack `/Encrypt` while the original bytes remain ciphertext, so this must
-/// be rejected rather than silently producing a corrupt file.
-#[test]
-fn incremental_save_of_decrypted_document_is_rejected() {
+/// Prepare an encrypted PDF: build a minimal encryptable document, apply the
+/// supplied `EncryptionState`, and save it to bytes.
+fn build_encrypted_pdf(state: &EncryptionState) -> Vec<u8> {
     let mut doc = minimal_encryptable_document();
+    doc.encrypt(state).unwrap();
+    let mut bytes = Vec::new();
+    doc.save_to(&mut bytes).unwrap();
+    bytes
+}
 
-    let encryption_version = EncryptionVersion::V1 {
+/// Return the `/Encrypt` object id currently stored in the on-disk trailer
+/// of `bytes` (the file must not be decrypted before calling this).
+fn read_encrypt_id(bytes: &[u8]) -> lopdf::ObjectId {
+    Document::load_mem(bytes)
+        .unwrap()
+        .trailer
+        .get(b"Encrypt")
+        .unwrap()
+        .as_reference()
+        .unwrap()
+}
+
+/// Load `bytes` and immediately decrypt using `password`, returning the
+/// fully-populated `Document`. `Document::load_mem` defers object parsing for
+/// encrypted files that arrive without a password, so tests that need the
+/// content objects present must go through `load_mem_with_options`.
+fn load_and_decrypt(bytes: &[u8], password: &str) -> Document {
+    Document::load_mem_with_options(bytes, LoadOptions::with_password(password)).unwrap()
+}
+
+/// End-to-end verification of an incremental save on a decrypted document:
+/// build encrypted `prev_bytes`, decrypt them, append a new plaintext-marker
+/// stream, save incrementally, then check that the appended region does not
+/// leak the plaintext, that decrypt+read still round-trips, and that the
+/// trailer's `/Encrypt` reference resolves to the original id.
+fn encrypted_incremental_round_trip(label: &str, state: EncryptionState) {
+    let prev_bytes = build_encrypted_pdf(&state);
+    let original_encrypt_id = read_encrypt_id(&prev_bytes);
+
+    let loaded = load_and_decrypt(&prev_bytes, "user");
+    assert!(
+        loaded.encryption_state.as_ref().unwrap().encrypt_object_id().is_some(),
+        "{label}: encrypt_object_id must be recorded during load-and-decrypt"
+    );
+
+    let mut incremental = IncrementalDocument::create_from(prev_bytes.clone(), loaded);
+    let marker: Vec<u8> = format!("PR520-MARKER-{label}").into_bytes();
+    let stream = Stream::new(dictionary! {}, marker.clone()).with_compression(false);
+    let new_stream_id = incremental.new_document.add_object(Object::Stream(stream));
+
+    let mut out = Vec::new();
+    incremental.save_to(&mut out).unwrap();
+
+    // Assert A: the plaintext marker must not appear anywhere in the
+    // appended (encrypted) region.
+    let appended = &out[prev_bytes.len()..];
+    assert!(
+        !appended.windows(marker.len()).any(|w| w == marker.as_slice()),
+        "{label}: plaintext marker leaked in the appended region"
+    );
+
+    // Assert B: round-trip. Reloading and decrypting the appended file must
+    // reveal the marker again.
+    let reloaded = load_and_decrypt(&out, "user");
+    let stream = reloaded.get_object(new_stream_id).unwrap().as_stream().unwrap();
+    assert_eq!(
+        stream.content, marker,
+        "{label}: appended stream content mismatch after round-trip"
+    );
+
+    // Assert C: the trailer's /Encrypt reference in the appended file resolves
+    // to the same object id as the original encrypted revision. The dictionary
+    // bytes themselves live in the previous revision and are still intact.
+    let round_encrypt_id = read_encrypt_id(&out);
+    assert_eq!(
+        round_encrypt_id, original_encrypt_id,
+        "{label}: trailer /Encrypt reference mismatch after round-trip"
+    );
+}
+
+/// Incremental save of a document decrypted from V1 (RC4-40) round-trips —
+/// replaces the earlier PR #521 rejection test now that #520 supports this.
+#[test]
+fn incremental_save_of_decrypted_document_v1_round_trip() {
+    let doc = minimal_encryptable_document();
+    let state = EncryptionState::try_from(EncryptionVersion::V1 {
         document: &doc,
         owner_password: "owner",
         user_password: "user",
         permissions: Permissions::all(),
-    };
-    let encryption_state = EncryptionState::try_from(encryption_version).unwrap();
-    doc.encrypt(&encryption_state).unwrap();
+    })
+    .unwrap();
+    encrypted_incremental_round_trip("V1", state);
+}
 
-    let mut prev_bytes = Vec::new();
-    doc.save_to(&mut prev_bytes).unwrap();
+#[test]
+fn incremental_save_of_decrypted_document_v2_round_trip() {
+    let doc = minimal_encryptable_document();
+    let state = EncryptionState::try_from(EncryptionVersion::V2 {
+        document: &doc,
+        owner_password: "owner",
+        user_password: "user",
+        key_length: 128,
+        permissions: Permissions::all(),
+    })
+    .unwrap();
+    encrypted_incremental_round_trip("V2", state);
+}
 
-    let mut loaded = Document::load_mem(&prev_bytes).unwrap();
-    loaded.decrypt("user").unwrap();
-    assert!(!loaded.is_encrypted());
-    assert!(loaded.was_encrypted());
+#[test]
+fn incremental_save_of_decrypted_document_v4_round_trip() {
+    let doc = minimal_encryptable_document();
+    let crypt_filter: Arc<dyn CryptFilter> = Arc::new(Aes128CryptFilter);
+    let state = EncryptionState::try_from(EncryptionVersion::V4 {
+        document: &doc,
+        encrypt_metadata: true,
+        crypt_filters: BTreeMap::from([(b"StdCF".to_vec(), crypt_filter)]),
+        stream_filter: b"StdCF".to_vec(),
+        string_filter: b"StdCF".to_vec(),
+        owner_password: "owner",
+        user_password: "user",
+        permissions: Permissions::all(),
+    })
+    .unwrap();
+    encrypted_incremental_round_trip("V4", state);
+}
 
+#[test]
+fn incremental_save_of_decrypted_document_v5_round_trip() {
+    // Fixed key: this is a deterministic test; `Aes256CryptFilter` combined
+    // with V5's per-object IV keeps the outputs distinct anyway.
+    let file_encryption_key = [7u8; 32];
+    let crypt_filter: Arc<dyn CryptFilter> = Arc::new(Aes256CryptFilter);
+    let state = EncryptionState::try_from(EncryptionVersion::V5 {
+        encrypt_metadata: true,
+        crypt_filters: BTreeMap::from([(b"StdCF".to_vec(), crypt_filter)]),
+        file_encryption_key: &file_encryption_key,
+        stream_filter: b"StdCF".to_vec(),
+        string_filter: b"StdCF".to_vec(),
+        owner_password: "owner",
+        user_password: "user",
+        permissions: Permissions::all(),
+    })
+    .unwrap();
+    encrypted_incremental_round_trip("V5", state);
+}
+
+/// Regression guard for the "clone before encrypt" invariant: two successive
+/// incremental saves on the same `IncrementalDocument` must not double-encrypt
+/// the objects added in the earlier round. If we mutated in-place, the second
+/// save would re-encrypt already-encrypted bytes and decrypt would return
+/// garbage instead of the marker.
+#[test]
+fn incremental_save_of_decrypted_document_does_not_double_encrypt_on_repeated_save() {
+    let doc = minimal_encryptable_document();
+    let state = EncryptionState::try_from(EncryptionVersion::V1 {
+        document: &doc,
+        owner_password: "owner",
+        user_password: "user",
+        permissions: Permissions::all(),
+    })
+    .unwrap();
+    let prev_bytes = build_encrypted_pdf(&state);
+
+    let loaded = load_and_decrypt(&prev_bytes, "user");
     let mut incremental = IncrementalDocument::create_from(prev_bytes, loaded);
-    incremental.new_document.add_object(Object::Integer(42));
 
-    let mut out = Vec::new();
-    let err = incremental.save_to(&mut out).unwrap_err();
-    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    let marker_a: Vec<u8> = b"PR520-A".to_vec();
+    let stream_a = Stream::new(dictionary! {}, marker_a.clone()).with_compression(false);
+    let id_a = incremental.new_document.add_object(Object::Stream(stream_a));
+
+    let mut buf1 = Vec::new();
+    incremental.save_to(&mut buf1).unwrap();
+
+    let marker_b: Vec<u8> = b"PR520-B".to_vec();
+    let stream_b = Stream::new(dictionary! {}, marker_b.clone()).with_compression(false);
+    let id_b = incremental.new_document.add_object(Object::Stream(stream_b));
+
+    let mut buf2 = Vec::new();
+    incremental.save_to(&mut buf2).unwrap();
+
+    let reloaded = load_and_decrypt(&buf2, "user");
+    let content_a = reloaded.get_object(id_a).unwrap().as_stream().unwrap().content.clone();
+    let content_b = reloaded.get_object(id_b).unwrap().as_stream().unwrap().content.clone();
+    assert_eq!(
+        content_a, marker_a,
+        "stream A must survive a second incremental save without double-encryption"
+    );
+    assert_eq!(
+        content_b, marker_b,
+        "stream B must be readable after the second incremental save"
+    );
 }
 
 /// Incremental save of a still-*encrypted* (never decrypted) document must


### PR DESCRIPTION
Closes #520. Follow-up to #521.

When a decrypted document (`encryption_state` is `Some`) is saved as an
incremental update, this PR:

- re-encrypts every appended object with the existing `EncryptionState` via
  `encryption::encrypt_object` (objects are cloned at write time; the in-memory
  document stays plaintext, so repeated edit/save cycles do not double-encrypt),
- restores the `/Encrypt` reference in the appended trailer. `EncryptionState`
  now remembers the object id of the original `/Encrypt` dictionary (recorded in
  `decrypt_raw` before it is removed, and also in the reader's password-at-load
  path). The original dictionary is still intact in the previous revision's
  bytes, so referencing it is both sufficient and more faithful than re-emitting
  a reconstructed dictionary, which could drop non-standard entries.

The first `/ID` element is left untouched (it feeds key derivation for R <= 4).

Additionally, the remaining unsupported path (saving a still-encrypted, not
decrypted, document) is now checked *before* `save(path)` truncates the target
file, so a failed save no longer destroys an existing file.

Limitations (unchanged behavior, guarded by the error from #521):
incremental save of a still-encrypted (not decrypted) document; full rewrites of
encrypted documents (#479); public-key security handlers; the special handling
of `/Contents` in signature dictionaries.

Tested with round-trips for V1/V2 (RC4), V4 (AES-128) and V5 (AES-256):
appended bytes contain no plaintext markers, and the resulting files load and
decrypt correctly.
