### PR TITLE
Fix four crash bugs from crafted PDFs (fixes #532)

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -776,7 +776,10 @@ impl Document {
                 let height = dict.get(b"Height")?.as_i64()?;
                 let color_space = match dict.get(b"ColorSpace") {
                     Ok(cs) => match cs {
-                        Object::Array(array) => Some(String::from_utf8_lossy(array[0].as_name()?).to_string()),
+                        Object::Array(array) => match array.first() {
+                            Some(first) => Some(String::from_utf8_lossy(first.as_name()?).to_string()),
+                            None => None,
+                        },
                         Object::Name(name) => Some(String::from_utf8_lossy(name).to_string()),
                         _ => None,
                     },

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -667,7 +667,7 @@ fn image_data_stream(input: ParserInput, stream_dict: Dictionary) -> crate::Resu
         // If we have an image mask then we don't have a colorspace
         Ok(true) => 1,
         _ => {
-            let colorspace = get_abbr(b"CS", b"ColorSpace").unwrap().as_name()?;
+            let colorspace = get_abbr(b"CS", b"ColorSpace")?.as_name()?;
             match colorspace {
                 b"DeviceGray" | b"Gray" => 1,
                 b"DeviceRGB" | b"RGB" => 3,

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -557,10 +557,17 @@ pub fn decode_xref_stream_with_limit(mut stream: Stream, max_decompressed_size: 
             .and_then(parse_integer_array)
             .map_err(|_| ParseError::InvalidXref)?;
 
+        // Each width is a byte count for one xref-stream field. The PDF spec doesn't need more than a
+        // few bytes per field (8 covers the full u64/i64 range); bound them before sizing a Vec from
+        // them, or a crafted stream can request an allocation of up to (2^64-1) bytes per field.
+        const MAX_XREF_FIELD_WIDTH: i64 = 8;
         if field_widths.len() < 3
             || field_widths[0].is_negative()
             || field_widths[1].is_negative()
             || field_widths[2].is_negative()
+            || field_widths[0] > MAX_XREF_FIELD_WIDTH
+            || field_widths[1] > MAX_XREF_FIELD_WIDTH
+            || field_widths[2] > MAX_XREF_FIELD_WIDTH
         {
             return Err(ParseError::InvalidXref.into());
         }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -730,10 +730,16 @@ impl Reader<'_> {
             Err(_) => return Ok(0),
         };
 
-        self.get_pages_tree_count(pages_ref, &mut HashSet::new()).or(Ok(0))
+        self.get_pages_tree_count(pages_ref, &mut HashSet::new(), 0).or(Ok(0))
     }
 
-    fn get_pages_tree_count(&self, pages_id: ObjectId, seen: &mut HashSet<ObjectId>) -> Result<u32> {
+    fn get_pages_tree_count(&self, pages_id: ObjectId, seen: &mut HashSet<ObjectId>, depth: usize) -> Result<u32> {
+        // `seen` catches a repeated node (a cycle); it does not bound the depth of a long,
+        // non-cyclic /Pages chain with no /Count, which recurses once per level. Cap that
+        // separately, matching this crate's existing MAX_NESTING_DEPTH budget.
+        if depth >= MAX_NESTING_DEPTH {
+            return Ok(0);
+        }
         if seen.contains(&pages_id) {
             return Err(Error::ReferenceCycle(pages_id));
         }
@@ -768,7 +774,7 @@ impl Reader<'_> {
                 let mut total = 0u32;
                 for kid in kids.iter() {
                     if let Ok(kid_ref) = kid.as_reference()
-                        && let Ok(count) = self.get_pages_tree_count(kid_ref, seen)
+                        && let Ok(count) = self.get_pages_tree_count(kid_ref, seen, depth + 1)
                     {
                         total += count;
                     }


### PR DESCRIPTION
Fixes #532.

Four independent, small fixes for the four crash bugs described in the issue — each touches a different
file/function, so listed separately:

1. **`image_data_stream`** (`parser/mod.rs:670`): `.unwrap()` → `?` on `get_abbr(b"CS", b"ColorSpace")`,
   mirroring the `?`-siblings two lines above it (`W`/`H`/`BPC` already use `?`).
2. **`get_page_images`** (`document.rs:779`): guard `array.first()` before indexing, instead of
   `array[0]`. Preserves the existing `?`-propagation for a malformed (non-empty-but-invalid) name —
   only the empty-array case changes behavior (panic → `None` for that image's colorspace).
3. **`decode_xref_stream_with_limit`** (`parser_aux.rs`): bound each of the three `/W` field widths to
   `<= 8` (alongside the existing non-negativity check), before they size a `Vec` allocation.
4. **`get_pages_tree_count`** (`reader.rs`): added a `depth: usize` parameter, checked against the
   crate's existing `MAX_NESTING_DEPTH`, returning `Ok(0)` past the limit — matching the function's own
   graceful-degradation style (its caller already does `.or(Ok(0))`). The existing `seen: HashSet`
   cycle-guard is unaffected; it's a genuinely separate axis (a long, non-cyclic chain visits distinct
   ids the `HashSet` never repeats, so it never trips).

### Validation

- `cargo test`: all green, no test changes needed.
- All 4 PoCs from the issue, before → after this patch:

  | # | before | after |
  |---|---|---|
  | 1 | panics (`unwrap()` on `DictKey("ColorSpace")`) | returns `Err` cleanly |
  | 2 | panics (`index out of bounds: len 0, index 0`) | returns `Ok` cleanly |
  | 3 | aborts (`memory allocation of 1099511627776 bytes failed`) | returns `Err` cleanly |
  | 4 | aborts (`stack overflow`) | `load_metadata` succeeds |

Happy to split into 4 separate PRs if you'd prefer to review/merge them independently — the diffs don't
overlap (`document.rs`, `parser/mod.rs`, `parser_aux.rs`, `reader.rs`).

Found & fixed with the [rust-in-peace](https://github.com/scadastrangelove/rust-in-peace) security pipeline.
