### PR TITLE
Write a cross-reference stream when object streams are disabled

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -28,6 +28,18 @@ impl Document {
     /// Object streams are skipped for an encrypted document, which is written with every
     /// object serialized individually instead. See [`Document::save_modern`].
     pub fn save_with_options<W: Write>(&mut self, target: &mut W, options: crate::SaveOptions) -> Result<()> {
+        // Cross-reference streams are independent of object streams: a document can use one
+        // without the other. Select the requested type here so the choice applies whichever
+        // path writes the body below. Both features arrived in PDF 1.5, so a document that is
+        // about to use one is moved up to that version.
+        if options.use_xref_streams {
+            self.reference_table.cross_reference_type = XrefType::CrossReferenceStream;
+
+            if self.version.as_str() < "1.5" {
+                self.version = "1.5".to_string();
+            }
+        }
+
         if options.use_object_streams {
             self.save_with_object_streams(target, options)
         } else {
@@ -102,11 +114,6 @@ impl Document {
             self.version = "1.5".to_string();
         }
 
-        // Update cross-reference type if requested
-        if options.use_xref_streams {
-            self.reference_table.cross_reference_type = XrefType::CrossReferenceStream;
-        }
-
         // Object streams are built here, while serializing, but the document's objects were
         // already encrypted by `Document::encrypt`, which drops the file encryption key once
         // it is done. There is nothing left to encrypt a new stream with, so it would go out
@@ -114,7 +121,7 @@ impl Document {
         // the strings packed into it would stay encrypted a second time: an object stream is
         // itself the unit of encryption, and strings inside one shall not be encrypted
         // separately. Write the objects out individually instead, as `save` does. The
-        // cross-reference type selected above still applies.
+        // cross-reference type chosen in `save_with_options` still applies.
         if self.is_encrypted() {
             return self.save_internal(target);
         }

--- a/tests/save_options_xref_streams_test.rs
+++ b/tests/save_options_xref_streams_test.rs
@@ -1,0 +1,128 @@
+//! `SaveOptions::use_xref_streams` on its own, without object streams.
+//!
+//! The two features are independent in the PDF specification, so asking for a
+//! cross-reference stream should not require asking for object streams as well.
+
+#![cfg(not(feature = "async"))]
+
+use lopdf::xref::XrefType;
+use lopdf::{Document, Object, SaveOptions, Stream, dictionary};
+
+/// A one page document written with a classic cross-reference table, as a document
+/// loaded from a pre-1.5 file would be.
+fn sample_document() -> Document {
+    let mut doc = Document::with_version("1.4");
+    doc.reference_table.cross_reference_type = XrefType::CrossReferenceTable;
+
+    let pages_id = doc.new_object_id();
+    let content_id = doc.add_object(Stream::new(dictionary! {}, b"BT ET".to_vec()));
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Parent" => Object::Reference(pages_id),
+        "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+        "Contents" => Object::Reference(content_id),
+    });
+    doc.objects.insert(
+        pages_id,
+        Object::Dictionary(dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![Object::Reference(page_id)],
+            "Count" => 1,
+        }),
+    );
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => Object::Reference(pages_id),
+    });
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+
+    doc
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|window| window == needle)
+}
+
+#[test]
+fn xref_streams_are_written_without_object_streams() {
+    let mut doc = sample_document();
+
+    let options = SaveOptions::builder()
+        .use_object_streams(false)
+        .use_xref_streams(true)
+        .build();
+    let mut buffer = Vec::new();
+    doc.save_with_options(&mut buffer, options).unwrap();
+
+    assert!(
+        contains(&buffer, b"/Type/XRef") || contains(&buffer, b"/Type /XRef"),
+        "a requested cross-reference stream should be written even with object streams off"
+    );
+    assert!(
+        !contains(&buffer, b"\nxref\n"),
+        "the classic cross-reference table should not be written as well"
+    );
+    assert!(
+        !contains(&buffer, b"/ObjStm"),
+        "object streams were not requested and must not appear"
+    );
+
+    // A cross-reference stream is a PDF 1.5 construct, so the header has to say so.
+    assert!(
+        buffer.starts_with(b"%PDF-1.5"),
+        "expected the version to be raised to 1.5, got {:?}",
+        String::from_utf8_lossy(&buffer[..8.min(buffer.len())])
+    );
+
+    let reloaded = Document::load_mem(&buffer).unwrap();
+    assert_eq!(reloaded.get_pages().len(), 1, "the saved document should still load");
+}
+
+#[test]
+fn cross_reference_table_is_kept_when_xref_streams_are_not_requested() {
+    let mut doc = sample_document();
+
+    let options = SaveOptions::builder()
+        .use_object_streams(false)
+        .use_xref_streams(false)
+        .build();
+    let mut buffer = Vec::new();
+    doc.save_with_options(&mut buffer, options).unwrap();
+
+    assert!(
+        contains(&buffer, b"\nxref\n"),
+        "without the option the document keeps its cross-reference table"
+    );
+    assert!(
+        !contains(&buffer, b"/Type/XRef") && !contains(&buffer, b"/Type /XRef"),
+        "no cross-reference stream should appear when it was not requested"
+    );
+    assert!(
+        buffer.starts_with(b"%PDF-1.4"),
+        "the version should be left alone when no 1.5 feature is used"
+    );
+}
+
+#[test]
+fn both_options_together_still_write_object_and_xref_streams() {
+    let mut doc = sample_document();
+
+    let options = SaveOptions::builder()
+        .use_object_streams(true)
+        .use_xref_streams(true)
+        .build();
+    let mut buffer = Vec::new();
+    doc.save_with_options(&mut buffer, options).unwrap();
+
+    assert!(
+        contains(&buffer, b"/ObjStm"),
+        "object streams were requested and should still be written"
+    );
+    assert!(
+        contains(&buffer, b"/Type/XRef") || contains(&buffer, b"/Type /XRef"),
+        "cross-reference streams were requested and should still be written"
+    );
+
+    let reloaded = Document::load_mem(&buffer).unwrap();
+    assert_eq!(reloaded.get_pages().len(), 1, "the saved document should still load");
+}


