### PR TITLE
fix: omit the file header from an incremental update

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -341,9 +341,16 @@ impl IncrementalDocument {
             // Add a newline if it was not already present
             writeln!(target)?;
         }
-        writeln!(target, "%PDF-{}", self.new_document.version)?;
 
-        Writer::write_binary_mark(&mut target, &self.new_document.binary_mark)?;
+        // No file header and no binary marker here. An incremental update is
+        // defined (ISO 32000-1, 7.5.6) as the original file followed by the
+        // changed objects, a cross-reference section and a trailer — the
+        // header belongs to the file, which the previous revision already
+        // carries. Emitting a second "%PDF-x.y" makes the appended region
+        // look like the start of another document to anything that locates a
+        // PDF by scanning for the header, and because `new_document`'s
+        // version defaults to 1.4 it also understated the format of every
+        // file built on a later version.
 
         // Write each newly added indirect object. When the document is
         // encrypted, each object is cloned first and the clone is encrypted;

--- a/tests/incremental_document.rs
+++ b/tests/incremental_document.rs
@@ -33,6 +33,62 @@ fn load_incremental_file() -> Result<()> {
     Ok(())
 }
 
+/// An incremental update must not open with a file header. ISO 32000-1,
+/// 7.5.6 defines it as the original bytes followed by the changed objects, a
+/// cross-reference section and a trailer: the header belongs to the *file*,
+/// and the previous revision already carries it.
+///
+/// Two things went wrong with the second `%PDF-x.y`. A file that appears to
+/// start another document halfway through misleads anything that locates a
+/// PDF by scanning for the header. And because `new_document`'s version
+/// defaults to 1.4, appending to a 1.7 file wrote a line claiming 1.4.
+#[test]
+fn incremental_save_appends_no_second_file_header() {
+    let mut doc = Document::with_version("1.7");
+    let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog" });
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+    let mut prev_bytes = Vec::new();
+    doc.save_to(&mut prev_bytes).unwrap();
+
+    let loaded = Document::load_mem(&prev_bytes).unwrap();
+    let mut incremental = IncrementalDocument::create_from(prev_bytes.clone(), loaded);
+    let marker: Vec<u8> = b"header-guard".to_vec();
+    let stream = Stream::new(dictionary! {}, marker.clone()).with_compression(false);
+    let new_id = incremental.new_document.add_object(Object::Stream(stream));
+
+    let mut out = Vec::new();
+    incremental.save_to(&mut out).unwrap();
+
+    // The previous revision is reproduced untouched.
+    assert_eq!(&out[..prev_bytes.len()], &prev_bytes[..]);
+
+    // The appended region carries neither a header nor a binary marker: it
+    // begins directly with an indirect object.
+    let appended = &out[prev_bytes.len()..];
+    assert!(
+        !appended.windows(b"%PDF-".len()).any(|w| w == b"%PDF-"),
+        "appended region must not open a second document"
+    );
+    let first = appended
+        .iter()
+        .position(|b| !b" \r\n".contains(b))
+        .expect("appended region is not empty");
+    assert!(
+        appended[first].is_ascii_digit(),
+        "appended region must begin with an indirect object, found {:?}",
+        String::from_utf8_lossy(&appended[first..(first + 16).min(appended.len())])
+    );
+
+    // The result still parses, keeps the version it was built with, and the
+    // appended object reads back.
+    let reloaded = Document::load_mem(&out).unwrap();
+    assert_eq!(reloaded.version, "1.7", "the file's version was rewritten");
+    assert_eq!(
+        reloaded.get_object(new_id).unwrap().as_stream().unwrap().content,
+        marker
+    );
+}
+
 /// Build a minimal document that has everything `EncryptionVersion::V1`
 /// needs to derive an encryption key (a `Root` entry and a file `ID`).
 fn minimal_encryptable_document() -> Document {


### PR DESCRIPTION
## The problem

`IncrementalDocument::save_internal` writes a `%PDF-x.y` line and a binary marker for the appended section (`src/writer.rs:344`). ISO 32000-1, 7.5.6 defines an incremental update as the original file followed by the changed objects, a cross-reference section and a trailer - the header belongs to the *file*, and the previous revision already carries it.

Two things go wrong as a result:

1. **The file looks like it starts a second document halfway through.** Syntactically `%PDF-1.4` mid-file is only a comment, so a parser reading the grammar is unharmed. But plenty of tooling locates a PDF by scanning for the header, and a publisher's review pipeline is not the place to find out which.
2. **The declared version is understated.** `new_document`'s version defaults to `1.4`, so appending an annotation layer to a 1.6 file wrote a line claiming 1.4.

Observed on a real publisher proof (PDF 1.6, linearized, classic cross-reference table). The appended region opened:

```
%PDF-1.4
%»­ÀÞ
1 0 obj
```

## The change

Drop the header and the binary marker from the appended section. The newline that separates the update from the previous revision's last byte stays.

The binary marker goes with the header on purpose: its role is to mark the *file* as binary in the bytes right after the header, which is not where an appended section sits.

## Test

`incremental_save_appends_no_second_file_header` in `tests/incremental_document.rs` builds a 1.7 document, appends a stream incrementally, and asserts that

- the previous revision is reproduced byte for byte,
- the appended region contains no `%PDF-` and begins directly with an indirect object,
- the result still parses, still reports version 1.7, and the appended object reads back.

Verified as a regression guard: it fails on `main` and passes with the change.

## Compatibility

Nothing that reads the grammar depends on the removed bytes - a comment is skipped either way. Byte-for-byte output comparisons of incrementally saved files will differ, which is the point.

`cargo test`: 279 passing (278 before, plus the new one). `cargo fmt --check` and `cargo clippy --all-targets` clean.