### PR TITLE
bump version to  v0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+<a name="v0.44.0"></a>
+## [v0.44.0](https://github.com/J-F-Liu/lopdf/compare/v0.43.0...v0.44.0) (2026-07-10)
+
+### Add
+
+* Add back assets/test.pdf
+
+### Feat
+
+* Support incremental save of encrypted documents (#522)
+* Bound text extraction against decompression bombs
+* Bound load-time decompression via LoadOptions.max_decompressed_size
+* Bound stream decompression to guard against bombs
+* Make ttf-parser optional behind font_embedding feature
+
+### Fix
+
+* Reject incremental save of encrypted documents (#521)
+* Fix Document::get_toc() dropping entries when outline titles repeat (#517)
+* Add feature flag to font test
+* Only use criterion for non-wasm tests/benches
+
+### Move
+
+* Move resource files in tests to assets
+
+### Refactor
+
+* Make `Document::get_page_content` return `Vec<u8>` since it cannot fail
+
+### Test
+
+* Add tests demonstrating unbounded stream decompression
+
+### CI
+
+* CI skip performance test
+* Actually pass --no-default-features in the no-default-features matrix cell (#510)
 
 <a name="v0.43.0"></a>
 ## [v0.43.0](https://github.com/J-F-Liu/lopdf/compare/v0.42.0...v0.43.0) (2026-06-25)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 name = "lopdf"
 readme = "README.md"
 repository = "https://github.com/J-F-Liu/lopdf.git"
-version = "0.43.0"
+version = "0.44.0"
 rust-version = "1.88"
 exclude = ["/benches", "/assets", "/.chglog", "/.vscode", "/.github"]
 


### PR DESCRIPTION
This bumps the crate version to 0.44.0 and adds the corresponding CHANGELOG entry.
Notes:

The CHANGELOG entry was written by hand following the existing format; I couldn't reproduce the committed output with the git-chglog tooling in .chglog/. Happy to adjust the format if you generate it differently.

Downstream verification: we've been running the encrypted incremental save changes (#521/#522) in a PDF reader app against RC4-40/128, AES-128 and AES-256 files, including consecutive incremental updates, validated with qpdf --check.