### PR TITLE
Skip white space after comments in content streams (fix #535)

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -610,7 +610,9 @@ fn operand(input: ParserInput) -> NomResult<Object> {
 fn operation(input: ParserInput) -> NomResult<Operation> {
     map(
         preceded(
-            many0(comment),
+            // A comment consumes its end-of-line marker, so also skip any
+            // white space that follows it (e.g. an indented next line).
+            many0(terminated(comment, content_space)),
             alt((inline_image, terminated(pair(many0(operand), operator), content_space))),
         ),
         |(operands, operator)| Operation { operator, operands },
@@ -942,6 +944,21 @@ startxref
         let out_strict = content_strict(test_span(input)).unwrap();
         assert_eq!(out.operations.len(), out_strict.operations.len());
         assert_eq!(out.operations.len(), 3);
+    }
+
+    #[test]
+    fn content_with_comment_followed_by_indented_line() {
+        // A comment is equivalent to a single white-space character
+        // (ISO 32000-2, 7.2.4), so a line starting with white space right
+        // after a comment must not stop the parser (issue #535).
+        let input = b"BT /F1 24 Tf
+% comment
+  100 100 Td (Hello World) Tj ET";
+        let out = content(test_span(input)).unwrap();
+        let out_strict = content_strict(test_span(input)).unwrap();
+        assert_eq!(out.operations.len(), out_strict.operations.len());
+        let ops: Vec<&str> = out.operations.iter().map(|o| o.operator.as_str()).collect();
+        assert_eq!(ops, vec!["BT", "Tf", "Td", "Tj", "ET"]);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #535.

The content-stream `operation` parser skips leading comments with
`many0(comment)`, but `comment` consumes its own end-of-line marker and
nothing after it. Every token parser (`operand`, `operator`) relies on the
*previous* token's trailing `content_space` to have consumed any leading
white space, so when the line right after a comment starts with white space
(indentation or a blank line), no rule can consume it: `comment` fails (no
`%`), every operand alternative fails, and `operator`'s `take_while1` fails.
The whole `operation` parser errors out, `many0(operation)` stops, and the
lenient `content()` path (`strip_nom`) silently discards everything that
follows — `Content::decode` returns a truncated operation list and
`extract_text` comes back empty.

```text
BT /F1 24 Tf
% comment
  100 100 Td (Hello World) Tj ET
```

Before this change the stream above decodes to 2 operations (`BT`, `Tf`)
instead of 5, and `content_strict` rejects it entirely. The pattern is not
exotic: the PDF Association's official "Simple PDF 2.0 file" example uses a
comment followed by a blank line in its graphics stream, which made
`extract_text` return an empty string for a page with visible text. Per
ISO 32000-2, 7.2.4 a comment is equivalent to a single white-space
character, so the indentation after it must be insignificant.

The fix reuses the pattern `_content` already applies to trailing comments:
skip comments with `many0(terminated(comment, content_space))` so any white
space following each comment is consumed too. `content_space` also matches
the empty string, so bare comments keep working, and the after-`ID` inline
image path is untouched (it must never treat binary data as comments).

Verified against the PDF Association sample: all 26 operations of the
graphics + text streams now decode and `extract_text` returns
"Hello World\n". Added a regression test covering both `content` and
`content_strict`; `cargo test`, `cargo clippy --all-targets` and
`cargo fmt --check` pass.
