### PR TITLE
fix: keep direct dictionaries in get_page_annotations

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -732,22 +732,32 @@ impl Document {
     /// Get the PDF annotations of a page. The /Subtype of each annotation dictionary defines the
     /// annotation type (Text, Link, Highlight, Underline, Ink, Popup, Widget, etc.). The /Rect of
     /// an annotation dictionary defines its location on the page.
+    ///
+    /// `/Annots` itself may be an array or a reference to one, and each entry of that array may be
+    /// a reference to an annotation dictionary or, equally legally, the dictionary written directly
+    /// (ISO 32000-1, 12.5.2 requires an indirect object only for an annotation that carries a
+    /// `/Popup` or is the target of an `/IRT` reply). Both forms are returned.
+    ///
+    /// An entry that is neither is skipped, as is a reference that does not resolve to a
+    /// dictionary: a damaged entry costs its own annotation rather than the whole page.
     pub fn get_page_annotations(&self, page_id: ObjectId) -> Result<Vec<&Dictionary>> {
-        let mut annotations = vec![];
-        if let Ok(page) = self.get_dictionary(page_id) {
-            match page.get(b"Annots") {
-                Ok(Object::Reference(id)) => self
-                    .get_object(*id)
-                    .and_then(Object::as_array)?
-                    .iter()
-                    .flat_map(Object::as_reference)
-                    .flat_map(|id| self.get_dictionary(id))
-                    .for_each(|a| annotations.push(a)),
-                Ok(Object::Array(a)) => a
-                    .iter()
-                    .flat_map(Object::as_reference)
-                    .flat_map(|id| self.get_dictionary(id))
-                    .for_each(|a| annotations.push(a)),
+        let Ok(page) = self.get_dictionary(page_id) else {
+            return Ok(vec![]);
+        };
+        let entries = match page.get(b"Annots") {
+            Ok(Object::Reference(id)) => self.get_object(*id).and_then(Object::as_array)?,
+            Ok(Object::Array(entries)) => entries,
+            _ => return Ok(vec![]),
+        };
+        let mut annotations = Vec::with_capacity(entries.len());
+        for entry in entries {
+            match entry {
+                Object::Reference(id) => {
+                    if let Ok(dictionary) = self.get_dictionary(*id) {
+                        annotations.push(dictionary);
+                    }
+                }
+                Object::Dictionary(dictionary) => annotations.push(dictionary),
                 _ => {}
             }
         }

--- a/tests/annotation.rs
+++ b/tests/annotation.rs
@@ -1,6 +1,92 @@
-use lopdf::Result;
+use lopdf::{Document, Object, Result, dictionary};
 
 mod utils;
+
+/// One page whose `/Annots` mixes the two legal entry forms: a reference to
+/// an annotation dictionary, and the dictionary written directly into the
+/// array. Returns the document and the page's id.
+fn page_with_mixed_annots(annots_indirect: bool) -> (Document, lopdf::ObjectId) {
+    let mut doc = Document::with_version("1.7");
+    let referenced = doc.add_object(dictionary! {
+        "Type" => "Annot",
+        "Subtype" => "Text",
+        "Contents" => Object::string_literal("referenced"),
+    });
+    let entries = vec![
+        Object::Reference(referenced),
+        Object::Dictionary(dictionary! {
+            "Type" => "Annot",
+            "Subtype" => "Text",
+            "Contents" => Object::string_literal("direct"),
+        }),
+    ];
+    // `/Annots` is itself allowed to be either an array or a reference to one.
+    let annots = if annots_indirect {
+        Object::Reference(doc.add_object(Object::Array(entries)))
+    } else {
+        Object::Array(entries)
+    };
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Annots" => annots,
+    });
+    (doc, page_id)
+}
+
+fn contents_of(doc: &Document, page_id: lopdf::ObjectId) -> Vec<String> {
+    doc.get_page_annotations(page_id)
+        .unwrap()
+        .iter()
+        .map(|a| String::from_utf8_lossy(a.get(b"Contents").unwrap().as_str().unwrap()).into_owned())
+        .collect()
+}
+
+/// An entry of `/Annots` may be the annotation dictionary itself rather than
+/// a reference to one — ISO 32000-1, 12.5.2 requires an indirect object only
+/// for an annotation that carries a `/Popup` or is an `/IRT` target. Direct
+/// dictionaries used to be dropped without a word, so a page could report
+/// fewer annotations than it has.
+#[test]
+fn page_annotations_include_direct_dictionaries() {
+    let (doc, page_id) = page_with_mixed_annots(false);
+    assert_eq!(contents_of(&doc, page_id), vec!["referenced", "direct"]);
+}
+
+/// The same, with `/Annots` written as a reference to the array.
+#[test]
+fn page_annotations_include_direct_dictionaries_behind_an_indirect_annots() {
+    let (doc, page_id) = page_with_mixed_annots(true);
+    assert_eq!(contents_of(&doc, page_id), vec!["referenced", "direct"]);
+}
+
+/// A reference that does not resolve costs its own annotation, not the page:
+/// the surviving entries still come back.
+#[test]
+fn page_annotations_skip_a_dangling_reference() {
+    let mut doc = Document::with_version("1.7");
+    let good = doc.add_object(dictionary! {
+        "Type" => "Annot",
+        "Subtype" => "Text",
+        "Contents" => Object::string_literal("kept"),
+    });
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Annots" => vec![
+            Object::Reference((9999, 0)),
+            Object::Reference(good),
+            Object::Null,
+        ],
+    });
+    assert_eq!(contents_of(&doc, page_id), vec!["kept"]);
+}
+
+/// A page without `/Annots` has no annotations, and that is not an error.
+#[test]
+fn page_annotations_without_annots_is_empty() {
+    let mut doc = Document::with_version("1.7");
+    let page_id = doc.add_object(dictionary! { "Type" => "Page" });
+    assert!(doc.get_page_annotations(page_id).unwrap().is_empty());
+}
 
 #[test]
 fn annotation_count() -> Result<()> {


### PR DESCRIPTION
## The problem

`Document::get_page_annotations` (`src/document.rs:735`) resolved `/Annots` entries with

```rust
.iter()
.flat_map(Object::as_reference)
.flat_map(|id| self.get_dictionary(id))
```

in both of its branches. `Object::as_reference` yields nothing for a dictionary, so **every annotation written directly into the array was discarded without a word**.

That form is legal. ISO 32000-1, 12.5.2 requires an annotation to be an indirect object only when it carries a `/Popup` or is the target of an `/IRT` reply; otherwise the dictionary may sit in the array. A page could therefore report fewer annotations than it has, and a caller auditing a document for marks it must not miss had no way to tell.

## The change

Walk the entries explicitly, accepting a reference or a dictionary and skipping anything else. `/Annots` itself is still allowed to be an array or a reference to one.

A reference that does not resolve continues to cost only its own annotation rather than the whole page. That leniency was already the behaviour and is now stated in the doc comment instead of being a side effect of `flat_map`.

## Tests

Four in `tests/annotation.rs`, all building their documents in memory so no new asset is needed:

- `page_annotations_include_direct_dictionaries`:  a mixed array of one reference and one direct dictionary returns both, in order.
- `page_annotations_include_direct_dictionaries_behind_an_indirect_annots`: the same with `/Annots` written as a reference to the array, covering the other branch.
- `page_annotations_skip_a_dangling_reference`: an unresolvable reference and a `null` are skipped, the good entry survives.
- `page_annotations_without_annots_is_empty`: a page with no `/Annots` is empty rather than an error.

The first two fail on `main` and pass with the change. The existing `annotation_count` test against `assets/AnnotationDemo.pdf` still reports 33, so files that only use references are unaffected.

## Compatibility

Purely additive in what it returns: a document whose `/Annots` holds only references produces the same result. Callers that assumed every returned dictionary was also reachable as an indirect object could see a dictionary that is not, which is the correct reading of the file.