### PR TITLE
Default the file encryption key length from V when Length is absent

### DIFF
--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -957,6 +957,39 @@ mod tests {
     }
 
     #[test]
+    fn decrypt_v4_without_length() {
+        let mut document = create_document();
+
+        let crypt_filter: Arc<dyn CryptFilter> = Arc::new(Aes128CryptFilter);
+
+        let version = EncryptionVersion::V4 {
+            document: &document,
+            encrypt_metadata: true,
+            crypt_filters: BTreeMap::from([(b"StdCF".to_vec(), crypt_filter)]),
+            stream_filter: b"StdCF".to_vec(),
+            string_filter: b"StdCF".to_vec(),
+            owner_password: "owner",
+            user_password: "user",
+            permissions: Permissions::all(),
+        };
+
+        let state = EncryptionState::try_from(version).unwrap();
+        document.encrypt(&state).unwrap();
+
+        // Length is optional for V4, which fixes the file encryption key at 128
+        // bits, and plenty of producers leave the entry out.
+        let encrypt_id = document.trailer.get(b"Encrypt").unwrap().as_reference().unwrap();
+        document
+            .get_object_mut(encrypt_id)
+            .unwrap()
+            .as_dict_mut()
+            .unwrap()
+            .remove(b"Length");
+
+        assert!(document.decrypt("user").is_ok());
+    }
+
+    #[test]
     fn encrypt_r5() {
         let mut document = create_document();
 

--- a/src/encryption/algorithms.rs
+++ b/src/encryption/algorithms.rs
@@ -101,6 +101,16 @@ impl TryFrom<&Document> for PasswordAlgorithm {
             _ => Err(DecryptionError::UnsupportedVersion)?,
         }
 
+        // V4 and V5 fix the length of the file encryption key at 128 and 256 bits, so the Length
+        // entry is optional for them and plenty of producers leave it out. Without a default here
+        // the key derivation below falls back to 40 bits and the password check fails on files
+        // that other readers open without complaint.
+        let length = length.or(match version {
+            4 => Some(128),
+            5 => Some(256),
+            _ => None,
+        });
+
         // The length of the file encryption key shall only be present if V is 2 or 3 (but
         // documents with higher values for V seem to have this field).
         if let Some(length) = length {


### PR DESCRIPTION
Fixes #523

`/V 4` fixes the file encryption key at 128 bits, which is why `/Length` is optional there. `PasswordAlgorithm::try_from` only reads the entry when it is present and leaves it `None` otherwise, and three separate places then do:

```rust
self.length.unwrap_or(40) / 8
```

So a 128 bit file gets a 40 bit key, the password check fails, and loading returns `InvalidPassword`. Nothing in the file is malformed. The crypt filter still says `/CFM /AESV2 /Length 16`, the key width is just never read from `/V`.

I defaulted it at the parse site instead of patching the three consumers. The validation block immediately below already requires 128 for V4 and 256 for V5 when the entry is present, so the defaults line up with rules the code was enforcing anyway. V5 gets 256 for symmetry, though R6 key derivation never reads the field, so that half changes nothing today.

The test encrypts through lopdf's own V4 path, removes `/Length` from the `/Encrypt` dict, then decrypts. It fails on main and needs no binary asset committed.

A test built from our own writer only proves we agree with ourselves, so I also ran it against a file written by something else, pypdf's `resources/encryption/r4-aes-v2-no-key-length.pdf`:

```
before: ERR: InvalidPassword
after:  OK: loaded, 1 pages
```

I left that file out of the repo since it is someone else's test asset. Say the word if you would rather have it in for real world coverage.

Full suite passes, fmt and clippy clean.