### PR TITLE
feat: one date backend by default, and a cheaper one available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ bitflags = "2.13"
 cbc = "0.2"
 chrono = { version = "0.4", optional = true, default-features = false, features = [
     "std",
-    "clock",
 ] }
 ecb = "0.2"
 encoding_rs = "0.8"
@@ -66,8 +65,11 @@ criterion = "0.8"
 
 [features]
 async = ["tokio/rt-multi-thread", "tokio/macros"]
+# Fixed-offset and UTC conversions, which is all a PDF date can express.
 chrono = ["dep:chrono"]
-default = ["chrono", "jiff", "rayon", "time"]
+# The system-local conversions, and the iana-time-zone subtree they need.
+chrono-clock = ["chrono", "chrono/clock"]
+default = ["chrono-clock", "rayon"]
 embed_image = ["image"]
 font_embedding = ["dep:ttf-parser"]
 jiff = ["dep:jiff"]
@@ -85,7 +87,10 @@ required-features = ["serde"]
 
 [[example]]
 name = "print_annotations"
-required-features = ["default"]
+# No `required-features`: the example uses `env_logger` (a dev-dependency,
+# always available to an example) and `Document`/`Object`, none of which is
+# behind a feature. Naming `default` only made it silently unbuildable under
+# `--no-default-features`.
 
 [[example]]
 name = "rotate"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,25 @@ The PDF 2.0 specification is available [here](https://www.pdfa.org/announcing-no
 - To check your Rust version: `rustc --version`
 - To update Rust: `rustup update`
 
+## Cargo features
+
+| Feature | Default | What it adds |
+| --- | :---: | --- |
+| `chrono-clock` | ✅ | `chrono` plus its `clock` feature: conversions to and from `DateTime<Local>`, the reading machine's own zone. Brings `iana-time-zone` and its per-platform chain. |
+| `rayon` | ✅ | Parallel object-stream and cross-reference parsing. |
+| `chrono` | | Conversions to and from `DateTime<FixedOffset>` and `DateTime<Utc>`, which is all a PDF date can express. Costs `chrono` and `num-traits`, nothing else. |
+| `jiff` | | Conversions to and from `jiff::Zoned` and `jiff::Timestamp`. Resolves named zones, so it needs a timezone database — bundled into the binary on Windows and on any wasm target. |
+| `time` | | Conversions to and from `time::OffsetDateTime` and `time::PrimitiveDateTime`. |
+| `serde` | | `Serialize`/`Deserialize` for the object model. |
+| `async` | | Tokio-based asynchronous document loading. |
+| `embed_image` | | Embedding raster images, via the `image` crate. |
+| `font_embedding` | | Embedding TrueType fonts, via `ttf-parser`. |
+| `wasm_js` | | Selects `getrandom`'s `wasm_js` backend, needed for encryption on wasm. |
+
+The date backends are alternatives, not layers: each supplies conversions for the same [`DateTime`] value, so enabling more than one only adds dependencies. Enabling none is supported too — `Object::as_datetime` needs no backend, and `DateTime::as_str` returns the raw date for a caller that would rather parse it itself.
+
+A PDF date states a fixed offset from UT and never a named zone (ISO 32000-1, 7.9.4), so `chrono` without `clock` is enough to read one faithfully. `chrono-clock` is the default only because it is what earlier versions gave you.
+
 ## Example Code
 
 * Create PDF document

--- a/benches/datetime.rs
+++ b/benches/datetime.rs
@@ -1,7 +1,13 @@
+#[cfg(feature = "chrono-clock")]
 use chrono::prelude::{Local, Timelike};
 use criterion::{Criterion, criterion_group, criterion_main};
 use lopdf::Object;
 
+// Only the date benchmark needs a date backend, and only this one needs the
+// system clock. Without the gate the whole bench target fails to compile
+// under `--no-default-features`, which is why
+// `cargo clippy --all-targets --no-default-features` does not build.
+#[cfg(feature = "chrono-clock")]
 fn create_and_parse_datetime(c: &mut Criterion) {
     c.bench_function("create_and_parse_datetime", |b| {
         b.iter(|| {
@@ -9,6 +15,19 @@ fn create_and_parse_datetime(c: &mut Criterion) {
             let text: Object = time.into();
             let time2 = text.as_datetime();
             assert!(time2.is_some());
+        });
+    });
+}
+
+#[cfg(not(feature = "chrono-clock"))]
+fn create_and_parse_datetime(c: &mut Criterion) {
+    // The parse half still measures without any backend, through the
+    // accessor that needs none.
+    c.bench_function("create_and_parse_datetime", |b| {
+        b.iter(|| {
+            let text = Object::string_literal("D:20260710143000+02'00'");
+            let parsed = text.as_datetime();
+            assert!(parsed.is_some());
         });
     });
 }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -5,8 +5,8 @@ mod chrono_impl {
     use crate::{Object, datetime::convert_utc_offset};
     use chrono::prelude::*;
 
-    impl From<DateTime<Local>> for Object {
-        fn from(date: DateTime<Local>) -> Self {
+    impl From<DateTime<FixedOffset>> for Object {
+        fn from(date: DateTime<FixedOffset>) -> Self {
             let mut timezone_str = date.format("D:%Y%m%d%H%M%S%:z'").to_string().into_bytes();
             convert_utc_offset(&mut timezone_str);
             Object::string_literal(timezone_str)
@@ -19,10 +19,14 @@ mod chrono_impl {
         }
     }
 
-    impl TryFrom<super::DateTime> for DateTime<Local> {
+    /// A PDF date states a fixed offset from UT and never a named zone
+    /// (ISO 32000-1, 7.9.4), so this is the conversion that keeps what the
+    /// file said. Re-expressing it in the machine's own zone is what the
+    /// `chrono-clock` feature adds.
+    impl TryFrom<super::DateTime> for DateTime<FixedOffset> {
         type Error = chrono::format::ParseError;
 
-        fn try_from(value: super::DateTime) -> Result<DateTime<Local>, Self::Error> {
+        fn try_from(value: super::DateTime) -> Result<DateTime<FixedOffset>, Self::Error> {
             let from_date = |date: NaiveDate| {
                 FixedOffset::east_opt(0)
                     .unwrap()
@@ -32,7 +36,33 @@ mod chrono_impl {
             DateTime::parse_from_str(&value.0, "%Y%m%d%H%M%S%#z")
                 .or_else(|_| DateTime::parse_from_str(&value.0, "%Y%m%d%H%M%#z"))
                 .or_else(|_| NaiveDate::parse_from_str(&value.0, "%Y%m%d").map(from_date))
-                .map(|date| date.with_timezone(&Local))
+        }
+    }
+}
+
+/// The system-local conversions, kept apart from `chrono` because `Local`
+/// exists only with chrono's `clock` feature — which brings `iana-time-zone`
+/// and its per-platform chain. A PDF date never names a zone, so a consumer
+/// that does not want the reading machine's offset applied to someone else's
+/// document can have dates for `chrono` and `num-traits` alone.
+#[cfg(feature = "chrono-clock")]
+mod chrono_clock_impl {
+    use crate::{Object, datetime::convert_utc_offset};
+    use chrono::prelude::*;
+
+    impl From<DateTime<Local>> for Object {
+        fn from(date: DateTime<Local>) -> Self {
+            let mut timezone_str = date.format("D:%Y%m%d%H%M%S%:z'").to_string().into_bytes();
+            convert_utc_offset(&mut timezone_str);
+            Object::string_literal(timezone_str)
+        }
+    }
+
+    impl TryFrom<super::DateTime> for DateTime<Local> {
+        type Error = chrono::format::ParseError;
+
+        fn try_from(value: super::DateTime) -> Result<DateTime<Local>, Self::Error> {
+            DateTime::<FixedOffset>::try_from(value).map(|date| date.with_timezone(&Local))
         }
     }
 }
@@ -176,7 +206,60 @@ impl Object {
     }
 }
 
+impl DateTime {
+    /// The date's characters with `D`, `:` and `'` removed.
+    ///
+    /// Every typed conversion of this value needs a date backend — `chrono`,
+    /// `jiff` or `time` — but [`Object::as_datetime`] itself needs none. A
+    /// build that enables no backend could therefore obtain a `DateTime` and
+    /// have no way to read it. This is that way.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[test]
+fn a_datetime_is_readable_without_a_backend() {
+    let text = Object::string_literal("D:20260710143000+02'00'");
+    // The `D`, `:` and apostrophes are filtered out on the way in; the
+    // relation sign survives, because it is what the offset means.
+    assert_eq!(text.as_datetime().unwrap().as_str(), "20260710143000+0200");
+    assert!(Object::Integer(20260710).as_datetime().is_none());
+}
+
 #[cfg(feature = "chrono")]
+#[test]
+fn parse_datetime_fixed_offset_keeps_the_offset_the_file_stated() {
+    use chrono::prelude::*;
+
+    let text = Object::string_literal("D:20260710143000+02'00'");
+    let date: DateTime<FixedOffset> = text.as_datetime().unwrap().try_into().unwrap();
+    // Not shifted into UTC, and not into the reading machine's zone either.
+    assert_eq!(date.offset().local_minus_utc(), 2 * 3600);
+    assert_eq!(date.hour(), 14);
+    // And it round-trips back to the same text.
+    let back: Object = date.into();
+    assert_eq!(back, Object::string_literal("D:20260710143000+02'00'"));
+}
+
+#[cfg(feature = "chrono")]
+#[test]
+fn parse_datetime_fixed_offset_round_trip() {
+    use chrono::prelude::*;
+
+    // A fixed instant rather than `now()`: `Utc::now` needs chrono's `clock`
+    // feature, which this row deliberately does without, and a deterministic
+    // test is the better one regardless.
+    let time = FixedOffset::east_opt(-5 * 3600 - 30 * 60)
+        .unwrap()
+        .with_ymd_and_hms(2026, 7, 10, 14, 30, 0)
+        .unwrap();
+    let text: Object = time.into();
+    let time2: Option<DateTime<FixedOffset>> = text.as_datetime().and_then(|dt| dt.try_into().ok());
+    assert_eq!(time2, Some(time));
+}
+
+#[cfg(feature = "chrono-clock")]
 #[test]
 fn parse_datetime_local() {
     use chrono::prelude::*;
@@ -192,10 +275,10 @@ fn parse_datetime_local() {
 fn parse_datetime_utc() {
     use chrono::prelude::*;
 
-    let time = Utc::now().with_nanosecond(0).unwrap();
+    let time = Utc.with_ymd_and_hms(2026, 7, 10, 14, 30, 0).unwrap();
     let text: Object = time.into();
-    let time2: Option<DateTime<Local>> = text.as_datetime().and_then(|dt| dt.try_into().ok());
-    assert_eq!(time2, Some(time.with_timezone(&Local)));
+    let time2: Option<DateTime<FixedOffset>> = text.as_datetime().and_then(|dt| dt.try_into().ok());
+    assert_eq!(time2, Some(time.fixed_offset()));
 }
 
 #[cfg(feature = "jiff")]
@@ -227,7 +310,7 @@ fn parse_datetime_seconds_missing_chrono() {
 
     // this is the example from the PDF reference, version 1.7, chapter 3.8.3
     let text = Object::string_literal("D:199812231952-08'00'");
-    let dt: Option<DateTime<Local>> = text.as_datetime().and_then(|dt| dt.try_into().ok());
+    let dt: Option<DateTime<FixedOffset>> = text.as_datetime().and_then(|dt| dt.try_into().ok());
     assert!(dt.is_some());
 }
 
@@ -237,7 +320,7 @@ fn parse_datetime_time_missing_chrono() {
     use chrono::prelude::*;
 
     let text = Object::string_literal("D:20040229");
-    let dt: Option<DateTime<Local>> = text.as_datetime().and_then(|dt| dt.try_into().ok());
+    let dt: Option<DateTime<FixedOffset>> = text.as_datetime().and_then(|dt| dt.try_into().ok());
     assert!(dt.is_some());
 }
 


### PR DESCRIPTION
## The problem

```toml
default = ["chrono", "jiff", "rayon", "time"]
```

Every default build gets all three date backends. They are alternatives, not layers — each supplies conversions for the same `DateTime` newtype — so two of the three are pure cost. `pdfutil`, in this repository, depends on lopdf with default features and uses no date crate at all, so it pays for three.

This is accretion rather than intent. `3288bb0` ("Make chrono crate optional") established `default = ["chrono_time"]` — one backend — and `jiff` and `time` each joined `default` when they arrived.

Measured on Linux with `cargo tree -e normal`:

| Feature set | Crates |
| --- | --- |
| `main` default | **89** |
| this PR's default (`chrono-clock`, `rayon`) | **82** |
| `--no-default-features --features chrono` | **73** |

## The change

**`chrono-clock` is the new default, and it is exactly what `chrono` used to be** — chrono with its `clock` feature and the `DateTime<Local>` conversions. So a default-features build behaves as it did before: same impls, same dependency tree. It only sheds jiff and time.

**`chrono` alone now means chrono without `clock`**, converting to and from `DateTime<FixedOffset>` and `DateTime<Utc>`. That is the honest type for the format — a PDF date states a fixed offset from UT and never a named zone (ISO 32000-1, 7.9.4). The old `TryFrom` already parsed into a `FixedOffset` and then discarded it on its last line:

```rust
.map(|date| date.with_timezone(&Local))
```

which rewrote a date written in Berlin into the reading machine's zone. Keeping the offset is both cheaper and truer to the file.

Three smaller things, all feature-tree matters:

- **`benches/datetime.rs` is gated.** It imported `chrono::prelude` unconditionally, which is why `cargo clippy --all-targets --no-default-features` does not build on `main`. CI compiles the no-default-features row but never builds benches, so it has stayed hidden. The no-backend arm still benchmarks the parse half through the accessor below.
- **`required-features = ["default"]` is dropped from the `print_annotations` example.** It uses `env_logger` (a dev-dependency, always available to an example) and `Document`/`Object`, none of which is behind a feature. Naming `default` only made the example silently unbuildable under `--no-default-features`.
- **`DateTime::as_str` is added** — the one piece of #3 worth keeping. `Object::as_datetime` is not feature-gated while every conversion of its result is, so a build with no backend could obtain a `DateTime` whose `String` is private, with no accessor, no `Deref` and no `Display`, and no way to read the date.

The Cargo features are documented in the README for the first time.

## Two breaks, both mechanical

1. **`jiff` and `time` leave `default`.** A consumer relying on default features *and* using those conversions must now name the feature. This is the point of the change.
2. **The `Local` conversions move from `chrono` to `chrono-clock`.** Anyone pinning `default-features = false, features = ["chrono"]` renames it to `chrono-clock` and has exactly what they had. Default-features consumers notice nothing.

## Tests

| Feature set | Result |
| --- | --- |
| default | 270 passed |
| `--no-default-features` | 264 passed |
| `--no-default-features --features chrono` | 269 passed |
| `--no-default-features --features chrono-clock` | 270 passed |
| `--no-default-features --features jiff` | 268 passed |
| `--no-default-features --features time` | 266 passed |
| `--all-features` | 242 passed |

Run with CI's own invocation, `-- --test-threads=1 --skip performance`. (`tests/document_load_performance.rs` asserts on wall-clock time and trips on the rows where `rayon` is off; it fails the same way on `main`, which is why CI skips it.)

New tests: a fixed-offset date keeps `+02'00'` through a round trip rather than being shifted; `as_str` returns the raw date with no backend enabled. The two chrono tests that called `Utc::now()` now use fixed instants, since `now()` needs `clock` and a deterministic test is better anyway.