### PR TITLE
ci: enforce rustfmt and broader clippy checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,12 @@ jobs:
             - uses: actions/checkout@v7
             - uses: hecrj/setup-rust-action@v2
 
-            - name: clippy for lopdf
-              run: cargo clippy
+            - name: clippy for lopdf (sync examples)
+              run: cargo clippy --all-targets --features serde -- -D warnings
+            - name: clippy for lopdf (all features)
+              run: cargo clippy --all-targets --all-features -- -D warnings
             - name: clippy for pdfutil
-              run: cargo clippy --manifest-path pdfutil/Cargo.toml
+              run: cargo clippy --manifest-path pdfutil/Cargo.toml --all-targets -- -D warnings
 
     wasm:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,21 @@ jobs:
             - name: Run tests
               run: cargo test --verbose ${{ matrix.features }} -- --test-threads=1 --skip performance
 
+    fmt:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v7
+            - uses: hecrj/setup-rust-action@v2
+              with:
+                  rust-version: nightly
+                  components: rustfmt
+
+            - name: rustfmt for lopdf
+              run: cargo fmt --all -- --check
+            - name: rustfmt for pdfutil
+              run: cargo fmt --manifest-path pdfutil/Cargo.toml -- --check
+
     pdfutil:
         runs-on: ubuntu-latest
 

--- a/examples/decompression_bomb.rs
+++ b/examples/decompression_bomb.rs
@@ -10,8 +10,8 @@
 use std::io::Write;
 use std::time::Instant;
 
-use flate2::write::ZlibEncoder;
 use flate2::Compression;
+use flate2::write::ZlibEncoder;
 use lopdf::{Dictionary, Document, LoadOptions, Object, Stream};
 
 const MIB: usize = 1024 * 1024;
@@ -96,7 +96,10 @@ fn main() {
     }
     match Document::load_mem_with_options(&pdf, LoadOptions::with_max_decompressed_size(limit)) {
         Ok(_) => println!("  UNEXPECTED: guarded load succeeded"),
-        Err(e) => println!("  load_mem_with_options(max_decompressed_size = {} MiB): {e}", limit / MIB),
+        Err(e) => println!(
+            "  load_mem_with_options(max_decompressed_size = {} MiB): {e}",
+            limit / MIB
+        ),
     }
 }
 

--- a/examples/print_annotations.rs
+++ b/examples/print_annotations.rs
@@ -78,7 +78,7 @@ fn main() {
 
     match Document::load(&args[1]) {
         Ok(doc) => _ = handle_pdf_page(doc),
-        Err(e) => eprintln!("Error opening {:?}: {:?}", &args[1], e),
+        Err(e) => eprintln!("Error opening {:?}: {:?}", args[1], e),
     }
 }
 

