### PR TITLE
Use skrifa instead of unmaintained ttf-parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ time = { version = "0.3", features = [
 ], optional = true }
 tokio = { version = "1", features = ["fs", "io-util"], optional = true }
 weezl = "0.2"
-ttf-parser = { version = "0.25.1", optional = true }
+skrifa = { version = "0.45.1", optional = true }
 
 [dev-dependencies]
 clap = { version = "4.6", features = ["derive"] }
@@ -58,7 +58,6 @@ serde_json = "1.0"
 shellexpand = "3.1"
 tempfile = "3.27"
 wasm-bindgen-test = "0.3"
-ttf-parser = "0.25.1"
 
 [target.'cfg(not(target_family="wasm"))'.dev-dependencies]
 criterion = "0.8"
@@ -71,7 +70,7 @@ chrono = ["dep:chrono"]
 chrono-clock = ["chrono", "chrono/clock"]
 default = ["chrono-clock", "rayon"]
 embed_image = ["image"]
-font_embedding = ["dep:ttf-parser"]
+font_embedding = ["dep:skrifa"]
 jiff = ["dep:jiff"]
 wasm_js = ["getrandom/wasm_js"]
 serde = ["dep:serde"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The PDF 2.0 specification is available [here](https://www.pdfa.org/announcing-no
 | `serde` | | `Serialize`/`Deserialize` for the object model. |
 | `async` | | Tokio-based asynchronous document loading. |
 | `embed_image` | | Embedding raster images, via the `image` crate. |
-| `font_embedding` | | Embedding TrueType fonts, via `ttf-parser`. |
+| `font_embedding` | | Embedding TrueType fonts, via `skrifa`. |
 | `wasm_js` | | Selects `getrandom`'s `wasm_js` backend, needed for encryption on wasm. |
 
 The date backends are alternatives, not layers: each supplies conversions for the same [`DateTime`] value, so enabling more than one only adds dependencies. Enabling none is supported too — `Object::as_datetime` needs no backend, and `DateTime::as_str` returns the raw date for a caller that would rather parse it itself.

--- a/src/font.rs
+++ b/src/font.rs
@@ -65,23 +65,28 @@ impl FontData {
     /// Create a new `FontData` instance by parsing the provided TTF file.
     /// The TTF file is expected to be in bytes.
     pub fn new(font_file: &[u8], font_name: String) -> Self {
-        // Parse the TTF file using ttf_parser crate
-        let font = ttf_parser::Face::parse(font_file, 0).expect("Failed to parse font file");
+        use skrifa::MetadataProvider;
+        use skrifa::instance::{LocationRef, Size};
+
+        // Parse the TTF file using the skrifa crate
+        let font = skrifa::FontRef::new(font_file).expect("Failed to parse font file");
 
         // Extract font metadata
-        // Note: The ttf_parser crate provides methods to get font bounding box, ascent, descent, cap height, italic
+        // Note: The skrifa crate provides methods to get font bounding box, ascent, descent, cap height, italic
         // angle, and stemV.
-        let font_bbox = font.global_bounding_box();
-        let ascent = font.ascender();
-        let descent = font.descender();
-        let cap_height = font.capital_height().unwrap_or(ascent);
-        let italic_angle = font.italic_angle();
+        let metrics = font.metrics(Size::unscaled(), LocationRef::default());
+        let font_bbox = metrics.bounds.unwrap_or_default();
+        let ascent = metrics.ascent;
+        let descent = metrics.descent;
+        let cap_height = metrics.cap_height.unwrap_or(ascent);
+        let italic_angle = metrics.italic_angle;
         let flags = 1; // Default flags, can be modified later if needed
 
         // Calculate stemV based on the font bounding box
         // Reference: https://stackoverflow.com/questions/35485179/stemv-value-of-the-truetype-font
         // The stemV is typically calculated as 13% of the font's bbox width value.
-        let stem_v = (font_bbox.width() as f64 * 0.13).round() as i64;
+        let bbox_width = font_bbox.x_max - font_bbox.x_min;
+        let stem_v = (bbox_width as f64 * 0.13).round() as i64;
 
         Self {
             font_name,


### PR DESCRIPTION
ttf-parser is no longer maintained: https://rustsec.org/advisories/RUSTSEC-2026-0192.html

I replaced it with [skrifa](https://crates.io/crates/skrifa)