### PR TITLE
Add option to set FirstChar, LastChar and the Widths array of a custom font

### DIFF
--- a/src/creator.rs
+++ b/src/creator.rs
@@ -168,6 +168,11 @@ impl Document {
         let font_file_id = self.add_object(font_stream);
         let font_name = font_data.font_name.clone();
 
+        let widths = font_data
+            .widths
+            .into_iter()
+            .map(|width| Object::Integer(width))
+            .collect();
         // Create font descriptor dictionary
         let font_descriptor_id = self.add_object(dictionary! {
             "Type" => "FontDescriptor",
@@ -193,6 +198,7 @@ impl Document {
             "Subtype" => "TrueType",
             "BaseFont" => Object::Name(font_name.clone().into_bytes()),
             "FontDescriptor" => Object::Reference(font_descriptor_id),
+            "Widths" => Object::Array(widths),
             "Encoding" => Object::Name(font_data.encoding.into_bytes()),
         });
 

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -207,7 +207,7 @@ impl Document {
                 .set("LastChar", Object::Integer(last_char));
         }
         if let Some(widths_array) = font_data.widths {
-            let widths = widths_array.into_iter().map(|width| Object::Integer(width)).collect();
+            let widths = widths_array.into_iter().map(Object::Integer).collect();
             self.get_dictionary_mut(font_id)
                 .unwrap()
                 .set("Widths", Object::Array(widths));

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -168,11 +168,6 @@ impl Document {
         let font_file_id = self.add_object(font_stream);
         let font_name = font_data.font_name.clone();
 
-        let widths = font_data
-            .widths
-            .into_iter()
-            .map(|width| Object::Integer(width))
-            .collect();
         // Create font descriptor dictionary
         let font_descriptor_id = self.add_object(dictionary! {
             "Type" => "FontDescriptor",
@@ -198,11 +193,25 @@ impl Document {
             "Subtype" => "TrueType",
             "BaseFont" => Object::Name(font_name.clone().into_bytes()),
             "FontDescriptor" => Object::Reference(font_descriptor_id),
-            "FirstChar" => Object::Integer(font_data.first_char),
-            "LastChar" => Object::Integer(font_data.last_char),
-            "Widths" => Object::Array(widths),
             "Encoding" => Object::Name(font_data.encoding.into_bytes()),
         });
+
+        if let Some(first_char) = font_data.first_char {
+            self.get_dictionary_mut(font_id)
+                .unwrap()
+                .set("FirstChar", Object::Integer(first_char));
+        }
+        if let Some(last_char) = font_data.last_char {
+            self.get_dictionary_mut(font_id)
+                .unwrap()
+                .set("LastChar", Object::Integer(last_char));
+        }
+        if let Some(widths_array) = font_data.widths {
+            let widths = widths_array.into_iter().map(|width| Object::Integer(width)).collect();
+            self.get_dictionary_mut(font_id)
+                .unwrap()
+                .set("Widths", Object::Array(widths));
+        }
 
         Ok(font_id)
     }

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -198,6 +198,8 @@ impl Document {
             "Subtype" => "TrueType",
             "BaseFont" => Object::Name(font_name.clone().into_bytes()),
             "FontDescriptor" => Object::Reference(font_descriptor_id),
+            "FirstChar" => Object::Integer(font_data.first_char),
+            "LastChar" => Object::Integer(font_data.last_char),
             "Widths" => Object::Array(widths),
             "Encoding" => Object::Name(font_data.encoding.into_bytes()),
         });

--- a/src/font.rs
+++ b/src/font.rs
@@ -29,12 +29,27 @@ pub struct FontData {
     /// (Required, except for Type 3 fonts) The thickness, measured horizontally, of the dominant vertical stems of
     /// glyphs in the font.
     pub stem_v: i64,
-
-    pub widths: Vec<i64>,
     /// (Required) The name of a predefined CMap, or a stream containing a CMap program, that maps character codes to
     /// font numbers and CIDs. If the descendant is a Type 2 CIDFont whose associated TrueType font program is not
     /// embedded in the PDF file, the Encoding entry must be a predefined CMap name Read more (page 422): https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.5_v6.pdf
     pub encoding: String,
+    /// (Required except for the standard 14 fonts) The first character code defined in
+    /// the font’s Widths array.
+    pub first_char: i64,
+    /// (Required except for the standard 14 fonts) The last character code defined in
+    /// the font’s Widths array.
+    pub last_char: i64,
+    /// (Required except for the standard 14 fonts; indirect reference preferred) An ar-
+    /// ray of (LastChar − FirstChar + 1) widths, each element being the glyph width
+    /// for the character code that equals FirstChar plus the array index. For charac-
+    /// ter codes outside the range FirstChar to LastChar, the value of MissingWidth
+    /// from the FontDescriptor entry for this font is used. The glyph widths are
+    /// measured in units in which 1000 units corresponds to 1 unit in text space.
+    /// These widths must be consistent with the actual widths given in the font pro-
+    /// gram itself. (See implementation note 53 in Appendix H.) For more informa-
+    /// tion on glyph widths and other glyph metrics, see Section 5.1.3, “Glyph
+    /// Positioning and Metrics.”
+    pub widths: Vec<i64>,
     /// Size of the font data in bytes.
     /// This is used to set the `Length1` key in the font stream dictionary.
     font: Vec<u8>,
@@ -90,6 +105,8 @@ impl FontData {
         let bbox_width = font_bbox.x_max - font_bbox.x_min;
         let stem_v = (bbox_width as f64 * 0.13).round() as i64;
 
+        let first_char = 33;
+        let last_char = 255;
         let widths = Vec::new();
 
         Self {
@@ -106,8 +123,10 @@ impl FontData {
             descent: descent as i64,
             cap_height: cap_height as i64,
             stem_v,
-            widths,
             encoding: "WinAnsiEncoding".to_string(), // Default encoding, can be modified later if needed
+            first_char: first_char as i64,
+            last_char: last_char as i64,
+            widths,
             font: font_file.to_vec(),
         }
     }
@@ -147,13 +166,23 @@ impl FontData {
         self
     }
 
-    pub fn set_widths(&mut self, widths: Vec<i64>) -> &mut Self {
-        self.widths = widths;
+    pub fn set_encoding(&mut self, encoding: String) -> &mut Self {
+        self.encoding = encoding;
         self
     }
 
-    pub fn set_encoding(&mut self, encoding: String) -> &mut Self {
-        self.encoding = encoding;
+    pub fn set_first_char(&mut self, first_char: i64) -> &mut Self {
+        self.first_char = first_char;
+        self
+    }
+
+    pub fn set_last_char(&mut self, last_char: i64) -> &mut Self {
+        self.last_char = last_char;
+        self
+    }
+
+    pub fn set_widths(&mut self, widths: Vec<i64>) -> &mut Self {
+        self.widths = widths;
         self
     }
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -29,6 +29,8 @@ pub struct FontData {
     /// (Required, except for Type 3 fonts) The thickness, measured horizontally, of the dominant vertical stems of
     /// glyphs in the font.
     pub stem_v: i64,
+
+    pub widths: Vec<i64>,
     /// (Required) The name of a predefined CMap, or a stream containing a CMap program, that maps character codes to
     /// font numbers and CIDs. If the descendant is a Type 2 CIDFont whose associated TrueType font program is not
     /// embedded in the PDF file, the Encoding entry must be a predefined CMap name Read more (page 422): https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.5_v6.pdf
@@ -88,6 +90,8 @@ impl FontData {
         let bbox_width = font_bbox.x_max - font_bbox.x_min;
         let stem_v = (bbox_width as f64 * 0.13).round() as i64;
 
+        let widths = Vec::new();
+
         Self {
             font_name,
             flags,
@@ -102,6 +106,7 @@ impl FontData {
             descent: descent as i64,
             cap_height: cap_height as i64,
             stem_v,
+            widths,
             encoding: "WinAnsiEncoding".to_string(), // Default encoding, can be modified later if needed
             font: font_file.to_vec(),
         }
@@ -139,6 +144,11 @@ impl FontData {
 
     pub fn set_stem_v(&mut self, stem_v: i64) -> &mut Self {
         self.stem_v = stem_v;
+        self
+    }
+
+    pub fn set_widths(&mut self, widths: Vec<i64>) -> &mut Self {
+        self.widths = widths;
         self
     }
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -35,10 +35,10 @@ pub struct FontData {
     pub encoding: String,
     /// (Required except for the standard 14 fonts) The first character code defined in
     /// the font’s Widths array.
-    pub first_char: i64,
+    pub first_char: Option<i64>,
     /// (Required except for the standard 14 fonts) The last character code defined in
     /// the font’s Widths array.
-    pub last_char: i64,
+    pub last_char: Option<i64>,
     /// (Required except for the standard 14 fonts; indirect reference preferred) An ar-
     /// ray of (LastChar − FirstChar + 1) widths, each element being the glyph width
     /// for the character code that equals FirstChar plus the array index. For charac-
@@ -49,7 +49,7 @@ pub struct FontData {
     /// gram itself. (See implementation note 53 in Appendix H.) For more informa-
     /// tion on glyph widths and other glyph metrics, see Section 5.1.3, “Glyph
     /// Positioning and Metrics.”
-    pub widths: Vec<i64>,
+    pub widths: Option<Vec<i64>>,
     /// Size of the font data in bytes.
     /// This is used to set the `Length1` key in the font stream dictionary.
     font: Vec<u8>,
@@ -105,10 +105,6 @@ impl FontData {
         let bbox_width = font_bbox.x_max - font_bbox.x_min;
         let stem_v = (bbox_width as f64 * 0.13).round() as i64;
 
-        let first_char = 33;
-        let last_char = 255;
-        let widths = Vec::new();
-
         Self {
             font_name,
             flags,
@@ -124,9 +120,9 @@ impl FontData {
             cap_height: cap_height as i64,
             stem_v,
             encoding: "WinAnsiEncoding".to_string(), // Default encoding, can be modified later if needed
-            first_char: first_char as i64,
-            last_char: last_char as i64,
-            widths,
+            first_char: None,
+            last_char: None,
+            widths: None,
             font: font_file.to_vec(),
         }
     }
@@ -172,17 +168,17 @@ impl FontData {
     }
 
     pub fn set_first_char(&mut self, first_char: i64) -> &mut Self {
-        self.first_char = first_char;
+        self.first_char = Some(first_char);
         self
     }
 
     pub fn set_last_char(&mut self, last_char: i64) -> &mut Self {
-        self.last_char = last_char;
+        self.last_char = Some(last_char);
         self
     }
 
     pub fn set_widths(&mut self, widths: Vec<i64>) -> &mut Self {
-        self.widths = widths;
+        self.widths = Some(widths);
         self
     }
 


### PR DESCRIPTION
This should solve #448.

I'm not sure if there's a more ergonomic way of adding the parameters to the font dictionary only in case they are `Some`, but that's the best way I was able to come up with.

Let me know if additional changes are necessary.