### PR TITLE
refactor: remove duplicated error messages when chaining

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,13 +28,13 @@ pub enum Error {
     #[error("invalid character encoding")]
     CharacterEncoding,
     /// The stream couldn't be decompressed.
-    #[error("couldn't decompress stream {0}")]
+    #[error("couldn't decompress stream")]
     Decompress(#[from] DecompressError),
     /// Failed to parse input.
-    #[error("couldn't parse input: {0}")]
+    #[error("couldn't parse input")]
     Parse(#[from] ParseError),
     /// Error when decrypting the contents of the file
-    #[error("decryption error: {0}")]
+    #[error("decryption error")]
     Decryption(#[from] encryption::DecryptionError),
     /// Dictionary key was not found.
     #[error("missing required dictionary key \"{0}\"")]
@@ -55,7 +55,7 @@ pub enum Error {
     #[error("invalid byte offset")]
     InvalidOffset(usize),
     /// IO error
-    #[error("IO error: {0}")]
+    #[error("IO error")]
     IO(#[from] std::io::Error),
     // TODO: Maybe remove, as outline is not required in spec.
     /// PDF document has no outline.
@@ -90,8 +90,8 @@ pub enum Error {
     #[error("decoding text string failed")]
     TextStringDecode,
     /// Error while parsing cross reference table.
-    #[error("failed parsing cross reference table: {0}")]
-    Xref(XrefError),
+    #[error("failed parsing cross reference table")]
+    Xref(#[from] XrefError),
     /// Invalid indirect object while parsing at offset.
     #[error("invalid indirect object at byte offset {offset}")]
     IndirectObject { offset: usize },
@@ -100,15 +100,15 @@ pub enum Error {
     ObjectIdMismatch,
     /// Error when handling images.
     #[cfg(feature = "embed_image")]
-    #[error("image error: {0}")]
+    #[error("image error")]
     Image(#[from] image::ImageError),
     /// Syntax error while processing the content stream.
     #[error("syntax error in content stream: {0}")]
     Syntax(String),
     /// Could not parse ToUnicodeCMap.
-    #[error("failed parsing ToUnicode CMap: {0}")]
+    #[error("failed parsing ToUnicode CMap")]
     ToUnicodeCMap(#[from] UnicodeCMapError),
-    #[error("converting integer: {0}")]
+    #[error("converting integer")]
     TryFromInt(#[from] std::num::TryFromIntError),
     /// Encountered an unsupported security handler.
     #[error("unsupported security handler")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use common_data_structures::{decode_text_string, text_string};
 pub use destinations::Destination;
 pub use encodings::{Encoding, encode_utf8, encode_utf16_be};
 pub use encryption::{EncryptionState, EncryptionVersion, Permissions};
-pub use error::{DecompressError, Error, Result};
+pub use error::{DecompressError, Error, ParseError, Result};
 pub use incremental_document::IncrementalDocument;
 pub use load_options::{FilterFunc, LoadOptions};
 pub use object_stream::{ObjectStream, ObjectStreamBuilder, ObjectStreamConfig};

--- a/tests/load_options_test.rs
+++ b/tests/load_options_test.rs
@@ -1,6 +1,7 @@
 #[cfg(not(feature = "async"))]
 mod sync_tests {
-    use lopdf::{Document, LoadOptions, Object};
+    use lopdf::{Document, Error, LoadOptions, Object, ParseError};
+    use std::assert_matches;
     use std::fs::File;
 
     #[test]
@@ -194,11 +195,7 @@ mod sync_tests {
                 ..Default::default()
             },
         );
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("invalid file header"),
-            "expected InvalidFileHeader, got: {err}"
-        );
+        assert_matches!(result.unwrap_err(), Error::Parse(ParseError::InvalidFileHeader));
     }
 
     #[test]


### PR DESCRIPTION
Some error variants duplicate source text in both `Display` and `Error::source()`. Per [Rust's error docs](https://doc.rust-lang.org/std/error/trait.Error.html#error-source), pick one — prefer `source()` and remove the duplication from `Display`.