### PR TITLE
Bound object-graph recursion depth (fixes #530)

### DIFF
--- a/src/destinations.rs
+++ b/src/destinations.rs
@@ -33,10 +33,19 @@ impl Document {
     pub fn get_named_destinations(
         &self, tree: &Dictionary, named_destinations: &mut IndexMap<Vec<u8>, Destination>,
     ) -> Result<()> {
+        self.get_named_destinations_impl(tree, named_destinations, 0)
+    }
+
+    fn get_named_destinations_impl(
+        &self, tree: &Dictionary, named_destinations: &mut IndexMap<Vec<u8>, Destination>, depth: usize,
+    ) -> Result<()> {
+        if depth >= crate::reader::MAX_NESTING_DEPTH {
+            return Err(crate::Error::RecursionLimit);
+        }
         if let Ok(kids) = tree.get(b"Kids") {
             for kid in kids.as_array()? {
                 if let Ok(kid) = kid.as_reference().and_then(move |id| self.get_dictionary(id)) {
-                    self.get_named_destinations(kid, named_destinations)?;
+                    self.get_named_destinations_impl(kid, named_destinations, depth + 1)?;
                 }
             }
         }

--- a/src/document.rs
+++ b/src/document.rs
@@ -671,6 +671,9 @@ impl Document {
                 if already_seen.contains(&parent_id) {
                     return Err(Error::ReferenceCycle(parent_id));
                 }
+                if already_seen.len() >= crate::reader::MAX_NESTING_DEPTH {
+                    return Err(Error::RecursionLimit);
+                }
                 already_seen.insert(parent_id);
                 let parent_dict = doc.get_dictionary(parent_id)?;
                 collect_resources(parent_dict, resource_ids, doc, already_seen)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,6 +86,11 @@ pub enum Error {
     /// This might indicate a reference loop.
     #[error("dereferencing object reached limit, may indicate a reference cycle")]
     ReferenceLimit,
+    /// Traversal of the document's object graph (e.g. a `/Kids`, `/First`, or `/Parent` chain)
+    /// exceeded the supported nesting depth.
+    /// This might indicate a reference cycle or a maliciously deep structure.
+    #[error("object graph traversal reached the nesting-depth limit, may indicate a reference cycle")]
+    RecursionLimit,
     /// Decoding text string failed.
     #[error("decoding text string failed")]
     TextStringDecode,

--- a/src/outlines.rs
+++ b/src/outlines.rs
@@ -34,9 +34,19 @@ impl Document {
     }
 
     pub fn get_outlines(
-        &self, mut node: Option<Object>, mut outlines: Option<Vec<Outline>>,
+        &self, node: Option<Object>, outlines: Option<Vec<Outline>>,
         named_destinations: &mut IndexMap<Vec<u8>, Destination>,
     ) -> Result<Option<Vec<Outline>>> {
+        self.get_outlines_impl(node, outlines, named_destinations, 0)
+    }
+
+    fn get_outlines_impl(
+        &self, mut node: Option<Object>, mut outlines: Option<Vec<Outline>>,
+        named_destinations: &mut IndexMap<Vec<u8>, Destination>, depth: usize,
+    ) -> Result<Option<Vec<Outline>>> {
+        if depth >= crate::reader::MAX_NESTING_DEPTH {
+            return Err(Error::RecursionLimit);
+        }
         if outlines.is_none() {
             outlines = Some(Vec::new());
             let catalog = self.catalog()?;
@@ -76,7 +86,8 @@ impl Document {
             }
             if let Ok(first) = node.get(b"First") {
                 let sub_outlines = Vec::new();
-                let sub_outlines = self.get_outlines(Some(first.clone()), Some(sub_outlines), named_destinations)?;
+                let sub_outlines =
+                    self.get_outlines_impl(Some(first.clone()), Some(sub_outlines), named_destinations, depth + 1)?;
                 if let Some(sub_outlines) = sub_outlines
                     && !sub_outlines.is_empty()
                     && let Some(ref mut outlines) = outlines
@@ -101,7 +112,7 @@ impl Document {
         {
             let outlines = self.get_dictionary(outlines_id)?;
             if let Ok(Object::Reference(first)) = outlines.get(b"First") {
-                self.walk_outlines_del(*first)?;
+                self.walk_outlines_del(*first, 0)?;
             }
             self.delete_object(outlines_id);
         }
@@ -134,7 +145,10 @@ impl Document {
         Ok(Some(outline))
     }
 
-    fn walk_outlines_del(&mut self, outline: ObjectId) -> Result<()> {
+    fn walk_outlines_del(&mut self, outline: ObjectId, depth: usize) -> Result<()> {
+        if depth >= crate::reader::MAX_NESTING_DEPTH {
+            return Err(Error::RecursionLimit);
+        }
         let mut cur = Some(outline);
 
         while let Some(id) = cur.take() {
@@ -143,7 +157,7 @@ impl Document {
             let next = outline.get(b"Next").ok().and_then(|v| v.as_reference().ok());
 
             if let Some(first) = first {
-                self.walk_outlines_del(first)?;
+                self.walk_outlines_del(first, depth + 1)?;
             }
             cur = next;
             self.delete_object(id);


### PR DESCRIPTION
# PR — lopdf: bound object-graph recursion depth (`/Kids`, `/First`, `/Parent`)

**Title:** Bound recursion depth in `get_named_destinations`, `get_outlines`, `get_page_resources`, and `delete_outlines`

**Body:**

Fixes #530. RUSTSEC-2026-0187 bounded **parser** recursion via `MAX_NESTING_DEPTH`, but four post-load
`Document` graph-walks still recurse over the *parsed* object graph with no depth cap (two of them with no
cycle guard either): `get_named_destinations` (`/Kids`), `get_outlines` (`/First`), `get_page_resources`'s
`collect_resources` (`/Parent` — has a cycle guard but not a depth cap, so a long non-cyclic chain still
overflows), and `delete_outlines`'s `walk_outlines_del` (`/First`). All reachable from ordinary public APIs
on a crafted or self-referential PDF → uncatchable stack-overflow abort.

### The fix

Reuses the existing `MAX_NESTING_DEPTH` constant (the same one the 0187 parser fix uses) and adds
`Error::RecursionLimit`, matching the style/wording of the existing `Error::ReferenceLimit`:

```rust
/// Traversal of the document's object graph (e.g. a `/Kids`, `/First`, or `/Parent` chain)
/// exceeded the supported nesting depth.
/// This might indicate a reference cycle or a maliciously deep structure.
#[error("object graph traversal reached the nesting-depth limit, may indicate a reference cycle")]
RecursionLimit,
```

- `get_named_destinations` / `get_outlines` are **public API** — their signatures are unchanged; each gets
  a private `_impl` twin that threads a `depth: usize`, with the public function calling it at `depth = 0`.
- `collect_resources` (private, nested in `get_page_resources`) and `walk_outlines_del` (private) are
  internal, so their signatures were extended directly.
- `collect_resources` reuses `already_seen.len()` as the depth counter (no new state) — checked alongside
  the existing cycle check, before inserting/recursing.

### Validation

- Full `cargo test`: all green (no test changes needed).
- The 4 PoCs from the issue now return `Err(RecursionLimit)` instead of aborting:
  - self-referential `/Kids` (via `get_named_destinations`)
  - self-referential `/First` (via `get_outlines`)
  - a 200,000-deep **non-cyclic** `/Parent` chain (via `get_page_resources`)
  - self-referential `/First` on the delete path (via `delete_outlines`)
- Control case unaffected: a 2-node `/Parent` **cycle** through `get_page_resources` still returns
  `Err(ReferenceCycle(..))` (not `RecursionLimit`), exactly as before.

Found & fixed with the [rust-in-peace](https://github.com/scadastrangelove/rust-in-peace) security pipeline.
