### PR TITLE
fix(writer): correct xref sections for gapped object numbering

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -479,12 +479,16 @@ impl Writer {
         // Add first (0) entry
         xref_section.add_unusable_free_entry();
 
-        for obj_id in 1..xref.size {
-            // If section is empty change number of starting id.
-            if xref_section.is_empty() {
-                xref_section = XrefSection::new(obj_id);
-            }
+        // Iterate over the actual highest entry instead of `xref.size`:
+        // `size` is fixed before object streams (and the xref stream itself)
+        // are appended, so entries past it would never reach the table.
+        for obj_id in 1..=xref.max_id() {
             if let Some(entry) = xref.get(obj_id) {
+                // A section starts at the first *present* id; starting it at
+                // a missing id would shift every subsequent entry by one.
+                if xref_section.is_empty() {
+                    xref_section = XrefSection::new(obj_id);
+                }
                 match *entry {
                     XrefEntry::Normal { offset, generation } => {
                         // Add entry
@@ -504,7 +508,7 @@ impl Writer {
                 // Skip over `obj_id`, but finish section if not empty.
                 if !xref_section.is_empty() {
                     xref_section.write_xref_section(file)?;
-                    xref_section = XrefSection::new(obj_id);
+                    xref_section = XrefSection::new(0);
                 }
             }
         }
@@ -520,18 +524,22 @@ impl Writer {
         let mut xref_sections = Vec::new();
         let mut xref_section = XrefSection::new(0);
 
-        for obj_id in 1..xref.size {
-            // If section is empty change number of starting id.
-            if xref_section.is_empty() {
-                xref_section = XrefSection::new(obj_id);
-            }
+        // Iterate over the actual highest entry instead of `xref.size`:
+        // `size` is fixed before object streams (and the xref stream itself)
+        // are appended, so entries past it would never reach the stream.
+        for obj_id in 1..=xref.max_id() {
             if let Some(entry) = xref.get(obj_id) {
+                // A section starts at the first *present* id; starting it at
+                // a missing id would shift every subsequent entry by one.
+                if xref_section.is_empty() {
+                    xref_section = XrefSection::new(obj_id);
+                }
                 xref_section.add_entry(entry.clone());
             } else {
                 // Skip over but finish section if not empty
                 if !xref_section.is_empty() {
                     xref_sections.push(xref_section);
-                    xref_section = XrefSection::new(obj_id);
+                    xref_section = XrefSection::new(0);
                 }
             }
         }


### PR DESCRIPTION
Two defects in the cross-reference writers corrupt the xref of real-world PDFs, which typically have gaps in their object numbering and more than ~200 objects:

1. Both `write_xref` and `create_xref_steam` open a new xref section at the first *missing* object id but then append the next *present* entry to it, shifting every subsequent entry by one whenever a gap exists.

2. `xref.size` is fixed before object streams (and the xref stream itself) are appended, and both writers iterate `1..size`, so entries past it are silently dropped — i.e. all but the first object stream for documents with more than 200 objects.

The result is a cross-reference that qpdf rejects ("supposed object stream N is not a stream", "unable to find page tree") and poppler can render as blank pages. Fix by iterating over the actual entry range (`1..=max_id`) and starting each section at the first present id.