### PR TITLE
Skip object streams when saving an encrypted document

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -24,6 +24,9 @@ impl Document {
     }
 
     /// Save PDF with custom options
+    ///
+    /// Object streams are skipped for an encrypted document, which is written with every
+    /// object serialized individually instead. See [`Document::save_modern`].
     pub fn save_with_options<W: Write>(&mut self, target: &mut W, options: crate::SaveOptions) -> Result<()> {
         if options.use_object_streams {
             self.save_with_object_streams(target, options)
@@ -33,6 +36,12 @@ impl Document {
     }
 
     /// Save PDF with modern features (object streams and cross-reference streams)
+    ///
+    /// An encrypted document is written without object streams. The objects are already
+    /// encrypted by the time they reach the writer and the file encryption key is gone,
+    /// so an object stream built here could only be written in the clear, contradicting
+    /// the document's `/Encrypt` dictionary. The requested cross-reference type is still
+    /// used; cross-reference streams are never encrypted.
     pub fn save_modern<W: Write>(&mut self, target: &mut W) -> Result<()> {
         let options = crate::SaveOptions {
             use_object_streams: true,
@@ -88,11 +97,6 @@ impl Document {
         use crate::ObjectStream;
         use std::collections::HashMap;
 
-        let mut target = CountingWrite {
-            inner: target,
-            bytes_written: 0,
-        };
-
         // Ensure PDF version is at least 1.5 (required for object streams)
         if self.version.as_str() < "1.5" {
             self.version = "1.5".to_string();
@@ -102,6 +106,23 @@ impl Document {
         if options.use_xref_streams {
             self.reference_table.cross_reference_type = XrefType::CrossReferenceStream;
         }
+
+        // Object streams are built here, while serializing, but the document's objects were
+        // already encrypted by `Document::encrypt`, which drops the file encryption key once
+        // it is done. There is nothing left to encrypt a new stream with, so it would go out
+        // in the clear while the `/Encrypt` dictionary claims every stream is encrypted, and
+        // the strings packed into it would stay encrypted a second time: an object stream is
+        // itself the unit of encryption, and strings inside one shall not be encrypted
+        // separately. Write the objects out individually instead, as `save` does. The
+        // cross-reference type selected above still applies.
+        if self.is_encrypted() {
+            return self.save_internal(target);
+        }
+
+        let mut target = CountingWrite {
+            inner: target,
+            bytes_written: 0,
+        };
 
         let mut xref = Xref::new(self.max_id + 1, self.reference_table.cross_reference_type);
         writeln!(target, "%PDF-{}", self.version)?;

--- a/tests/encrypted_object_stream_test.rs
+++ b/tests/encrypted_object_stream_test.rs
@@ -1,0 +1,185 @@
+//! Saving an encrypted document with object streams enabled.
+//!
+//! Object streams are assembled while serializing, long after `Document::encrypt`
+//! has encrypted every object and dropped the file encryption key, so the writer
+//! has nothing left to encrypt one with.
+//! See https://github.com/J-F-Liu/lopdf/issues/479.
+
+#![cfg(not(feature = "async"))]
+
+use lopdf::{
+    Document, EncryptionState, EncryptionVersion, LoadOptions, Object, Permissions, SaveOptions, Stream, StringFormat,
+    dictionary,
+};
+
+/// Build a one page document carrying a string we can check after a round trip.
+fn sample_document() -> Document {
+    let mut doc = Document::with_version("1.7");
+
+    let pages_id = doc.new_object_id();
+    let content_id = doc.add_object(Stream::new(dictionary! {}, b"BT ET".to_vec()));
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Parent" => Object::Reference(pages_id),
+        "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+        "Contents" => Object::Reference(content_id),
+    });
+    doc.objects.insert(
+        pages_id,
+        Object::Dictionary(dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![Object::Reference(page_id)],
+            "Count" => 1,
+        }),
+    );
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => Object::Reference(pages_id),
+    });
+    let info_id = doc.add_object(dictionary! {
+        "Title" => Object::String(b"lopdf 479".to_vec(), StringFormat::Literal),
+    });
+
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+    doc.trailer.set("Info", Object::Reference(info_id));
+    let id = vec![0x42u8; 16];
+    doc.trailer.set(
+        "ID",
+        Object::Array(vec![
+            Object::String(id.clone(), StringFormat::Literal),
+            Object::String(id, StringFormat::Literal),
+        ]),
+    );
+
+    doc
+}
+
+/// AES-128, the setup from the issue report.
+fn encrypt_aes128(doc: &mut Document) {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    let crypt_filter: Arc<dyn lopdf::encryption::crypt_filters::CryptFilter> =
+        Arc::new(lopdf::encryption::crypt_filters::Aes128CryptFilter);
+    let version = EncryptionVersion::V4 {
+        document: doc,
+        encrypt_metadata: true,
+        crypt_filters: BTreeMap::from([(b"StdCF".to_vec(), crypt_filter)]),
+        stream_filter: b"StdCF".to_vec(),
+        string_filter: b"StdCF".to_vec(),
+        owner_password: "owner",
+        user_password: "",
+        permissions: Permissions::PRINTABLE,
+    };
+    let state = EncryptionState::try_from(version).unwrap();
+    doc.encrypt(&state).unwrap();
+}
+
+/// RC4-128, to show the problem is not specific to the AES crypt filters.
+fn encrypt_rc4_128(doc: &mut Document) {
+    let version = EncryptionVersion::V2 {
+        document: doc,
+        owner_password: "owner",
+        user_password: "",
+        key_length: 128,
+        permissions: Permissions::PRINTABLE,
+    };
+    let state = EncryptionState::try_from(version).unwrap();
+    doc.encrypt(&state).unwrap();
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|window| window == needle)
+}
+
+/// Assert the saved bytes are a readable encrypted PDF.
+fn assert_round_trips(buffer: &[u8], label: &str) {
+    let doc = Document::load_mem_with_options(buffer, LoadOptions::with_password("owner"))
+        .unwrap_or_else(|err| panic!("{label}: reloading the saved document failed: {err:?}"));
+
+    assert!(doc.was_encrypted(), "{label}: document should have been encrypted");
+
+    let pages = doc.get_pages();
+    assert_eq!(pages.len(), 1, "{label}: expected exactly one page");
+
+    // Before the fix this came back as the raw ciphertext of the title: the object
+    // holding it was packed into an object stream, so the reader decrypts the stream
+    // as a whole and correctly leaves the strings inside it alone, but `encrypt` had
+    // already encrypted them individually.
+    let title = doc
+        .trailer
+        .get(b"Info")
+        .and_then(Object::as_reference)
+        .and_then(|id| doc.get_dictionary(id))
+        .and_then(|dict| dict.get(b"Title"))
+        .and_then(Object::as_str)
+        .unwrap_or_else(|err| panic!("{label}: /Title is unreadable: {err:?}"));
+    assert_eq!(title, b"lopdf 479", "{label}: /Title did not survive the round trip");
+
+    let page_id = *pages.get(&1).unwrap();
+    let content = doc.get_page_content(page_id);
+    assert_eq!(
+        content.trim_ascii_end(),
+        b"BT ET",
+        "{label}: page content did not survive the round trip"
+    );
+}
+
+#[test]
+fn save_modern_keeps_encrypted_documents_readable() {
+    let mut doc = sample_document();
+    encrypt_aes128(&mut doc);
+
+    let mut buffer = Vec::new();
+    doc.save_modern(&mut buffer).unwrap();
+
+    assert_round_trips(&buffer, "save_modern");
+}
+
+#[test]
+fn save_with_object_streams_keeps_encrypted_rc4_documents_readable() {
+    let mut doc = sample_document();
+    encrypt_rc4_128(&mut doc);
+
+    let options = SaveOptions::builder()
+        .use_object_streams(true)
+        .use_xref_streams(false)
+        .build();
+    let mut buffer = Vec::new();
+    doc.save_with_options(&mut buffer, options).unwrap();
+
+    assert_round_trips(&buffer, "save_with_options");
+}
+
+#[test]
+fn save_modern_writes_no_object_stream_when_encrypted() {
+    let mut doc = sample_document();
+    encrypt_aes128(&mut doc);
+
+    let mut buffer = Vec::new();
+    doc.save_modern(&mut buffer).unwrap();
+
+    assert!(
+        !contains(&buffer, b"/ObjStm"),
+        "an encrypted document must not be packed into an object stream the writer cannot encrypt"
+    );
+    // The fallback drops object streams only. Cross-reference streams are never
+    // encrypted, so `save_modern` still gets the modern cross-reference section.
+    assert!(
+        contains(&buffer, b"/XRef"),
+        "the requested cross-reference stream should still be written"
+    );
+}
+
+#[test]
+fn save_modern_still_uses_object_streams_when_not_encrypted() {
+    let mut doc = sample_document();
+
+    let mut buffer = Vec::new();
+    doc.save_modern(&mut buffer).unwrap();
+
+    assert!(
+        contains(&buffer, b"/ObjStm"),
+        "an unencrypted document should still be packed into object streams"
+    );
+}


### PR DESCRIPTION
Fixes #479

When using `save_with_object_streams`, object streams are created after `Document::encrypt` has already encrypted each object individually and discarded the encryption key. This timing causes a problem: the `/Encrypt` dictionary indicates that streams should be encrypted, but the newly formed object stream ends up unencrypted. Meanwhile, the strings inside the packed objects were already encrypted separately, when they should instead have been encrypted together as part of the whole stream.

This inconsistency results in a corrupted encrypted PDF:

- AES-128: The decryption filter fails on the unencrypted stream, so lopdf leaves it untouched. The packed objects remain intact, but their string content never gets decrypted, because readers correctly avoid decrypting strings within an object stream. As a result, `/Title` appears as raw 32 byte ciphertext instead of the expected "lopdf 479".

- RC4-128: With no integrity checks, the malformed stream isn't rejected. It becomes garbled during parsing, taking down all embedded objects with it. The reloaded document ends up with no pages at all.

To prevent this, the most reliable solution is to skip packing objects into streams when saving encrypted PDFs, just like the standard `save` method does.

This behavior only kicks in after the requested PDF version and cross-reference format have been applied. So `save_modern` will still use cross-reference streams (which aren't encrypted anyway), but simply avoid creating object streams.

The new test file covers:

- An AES-128 round-trip using `save_modern`

- An RC4-128 round-trip via `save_with_options`

- A save operation with encryption that uses cross-reference streams but skips object streams

- A final check confirming that `save_modern` without encryption still uses object streams normally, ensuring our change only activates when encryption is enabled

The first three tests fail on the main branch but pass with this fix. The last one works consistently in both cases.

I've also verified the actual output using pypdf 6.14.2:

```
before, AES-128: ERR: PdfReadError: Cannot find Root object in pdf
before, RC4-128: ERR: PdfReadError: Cannot find Root object in pdf
after,  AES-128: OK: 1 page, title "lopdf 479"
after,  RC4-128: OK: 1 page, title "lopdf 479"
```

Fully supporting encrypted object streams would require keeping the encryption key alive until serialization, leaving individual objects unencrypted during packing, then encrypting the entire stream at once. That's technically feasible, but would involve significant changes across the crate's encryption layer, so it is better suited to a focused follow-up. For now, skipping object stream creation during encryption is the safer path.

While working through this, I noticed two other points worth addressing separately:

- The `use_xref_streams` flag is only respected in `save_with_object_streams`. When object streams are disabled, enabling xref streams has no effect.

- The `linearize` option does not appear to do anything. No `/Linearized` dictionary is written, and the output is byte for byte identical regardless.

Happy to open separate issues or pull requests for these if the maintainer would like to explore them further.