### PR TITLE
Bound xref-stream entry count against the decoded stream length

### DIFF
--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -578,9 +578,27 @@ pub fn decode_xref_stream_with_limit(
         let mut bytes2 = vec![0_u8; field_widths[1] as usize];
         let mut bytes3 = vec![0_u8; field_widths[2] as usize];
 
+        // Total bytes one entry consumes. With every width zero an entry reads nothing, so the loop
+        // below would run purely on the attacker-controlled /Index counts and never reach the end of
+        // the stream. Such a stream carries no information and can only be malformed, so reject it
+        // (this also keeps max_entries below from dividing by zero).
+        let entry_width = field_widths[0] + field_widths[1] + field_widths[2];
+        if entry_width == 0 {
+            return Err(ParseError::InvalidXref.into());
+        }
+
+        // An entry can't be read from bytes that aren't there, so no section may declare more entries
+        // than the decoded stream could possibly hold. Without this a huge /Index [0 N] still fails
+        // eventually once the reader runs dry, but only after inserting N-ish map entries first.
+        let max_entries = reader.get_ref().len() as i64 / entry_width;
+
         for i in 0..section_indice.len() / 2 {
             let start = section_indice[2 * i];
             let count = section_indice[2 * i + 1];
+
+            if count > max_entries {
+                return Err(ParseError::InvalidXref.into());
+            }
 
             for j in 0..count {
                 let entry_type = if !bytes1.is_empty() {

--- a/tests/xref_stream_bounds.rs
+++ b/tests/xref_stream_bounds.rs
@@ -1,0 +1,103 @@
+//! A cross-reference stream declares how many entries it holds in its `/Index`
+//! array, but the entries themselves live in the (decoded) stream body. If the
+//! declared count is allowed to run past what the body can hold, `load` spins on
+//! an attacker-controlled number instead of the bytes actually present.
+
+#![cfg(not(feature = "async"))]
+
+use lopdf::{Document, Error, ParseError, SaveOptions, Stream, dictionary};
+
+/// A PDF whose only cross-reference is an xref stream with the given `/W` widths,
+/// `/Index [0 count]`, and `body` as an uncompressed stream body.
+fn xref_stream_pdf(w: [i64; 3], count: i64, body: &[u8]) -> Vec<u8> {
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.5\n");
+    let obj_offset = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n");
+    pdf.extend_from_slice(
+        format!(
+            "<< /Type /XRef /Size 4 /W [{} {} {}] /Index [0 {count}] /Root 1 0 R /Length {} >>\n",
+            w[0],
+            w[1],
+            w[2],
+            body.len()
+        )
+        .as_bytes(),
+    );
+    pdf.extend_from_slice(b"stream\n");
+    pdf.extend_from_slice(body);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+    pdf.extend_from_slice(format!("startxref\n{obj_offset}\n%%EOF").as_bytes());
+    pdf
+}
+
+// With `/W [0 0 0]` every entry reads zero bytes, so before the bound the loop ran
+// purely on `/Index`. A 137-byte file claiming a million entries returned Ok with a
+// million-node xref table; `i64::MAX` never returned at all. It must be rejected,
+// and quickly.
+#[test]
+fn zero_width_xref_stream_is_rejected() {
+    let pdf = xref_stream_pdf([0, 0, 0], 1_000_000, b"");
+    match Document::load_mem(&pdf) {
+        Err(Error::Parse(ParseError::InvalidXref)) => {}
+        Err(other) => panic!("expected InvalidXref, got {other:?}"),
+        Ok(doc) => panic!(
+            "a 137-byte file claiming 1,000,000 xref entries loaded with {} entries",
+            doc.reference_table.entries.len()
+        ),
+    }
+}
+
+// Non-zero widths already terminate once the reader runs dry, but only after
+// inserting one map entry per byte first. Bounding the count against the bytes
+// present stops that up front: three body bytes at `/W [1 1 1]` hold one entry, so
+// a section claiming a million is malformed.
+#[test]
+fn index_count_past_stream_length_is_rejected() {
+    let pdf = xref_stream_pdf([1, 1, 1], 1_000_000, &[1, 0, 0]);
+    match Document::load_mem(&pdf) {
+        Err(Error::Parse(ParseError::InvalidXref)) => {}
+        Err(other) => panic!("expected InvalidXref, got {other:?}"),
+        Ok(_) => panic!("an /Index count far past the stream length was accepted"),
+    }
+}
+
+// The bound is derived from the real per-entry width, so a genuine xref stream
+// whose `/Index` matches its body still loads. Written by lopdf's own writer to be
+// sure the shape is exactly what the reader expects.
+#[test]
+fn valid_xref_stream_still_loads() {
+    let mut doc = Document::with_version("1.5");
+    let content_id = doc.add_object(Stream::new(dictionary! {}, b"BT ET".to_vec()));
+    let pages_id = doc.new_object_id();
+    let page_id = doc.add_object(dictionary! {
+        "Type" => "Page",
+        "Parent" => lopdf::Object::Reference(pages_id),
+        "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+        "Contents" => lopdf::Object::Reference(content_id),
+    });
+    doc.objects.insert(
+        pages_id,
+        lopdf::Object::Dictionary(dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![lopdf::Object::Reference(page_id)],
+            "Count" => 1,
+        }),
+    );
+    let catalog_id = doc.add_object(dictionary! {
+        "Type" => "Catalog",
+        "Pages" => lopdf::Object::Reference(pages_id),
+    });
+    doc.trailer.set("Root", lopdf::Object::Reference(catalog_id));
+
+    let options = SaveOptions::builder()
+        .use_object_streams(false)
+        .use_xref_streams(true)
+        .build();
+    let mut buffer = Vec::new();
+    doc.save_with_options(&mut buffer, options).unwrap();
+
+    let reloaded = Document::load_mem(&buffer).unwrap();
+    assert!(reloaded.get_object(catalog_id).is_ok());
+    assert_eq!(reloaded.get_pages().len(), 1);
+}


### PR DESCRIPTION
## Bound xref-stream entry count against the decoded stream length

A malformed cross-reference stream can make `Document::load` loop long enough to be a denial of service, from a file well under 1 KB. This fixes it.

### What happens

`decode_xref_stream_with_limit` (`src/parser_aux.rs`) walks the `/Index` array and reads that many entries out of the decoded stream body. The counts in `/Index` come straight from the file. Normally that is fine, because each entry reads `w1 + w2 + w3` bytes through `read_big_endian_integer`, so once the body is exhausted the read fails and `?` returns an error.

`/W [0 0 0]` removes the exit. All three field widths are zero, which passes the existing width check (it rejects only negatives and values above 8) and is handled explicitly by the `if !bytes1.is_empty() { ... } else { ... }` branches, so every iteration succeeds without touching the reader. The loop then runs purely on `/Index`, and each pass inserts one entry into the xref `BTreeMap`. Nothing bounds it against the actual stream, so the count is whatever the file says.

No decoding is involved (the body is empty and uncompressed), so `LoadOptions::max_decompressed_size` does not help, and because the loop is inside `load` a caller cannot limit it either.

### Impact

Release build, a 137-byte input whose only cross-reference is `<< /Type /XRef /Size 4 /W [0 0 0] /Index [0 N] /Root 1 0 R /Length 0 >>`:

| `/Index` count | result |
| --- | --- |
| 1,000,000 | `Ok`, a 1,000,000-entry xref table, ~2.8 s |
| `i64::MAX` | does not return |

It compounds after the loop: `load_objects_raw` then iterates every fabricated entry trying to read an object, in parallel when `rayon` is on (the default).

### The fix

Two independent guards in `decode_xref_stream_with_limit`, before the entry loop:

1. Reject `/W [0 0 0]`. A zero-width type field together with zero-width fields two and three carries no information, so such a stream can only be malformed. It also keeps the division below from hitting a zero divisor.
2. Cap each section's count at `stream_len / entry_width`. An entry cannot be read from bytes that are not present, so a legitimate section never declares more entries than the decoded body can hold. With this in place a bogus `/Index` is rejected up front instead of after inserting entries until the reader runs dry.

A valid cross-reference stream is unaffected. Its declared count always matches the bytes it ships, so it stays at or below the cap, and its widths are never all zero.

### Tests

`tests/xref_stream_bounds.rs`:

- `zero_width_xref_stream_is_rejected` builds the `/W [0 0 0]`, `/Index [0 1000000]` file above and checks `load_mem` returns `ParseError::InvalidXref` rather than a million-entry table. On the current code this returns `Ok` with 1,000,000 entries.
- `index_count_past_stream_length_is_rejected` uses real widths `/W [1 1 1]` with a three-byte body (one entry) and `/Index [0 1000000]`, and checks the same error. On the current code this reaches the reader-exhausted path and surfaces an IO error instead.
- `valid_xref_stream_still_loads` writes a one-page document with lopdf's own writer using a cross-reference stream, reloads it, and checks the catalog and page survive, guarding against over-rejection.

All three are fast (no multi-second work once the fix is in). `cargo fmt`, both clippy invocations from CI, and the full test suite pass on default, `--no-default-features`, and `--all-features`.