--- a/pdfutil/src/main.rs
+++ b/pdfutil/src/main.rs
@@ -160,13 +160,9 @@ fn main() -> Result<()> {
                 }
             } else {
                 // Replace on specific page
-                match doc.replace_partial_text(page, &search, &replace, default_char.as_deref()) {
-                    Ok(count) => {
-                        println!("Page {}: Replaced {} occurrences", page, count);
-                        total_replacements = count;
-                    }
-                    Err(e) => return Err(e),
-                }
+                let count = doc.replace_partial_text(page, &search, &replace, default_char.as_deref())?;
+                println!("Page {}: Replaced {} occurrences", page, count);
+                total_replacements = count;
             }
 
             if total_replacements > 0 {

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -204,10 +204,10 @@ impl Document {
 pub mod tests {
     use std::path::PathBuf;
 
-    use crate::content::*;
-    use crate::{Document, Object, Stream};
     #[cfg(feature = "font_embedding")]
     use crate::FontData;
+    use crate::content::*;
+    use crate::{Document, Object, Stream};
 
     #[cfg(not(feature = "time"))]
     pub fn get_timestamp() -> Object {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -106,10 +106,9 @@ mod time_impl {
         fn from(date: PrimitiveDateTime) -> Self {
             Object::string_literal({
                 // D:%Y%m%d%H%M%SZ
-                let format = time::format_description::parse_borrowed::<3>(
-                    "D:[year][month][day][hour][minute][second]Z",
-                )
-                .unwrap();
+                let format =
+                    time::format_description::parse_borrowed::<3>("D:[year][month][day][hour][minute][second]Z")
+                        .unwrap();
                 date.format(&format).unwrap()
             })
         }

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -533,7 +533,9 @@ pub fn decode_xref_stream(stream: Stream) -> Result<(Xref, Dictionary)> {
 /// would exceed `max_decompressed_size` bytes. `None` means no limit (the
 /// behavior of [`decode_xref_stream`]). Cross-reference streams are decoded
 /// early during loading, so this bounds the memory a `/XRef` stream can use.
-pub fn decode_xref_stream_with_limit(mut stream: Stream, max_decompressed_size: Option<usize>) -> Result<(Xref, Dictionary)> {
+pub fn decode_xref_stream_with_limit(
+    mut stream: Stream, max_decompressed_size: Option<usize>,
+) -> Result<(Xref, Dictionary)> {
     if stream.is_compressed() {
         match max_decompressed_size {
             Some(max) => stream.decompress_with_limit(max)?,
@@ -696,8 +698,8 @@ mod tests {
     /// by streaming zeros through the compressor so the test process never holds
     /// `target` bytes at once.
     fn flate_bomb(target: usize) -> Vec<u8> {
-        use flate2::write::ZlibEncoder;
         use flate2::Compression;
+        use flate2::write::ZlibEncoder;
         use std::io::Write;
 
         let mut encoder = ZlibEncoder::new(Vec::new(), Compression::best());
@@ -721,7 +723,8 @@ mod tests {
         let content_id = doc.get_page_contents(page_id)[0];
         let mut dict = Dictionary::new();
         dict.set("Filter", "FlateDecode");
-        doc.objects.insert(content_id, Object::Stream(Stream::new(dict, flate_bomb(target))));
+        doc.objects
+            .insert(content_id, Object::Stream(Stream::new(dict, flate_bomb(target))));
         doc
     }
 

--- a/tests/decompression_bomb.rs
+++ b/tests/decompression_bomb.rs
@@ -10,8 +10,8 @@
 //! Bombs are built by streaming zeros through the compressor, so the test
 //! process itself never allocates the full (large) plaintext.
 
-use flate2::write::ZlibEncoder;
 use flate2::Compression;
+use flate2::write::ZlibEncoder;
 use std::io::Write;
 
 use lopdf::{DecompressError, Dictionary, Document, Error, LoadOptions, Object, ObjectId, ObjectStream, Stream};
@@ -157,9 +157,16 @@ fn decompress_to_writer_bounds_output() {
         Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit })) => {
             assert_eq!(limit, 4 * MIB);
         }
-        other => panic!("expected MemoryLimitExceeded, got {:?}", other.map(|n| format!("Ok({n})"))),
+        other => panic!(
+            "expected MemoryLimitExceeded, got {:?}",
+            other.map(|n| format!("Ok({n})"))
+        ),
     }
-    assert!(sink.is_empty(), "sink should be untouched on rejection, got {} bytes", sink.len());
+    assert!(
+        sink.is_empty(),
+        "sink should be untouched on rejection, got {} bytes",
+        sink.len()
+    );
 }
 
 // Object streams and cross-reference streams are decompressed while the document

--- a/tests/incremental_document.rs
+++ b/tests/incremental_document.rs
@@ -228,9 +228,7 @@ fn incremental_save_of_decrypted_document_v2_cross_reference_table_round_trip() 
     // xref-stream path and no longer covers what it claims to cover.
     let trailer_keyword: &[u8] = b"trailer\n";
     assert!(
-        prev_bytes
-            .windows(trailer_keyword.len())
-            .any(|w| w == trailer_keyword),
+        prev_bytes.windows(trailer_keyword.len()).any(|w| w == trailer_keyword),
         "base revision must use classical trailer for this test to be meaningful"
     );
 
@@ -238,7 +236,10 @@ fn incremental_save_of_decrypted_document_v2_cross_reference_table_round_trip() 
 
     let loaded = load_and_decrypt(&prev_bytes, "user");
     assert!(
-        matches!(loaded.reference_table.cross_reference_type, XrefType::CrossReferenceTable),
+        matches!(
+            loaded.reference_table.cross_reference_type,
+            XrefType::CrossReferenceTable
+        ),
         "loaded document must retain the CrossReferenceTable format"
     );
 
@@ -255,9 +256,7 @@ fn incremental_save_of_decrypted_document_v2_cross_reference_table_round_trip() 
     // The appended region must go through the classical `trailer` path,
     // which is where `write_trailer` reads `self.trailer` — the swap target.
     assert!(
-        appended
-            .windows(trailer_keyword.len())
-            .any(|w| w == trailer_keyword),
+        appended.windows(trailer_keyword.len()).any(|w| w == trailer_keyword),
         "appended region must use classical trailer (CrossReferenceTable path)"
     );
 


### PR DESCRIPTION
follow up to #528.

apply the existing rustfmt config and adds CI coverage for formatting and all-target clippy checks