### PR DESCRIPTION
Following up on #546, yeah, that thing I brought up earlier.

So here's the deal: `use_xref_streams` only gets checked inside `save_with_object_streams`, which means it’s basically a no-op unless `use_object_streams` is also turned on. But hold up, the spec treats these two as totally separate. You can have a cross-reference stream without stuffing objects into streams. Right now, if you’ve got a doc using `CrossReferenceTable` and you try `use_object_streams(false)` with `use_xref_streams(true)`, it just quietly spits out an old-school `xref` table and zero `/Type /XRef` stream. Not what you asked for.

The fix? We’re moving the xref format decision up into `save_with_options`, so it applies no matter which route writes the body. That way, `save_with_object_streams` doesn’t pick the xref type anymore, it just rolls with whatever was already decided. When both flags are on (like in `save_modern`), everything works exactly as before.

Oh, and we bump the PDF version to 1.5 there too. Makes sense, xref streams didn’t exist before 1.5, and we don’t wanna sneak them into files claiming to be 1.4. This version bump used to live in `save_with_object_streams`, but now it’s shifted to where the xref choice happens. (Still not touching #434 though, that one’s about `Document::new()` defaulting to 1.4 while using `CrossReferenceStream` on plain `save`.)

Tests: one checks that setting `use_xref_streams` alone actually gives you an xref stream (fails on main, told ya). Another confirms that turning both off keeps the classic xref table and 1.4 header. Last one makes sure both features still work together. The last two pass either way, they’re just guardrails to stop side effects.

All tests green, default and `--no-default-features`, and rustfmt + clippy are chill.