### PR TITLE
Bound cross-reference entries during loading

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -154,6 +154,8 @@ pub enum ParseError {
     InvalidTrailer,
     #[error("invalid cross reference table")]
     InvalidXref,
+    #[error("cross-reference entry count exceeded the {limit}-entry limit")]
+    XrefEntryLimitExceeded { limit: usize },
 }
 
 #[derive(Debug, Error)]

--- a/src/load_options.rs
+++ b/src/load_options.rs
@@ -8,8 +8,9 @@ pub type FilterFunc = fn((u32, u16), &mut Object) -> Option<((u32, u16), Object)
 
 /// Options for loading PDF documents.
 ///
-/// Use this struct to configure password, object filtering, and strictness
-/// when loading a PDF. The default is lenient parsing with no password or filter.
+/// Use this struct to configure password, object filtering, resource limits,
+/// and strictness when loading a PDF. The default is lenient parsing with no
+/// password, filter, or resource limits.
 ///
 /// # Examples
 ///
@@ -49,6 +50,16 @@ pub struct LoadOptions {
     ///
     /// `None` (the default) applies no limit.
     pub max_decompressed_size: Option<usize>,
+    /// Maximum number of cross-reference entries accepted while loading.
+    ///
+    /// This limits each cross-reference table or stream and the cumulative
+    /// number of entries across incremental updates. Set it when loading untrusted PDFs
+    /// to prevent crafted cross-reference data from consuming excessive memory.
+    /// A document that exceeds the limit fails with
+    /// [`crate::ParseError::InvalidXref`].
+    ///
+    /// `None` (the default) applies no limit.
+    pub max_xref_entries: Option<usize>,
 }
 
 impl std::fmt::Debug for LoadOptions {
@@ -58,6 +69,7 @@ impl std::fmt::Debug for LoadOptions {
             .field("filter", &self.filter.map(|_| "fn(..)"))
             .field("strict", &self.strict)
             .field("max_decompressed_size", &self.max_decompressed_size)
+            .field("max_xref_entries", &self.max_xref_entries)
             .finish()
     }
 }
@@ -85,6 +97,15 @@ impl LoadOptions {
     pub fn with_max_decompressed_size(max_decompressed_size: usize) -> Self {
         Self {
             max_decompressed_size: Some(max_decompressed_size),
+            ..Default::default()
+        }
+    }
+
+    /// Create options that bound the number of cross-reference entries accepted
+    /// during loading. See [`LoadOptions::max_xref_entries`].
+    pub fn with_max_xref_entries(max_xref_entries: usize) -> Self {
+        Self {
+            max_xref_entries: Some(max_xref_entries),
             ..Default::default()
         }
     }

--- a/src/load_options.rs
+++ b/src/load_options.rs
@@ -56,7 +56,7 @@ pub struct LoadOptions {
     /// number of entries across incremental updates. Set it when loading untrusted PDFs
     /// to prevent crafted cross-reference data from consuming excessive memory.
     /// A document that exceeds the limit fails with
-    /// [`crate::ParseError::InvalidXref`].
+    /// [`crate::ParseError::XrefEntryLimitExceeded`].
     ///
     /// `None` (the default) applies no limit.
     pub max_xref_entries: Option<usize>,

--- a/src/object_stream.rs
+++ b/src/object_stream.rs
@@ -37,29 +37,28 @@ impl Default for ObjectStreamConfig {
 }
 
 impl ObjectStream {
-    /// Parse an existing object stream.
+    /// Parse an existing object stream without modifying its encoded content or
+    /// filter dictionary.
     ///
-    /// This decompresses the stream without any size limit. For untrusted input,
+    /// This decodes the stream without any size limit. For untrusted input,
     /// prefer [`ObjectStream::new_with_limit`] to guard against decompression
     /// bombs.
     pub fn new(stream: &mut Stream) -> Result<ObjectStream> {
         Self::new_with_limit(stream, None)
     }
 
-    /// Parse an existing object stream, rejecting it if its decompressed content
-    /// would exceed `max_decompressed_size` bytes. `None` means no limit (the
-    /// behavior of [`ObjectStream::new`]).
+    /// Parse an existing object stream without modifying it, rejecting the
+    /// decoded content if it would exceed `max_decompressed_size` bytes. `None`
+    /// means no limit (the behavior of [`ObjectStream::new`]).
     pub fn new_with_limit(stream: &mut Stream, max_decompressed_size: Option<usize>) -> Result<ObjectStream> {
-        match max_decompressed_size {
-            // Object streams are decompressed while the document is loaded, so
+        let content = match max_decompressed_size {
+            // Object streams are decoded while the document is loaded, so
             // enforcing the limit here bounds the memory a single stream can use.
-            Some(max) => stream.decompress_with_limit(max)?,
-            None => {
-                let _ = stream.decompress();
-            }
-        }
+            Some(max) => stream.get_plain_content_with_limit(max)?,
+            None => stream.get_plain_content()?,
+        };
 
-        if stream.content.is_empty() {
+        if content.is_empty() {
             return Ok(ObjectStream {
                 objects: BTreeMap::new(),
                 max_objects: 100,
@@ -73,10 +72,7 @@ impl ObjectStream {
             .and_then(Object::as_i64)?
             .try_into()
             .map_err(|e: TryFromIntError| Error::NumericCast(e.to_string()))?;
-        let index_block = stream
-            .content
-            .get(..first_offset)
-            .ok_or(Error::InvalidOffset(first_offset))?;
+        let index_block = content.get(..first_offset).ok_or(Error::InvalidOffset(first_offset))?;
 
         let numbers_str = std::str::from_utf8(index_block).map_err(|e| Error::InvalidObjectStream(e.to_string()))?;
         let numbers: Vec<_> = numbers_str
@@ -94,20 +90,20 @@ impl ObjectStream {
             let id = chunk[0]?;
             let offset = first_offset + chunk[1]? as usize;
 
-            if offset >= stream.content.len() {
+            if offset >= content.len() {
                 warn!("out-of-bounds offset in object stream");
                 return None;
             }
             // Skip leading whitespace — some PDFs emit newlines before objects in ObjStm
             let mut start = offset;
-            while start < stream.content.len() && stream.content[start].is_ascii_whitespace() {
+            while start < content.len() && content[start].is_ascii_whitespace() {
                 start += 1;
             }
-            if start >= stream.content.len() {
+            if start >= content.len() {
                 warn!("only whitespace after offset in object stream");
                 return None;
             }
-            let object = parser::direct_object(&stream.content[start..])?;
+            let object = parser::direct_object(&content[start..])?;
 
             Some(((id, 0), object))
         };

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -493,33 +493,66 @@ pub fn binary_mark(input: ParserInput) -> Option<Vec<u8>> {
 }
 
 /// Decode CrossReferenceTable
-fn xref(input: ParserInput) -> NomResult<Xref> {
+fn xref(input: ParserInput, max_xref_entries: Option<usize>) -> NomResult<crate::Result<Xref>> {
     let xref_eol = map(alt((tag(&b" \r"[..]), tag(&b" \n"[..]), tag(&b"\r\n"[..]))), |_| ());
     let xref_entry = pair(
         separated_pair(unsigned_int, tag(&b" "[..]), unsigned_int::<u32>),
         delimited(tag(&b" "[..]), map(one_of("nf"), |k| k == 'n'), xref_eol),
     );
 
+    let xref_entries = fold_many0(
+        xref_entry,
+        || (Vec::new(), false),
+        |(mut entries, mut limit_exceeded), entry| {
+            if max_xref_entries.is_some_and(|limit| entries.len() >= limit) {
+                limit_exceeded = true;
+            } else {
+                entries.push(entry);
+            }
+            (entries, limit_exceeded)
+        },
+    );
     let xref_section = pair(
         separated_pair(unsigned_int::<usize>, tag(&b" "[..]), unsigned_int::<u32>),
-        preceded(pair(opt(tag(&b" "[..])), eol), many0(xref_entry)),
+        preceded(pair(opt(tag(&b" "[..])), eol), xref_entries),
     );
 
-    delimited(
-        pair(tag(&b"xref"[..]), preceded(opt(tag(&b" "[..])), eol)),
-        fold_many1(
-            xref_section,
-            || -> Xref { Xref::new(0, XrefType::CrossReferenceTable) },
-            |mut xref, ((start, _count), entries)| {
-                for (index, ((offset, generation), is_normal)) in entries.into_iter().enumerate() {
-                    if is_normal && let Ok(generation) = generation.try_into() {
-                        xref.insert((start + index) as u32, XrefEntry::Normal { offset, generation });
+    map(
+        delimited(
+            pair(tag(&b"xref"[..]), preceded(opt(tag(&b" "[..])), eol)),
+            fold_many1(
+                xref_section,
+                || (Xref::new(0, XrefType::CrossReferenceTable), 0_usize, false),
+                |(mut xref, total_entries, limit_exceeded), ((start, _count), (entries, section_limit_exceeded))| {
+                    if limit_exceeded || section_limit_exceeded {
+                        return (xref, total_entries, true);
                     }
-                }
-                xref
-            },
+
+                    let Some(total_entries) = total_entries.checked_add(entries.len()) else {
+                        return (xref, total_entries, true);
+                    };
+                    if max_xref_entries.is_some_and(|limit| total_entries > limit) {
+                        return (xref, total_entries, true);
+                    }
+
+                    for (index, ((offset, generation), is_normal)) in entries.into_iter().enumerate() {
+                        if is_normal && let Ok(generation) = generation.try_into() {
+                            let id = (start + index) as u32;
+                            xref.insert(id, XrefEntry::Normal { offset, generation });
+                        }
+                    }
+                    (xref, total_entries, limit_exceeded)
+                },
+            ),
+            space,
         ),
-        space,
+        |(xref, _, limit_exceeded)| {
+            if limit_exceeded {
+                Err(error::ParseError::InvalidXref.into())
+            } else {
+                Ok(xref)
+            }
+        },
     )
     .parse(input)
 }
@@ -529,20 +562,28 @@ fn trailer(input: ParserInput) -> NomResult<Dictionary> {
 }
 
 pub fn xref_and_trailer(input: ParserInput, reader: &Reader) -> crate::Result<(Xref, Dictionary)> {
-    let xref_trailer = map(pair(xref, trailer), |(mut xref, trailer)| {
-        xref.size = trailer
-            .get(b"Size")
-            .and_then(Object::as_i64)
-            .map_err(|_| error::ParseError::InvalidTrailer)? as u32;
-        Ok((xref, trailer))
-    });
+    let xref_trailer = map(
+        pair(|input| xref(input, reader.max_xref_entries), trailer),
+        |(xref, trailer)| {
+            let mut xref = xref?;
+            xref.size = trailer
+                .get(b"Size")
+                .and_then(Object::as_i64)
+                .map_err(|_| error::ParseError::InvalidTrailer)? as u32;
+            Ok((xref, trailer))
+        },
+    );
     alt((
         xref_trailer,
         (|input| {
             _indirect_object(input, 0, None, reader, &mut HashSet::new())
                 .map(|(_, obj)| {
                     let res = match obj {
-                        Object::Stream(stream) => decode_xref_stream_with_limit(stream, reader.max_decompressed_size),
+                        Object::Stream(stream) => decode_xref_stream_with_limits(
+                            stream,
+                            reader.max_decompressed_size,
+                            reader.max_xref_entries,
+                        ),
                         _ => Err(crate::error::ParseError::InvalidXref.into()),
                     };
                     (input, res)
@@ -870,8 +911,9 @@ startxref
 153804\x20
 %%EOF
 ";
-        match xref(test_span(input)) {
-            Ok((_, re)) => assert_eq!(re.entries.len(), 15),
+        match xref(test_span(input), None) {
+            Ok((_, Ok(re))) => assert_eq!(re.entries.len(), 15),
+            Ok((_, Err(err))) => panic!("unexpected {err:?}"),
             Err(err) => panic!("unexpected {:?}", err),
         }
     }
@@ -998,8 +1040,9 @@ EI";
     fn xref_trailing_space_after_keyword() {
         // Some PDF generators emit "xref \n" with a trailing space.
         let input = b"xref \n0 3\n0000000000 65535 f \n0000000017 00000 n \n0000000081 00000 n \ntrailer\n<</Size 3/Root 1 0 R>>\nstartxref\n175\n%%EOF\n";
-        match xref(test_span(input)) {
-            Ok((_, re)) => assert_eq!(re.entries.len(), 2),
+        match xref(test_span(input), None) {
+            Ok((_, Ok(re))) => assert_eq!(re.entries.len(), 2),
+            Ok((_, Err(err))) => panic!("xref with trailing space should parse: {err:?}"),
             Err(err) => panic!("xref with trailing space should parse: {:?}", err),
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -548,7 +548,10 @@ fn xref(input: ParserInput, max_xref_entries: Option<usize>) -> NomResult<crate:
         ),
         |(xref, _, limit_exceeded)| {
             if limit_exceeded {
-                Err(error::ParseError::InvalidXref.into())
+                match max_xref_entries {
+                    Some(limit) => Err(error::ParseError::XrefEntryLimitExceeded { limit }.into()),
+                    None => Err(error::ParseError::InvalidXref.into()),
+                }
             } else {
                 Ok(xref)
             }

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -534,7 +534,18 @@ pub fn decode_xref_stream(stream: Stream) -> Result<(Xref, Dictionary)> {
 /// behavior of [`decode_xref_stream`]). Cross-reference streams are decoded
 /// early during loading, so this bounds the memory a `/XRef` stream can use.
 pub fn decode_xref_stream_with_limit(
-    mut stream: Stream, max_decompressed_size: Option<usize>,
+    stream: Stream, max_decompressed_size: Option<usize>,
+) -> Result<(Xref, Dictionary)> {
+    decode_xref_stream_with_limits(stream, max_decompressed_size, None)
+}
+
+/// Decode a cross-reference stream with independent decompressed-size and
+/// entry-count limits. `None` leaves the corresponding resource unbounded.
+///
+/// The entry limit applies to the total count declared by the stream's
+/// `/Index` array and is checked before any entries are inserted.
+pub fn decode_xref_stream_with_limits(
+    mut stream: Stream, max_decompressed_size: Option<usize>, max_xref_entries: Option<usize>,
 ) -> Result<(Xref, Dictionary)> {
     if stream.is_compressed() {
         match max_decompressed_size {
@@ -574,31 +585,36 @@ pub fn decode_xref_stream_with_limit(
             return Err(ParseError::InvalidXref.into());
         }
 
-        let mut bytes1 = vec![0_u8; field_widths[0] as usize];
-        let mut bytes2 = vec![0_u8; field_widths[1] as usize];
-        let mut bytes3 = vec![0_u8; field_widths[2] as usize];
-
         // Total bytes one entry consumes. With every width zero an entry reads nothing, so the loop
         // below would run purely on the attacker-controlled /Index counts and never reach the end of
         // the stream. Such a stream carries no information and can only be malformed, so reject it
-        // (this also keeps max_entries below from dividing by zero).
-        let entry_width = field_widths[0] + field_widths[1] + field_widths[2];
+        // (this also keeps the body-capacity check below from dividing by zero).
+        let entry_width = (field_widths[0] + field_widths[1] + field_widths[2]) as usize;
         if entry_width == 0 {
             return Err(ParseError::InvalidXref.into());
         }
 
-        // An entry can't be read from bytes that aren't there, so no section may declare more entries
-        // than the decoded stream could possibly hold. Without this a huge /Index [0 N] still fails
-        // eventually once the reader runs dry, but only after inserting N-ish map entries first.
-        let max_entries = reader.get_ref().len() as i64 / entry_width;
+        let index_entries = section_indice.chunks_exact(2).try_fold(0_usize, |total, section| {
+            let count = usize::try_from(section[1]).map_err(|_| ParseError::InvalidXref)?;
+            total.checked_add(count).ok_or(ParseError::InvalidXref)
+        })?;
+        if max_xref_entries.is_some_and(|limit| index_entries > limit) {
+            return Err(ParseError::InvalidXref.into());
+        }
+
+        // An entry can't be read from bytes that aren't there. Validate the total before inserting
+        // anything so multiple individually plausible /Index sections cannot overrun the body.
+        if index_entries > reader.get_ref().len() / entry_width {
+            return Err(ParseError::InvalidXref.into());
+        }
+
+        let mut bytes1 = vec![0_u8; field_widths[0] as usize];
+        let mut bytes2 = vec![0_u8; field_widths[1] as usize];
+        let mut bytes3 = vec![0_u8; field_widths[2] as usize];
 
         for i in 0..section_indice.len() / 2 {
             let start = section_indice[2 * i];
             let count = section_indice[2 * i + 1];
-
-            if count > max_entries {
-                return Err(ParseError::InvalidXref.into());
-            }
 
             for j in 0..count {
                 let entry_type = if !bytes1.is_empty() {

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -598,8 +598,10 @@ pub fn decode_xref_stream_with_limits(
             let count = usize::try_from(section[1]).map_err(|_| ParseError::InvalidXref)?;
             total.checked_add(count).ok_or(ParseError::InvalidXref)
         })?;
-        if max_xref_entries.is_some_and(|limit| index_entries > limit) {
-            return Err(ParseError::InvalidXref.into());
+        if let Some(limit) = max_xref_entries
+            && index_entries > limit
+        {
+            return Err(ParseError::XrefEntryLimitExceeded { limit }.into());
         }
 
         // An entry can't be read from bytes that aren't there. Validate the total before inserting

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -24,7 +24,7 @@ use crate::error::{ParseError, XrefError};
 use crate::load_options::{FilterFunc, LoadOptions};
 use crate::object_stream::ObjectStream;
 use crate::parser;
-use crate::xref::XrefEntry;
+use crate::xref::{Xref, XrefEntry};
 use crate::{Dictionary, Document, Error, IncrementalDocument, Object, ObjectId, Result};
 
 #[cfg(not(feature = "async"))]
@@ -86,6 +86,7 @@ impl Document {
             password: options.password,
             strict: options.strict,
             max_decompressed_size: options.max_decompressed_size,
+            max_xref_entries: options.max_xref_entries,
         }
         .read(options.filter)
     }
@@ -105,6 +106,7 @@ impl Document {
             password: options.password,
             strict: options.strict,
             max_decompressed_size: options.max_decompressed_size,
+            max_xref_entries: options.max_xref_entries,
         }
         .read(options.filter)
     }
@@ -119,42 +121,59 @@ impl Document {
     /// This is much faster for large PDFs when you only need basic information.
     #[inline]
     pub fn load_metadata<P: AsRef<Path>>(path: P) -> Result<PdfMetadata> {
+        Self::load_metadata_with_options(path, LoadOptions::default())
+    }
+
+    /// Load PDF metadata from a file path with the given options.
+    #[inline]
+    pub fn load_metadata_with_options<P: AsRef<Path>>(path: P, options: LoadOptions) -> Result<PdfMetadata> {
         let file = File::open(path)?;
         let capacity = Some(file.metadata()?.len() as usize);
-        Self::load_metadata_internal(file, capacity, None)
+        Self::load_metadata_internal(file, capacity, options)
     }
 
     /// Load PDF metadata from a file path with a password for encrypted PDFs.
     #[inline]
     pub fn load_metadata_with_password<P: AsRef<Path>>(path: P, password: &str) -> Result<PdfMetadata> {
-        let file = File::open(path)?;
-        let capacity = Some(file.metadata()?.len() as usize);
-        Self::load_metadata_internal(file, capacity, Some(password.to_string()))
+        Self::load_metadata_with_options(path, LoadOptions::with_password(password))
     }
 
     /// Load PDF metadata from an arbitrary source without loading the entire document.
     #[inline]
     pub fn load_metadata_from<R: Read>(source: R) -> Result<PdfMetadata> {
-        Self::load_metadata_internal(source, None, None)
+        Self::load_metadata_from_with_options(source, LoadOptions::default())
+    }
+
+    /// Load PDF metadata from an arbitrary source with the given options.
+    #[inline]
+    pub fn load_metadata_from_with_options<R: Read>(source: R, options: LoadOptions) -> Result<PdfMetadata> {
+        Self::load_metadata_internal(source, None, options)
     }
 
     /// Load PDF metadata from an arbitrary source with a password for encrypted PDFs.
     #[inline]
     pub fn load_metadata_from_with_password<R: Read>(source: R, password: &str) -> Result<PdfMetadata> {
-        Self::load_metadata_internal(source, None, Some(password.to_string()))
+        Self::load_metadata_from_with_options(source, LoadOptions::with_password(password))
     }
 
     /// Load PDF metadata from a memory slice without loading the entire document.
     #[inline]
     pub fn load_metadata_mem(buffer: &[u8]) -> Result<PdfMetadata> {
+        Self::load_metadata_mem_with_options(buffer, LoadOptions::default())
+    }
+
+    /// Load PDF metadata from a memory slice with the given options.
+    #[inline]
+    pub fn load_metadata_mem_with_options(buffer: &[u8], options: LoadOptions) -> Result<PdfMetadata> {
         Reader {
             buffer,
             document: Document::new(),
             encryption_state: None,
             raw_objects: BTreeMap::new(),
-            password: None,
-            strict: false,
-            max_decompressed_size: None,
+            password: options.password,
+            strict: options.strict,
+            max_decompressed_size: options.max_decompressed_size,
+            max_xref_entries: options.max_xref_entries,
         }
         .read_metadata()
     }
@@ -162,20 +181,11 @@ impl Document {
     /// Load PDF metadata from a memory slice with a password for encrypted PDFs.
     #[inline]
     pub fn load_metadata_mem_with_password(buffer: &[u8], password: &str) -> Result<PdfMetadata> {
-        Reader {
-            buffer,
-            document: Document::new(),
-            encryption_state: None,
-            raw_objects: BTreeMap::new(),
-            password: Some(password.to_string()),
-            strict: false,
-            max_decompressed_size: None,
-        }
-        .read_metadata()
+        Self::load_metadata_mem_with_options(buffer, LoadOptions::with_password(password))
     }
 
     fn load_metadata_internal<R: Read>(
-        mut source: R, capacity: Option<usize>, password: Option<String>,
+        mut source: R, capacity: Option<usize>, options: LoadOptions,
     ) -> Result<PdfMetadata> {
         let mut buffer = capacity.map(Vec::with_capacity).unwrap_or_default();
         source.read_to_end(&mut buffer)?;
@@ -185,9 +195,10 @@ impl Document {
             document: Document::new(),
             encryption_state: None,
             raw_objects: BTreeMap::new(),
-            password,
-            strict: false,
-            max_decompressed_size: None,
+            password: options.password,
+            strict: options.strict,
+            max_decompressed_size: options.max_decompressed_size,
+            max_xref_entries: options.max_xref_entries,
         }
         .read_metadata()
     }
@@ -231,6 +242,7 @@ impl Document {
             password: options.password,
             strict: options.strict,
             max_decompressed_size: options.max_decompressed_size,
+            max_xref_entries: options.max_xref_entries,
         }
         .read(options.filter)
     }
@@ -250,6 +262,7 @@ impl Document {
             password: options.password,
             strict: options.strict,
             max_decompressed_size: options.max_decompressed_size,
+            max_xref_entries: options.max_xref_entries,
         }
         .read(options.filter)
     }
@@ -258,44 +271,60 @@ impl Document {
     /// This is much faster for large PDFs when you only need basic information.
     #[inline]
     pub async fn load_metadata<P: AsRef<Path>>(path: P) -> Result<PdfMetadata> {
+        Self::load_metadata_with_options(path, LoadOptions::default()).await
+    }
+
+    /// Load PDF metadata from a file path with the given options.
+    #[inline]
+    pub async fn load_metadata_with_options<P: AsRef<Path>>(path: P, options: LoadOptions) -> Result<PdfMetadata> {
         let file = File::open(path).await?;
         let metadata = file.metadata().await?;
         let capacity = Some(metadata.len() as usize);
-        Self::load_metadata_internal(file, capacity, None).await
+        Self::load_metadata_internal(file, capacity, options).await
     }
 
     /// Load PDF metadata from a file path with a password for encrypted PDFs.
     #[inline]
     pub async fn load_metadata_with_password<P: AsRef<Path>>(path: P, password: &str) -> Result<PdfMetadata> {
-        let file = File::open(path).await?;
-        let metadata = file.metadata().await?;
-        let capacity = Some(metadata.len() as usize);
-        Self::load_metadata_internal(file, capacity, Some(password.to_string())).await
+        Self::load_metadata_with_options(path, LoadOptions::with_password(password)).await
     }
 
     /// Load PDF metadata from an arbitrary source without loading the entire document.
     #[inline]
     pub async fn load_metadata_from<R: AsyncRead>(source: R) -> Result<PdfMetadata> {
-        Self::load_metadata_internal(source, None, None).await
+        Self::load_metadata_from_with_options(source, LoadOptions::default()).await
+    }
+
+    /// Load PDF metadata from an arbitrary source with the given options.
+    #[inline]
+    pub async fn load_metadata_from_with_options<R: AsyncRead>(source: R, options: LoadOptions) -> Result<PdfMetadata> {
+        Self::load_metadata_internal(source, None, options).await
     }
 
     /// Load PDF metadata from an arbitrary source with a password for encrypted PDFs.
     #[inline]
     pub async fn load_metadata_from_with_password<R: AsyncRead>(source: R, password: &str) -> Result<PdfMetadata> {
-        Self::load_metadata_internal(source, None, Some(password.to_string())).await
+        Self::load_metadata_from_with_options(source, LoadOptions::with_password(password)).await
     }
 
     /// Load PDF metadata from a memory slice without loading the entire document.
     #[inline]
     pub fn load_metadata_mem(buffer: &[u8]) -> Result<PdfMetadata> {
+        Self::load_metadata_mem_with_options(buffer, LoadOptions::default())
+    }
+
+    /// Load PDF metadata from a memory slice with the given options.
+    #[inline]
+    pub fn load_metadata_mem_with_options(buffer: &[u8], options: LoadOptions) -> Result<PdfMetadata> {
         Reader {
             buffer,
             document: Document::new(),
             encryption_state: None,
             raw_objects: BTreeMap::new(),
-            password: None,
-            strict: false,
-            max_decompressed_size: None,
+            password: options.password,
+            strict: options.strict,
+            max_decompressed_size: options.max_decompressed_size,
+            max_xref_entries: options.max_xref_entries,
         }
         .read_metadata()
     }
@@ -303,20 +332,11 @@ impl Document {
     /// Load PDF metadata from a memory slice with a password for encrypted PDFs.
     #[inline]
     pub fn load_metadata_mem_with_password(buffer: &[u8], password: &str) -> Result<PdfMetadata> {
-        Reader {
-            buffer,
-            document: Document::new(),
-            encryption_state: None,
-            raw_objects: BTreeMap::new(),
-            password: Some(password.to_string()),
-            strict: false,
-            max_decompressed_size: None,
-        }
-        .read_metadata()
+        Self::load_metadata_mem_with_options(buffer, LoadOptions::with_password(password))
     }
 
     async fn load_metadata_internal<R: AsyncRead>(
-        source: R, capacity: Option<usize>, password: Option<String>,
+        source: R, capacity: Option<usize>, options: LoadOptions,
     ) -> Result<PdfMetadata> {
         pin!(source);
 
@@ -328,9 +348,10 @@ impl Document {
             document: Document::new(),
             encryption_state: None,
             raw_objects: BTreeMap::new(),
-            password,
-            strict: false,
-            max_decompressed_size: None,
+            password: options.password,
+            strict: options.strict,
+            max_decompressed_size: options.max_decompressed_size,
+            max_xref_entries: options.max_xref_entries,
         }
         .read_metadata()
     }
@@ -348,6 +369,7 @@ impl TryInto<Document> for &[u8] {
             password: None,
             strict: false,
             max_decompressed_size: None,
+            max_xref_entries: None,
         }
         .read(None)
     }
@@ -358,18 +380,30 @@ impl IncrementalDocument {
     /// Load a PDF document from a specified file path.
     #[inline]
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
+        Self::load_with_options(path, LoadOptions::default())
+    }
+
+    /// Load a PDF document from a specified file path with the given options.
+    #[inline]
+    pub fn load_with_options<P: AsRef<Path>>(path: P, options: LoadOptions) -> Result<Self> {
         let file = File::open(path)?;
         let capacity = Some(file.metadata()?.len() as usize);
-        Self::load_internal(file, capacity)
+        Self::load_internal(file, capacity, options)
     }
 
     /// Load a PDF document from an arbitrary source.
     #[inline]
     pub fn load_from<R: Read>(source: R) -> Result<Self> {
-        Self::load_internal(source, None)
+        Self::load_from_with_options(source, LoadOptions::default())
     }
 
-    fn load_internal<R: Read>(mut source: R, capacity: Option<usize>) -> Result<Self> {
+    /// Load a PDF document from an arbitrary source with the given options.
+    #[inline]
+    pub fn load_from_with_options<R: Read>(source: R, options: LoadOptions) -> Result<Self> {
+        Self::load_internal(source, None, options)
+    }
+
+    fn load_internal<R: Read>(mut source: R, capacity: Option<usize>, options: LoadOptions) -> Result<Self> {
         let mut buffer = capacity.map(Vec::with_capacity).unwrap_or_default();
         source.read_to_end(&mut buffer)?;
 
@@ -378,18 +412,24 @@ impl IncrementalDocument {
             document: Document::new(),
             encryption_state: None,
             raw_objects: BTreeMap::new(),
-            password: None,
-            strict: false,
-            max_decompressed_size: None,
+            password: options.password,
+            strict: options.strict,
+            max_decompressed_size: options.max_decompressed_size,
+            max_xref_entries: options.max_xref_entries,
         }
-        .read(None)?;
+        .read(options.filter)?;
 
         Ok(IncrementalDocument::create_from(buffer, document))
     }
 
     /// Load a PDF document from a memory slice.
     pub fn load_mem(buffer: &[u8]) -> Result<Document> {
-        buffer.try_into()
+        Self::load_mem_with_options(buffer, LoadOptions::default())
+    }
+
+    /// Load a PDF document from a memory slice with the given options.
+    pub fn load_mem_with_options(buffer: &[u8], options: LoadOptions) -> Result<Document> {
+        Document::load_mem_with_options(buffer, options)
     }
 }
 
@@ -398,19 +438,31 @@ impl IncrementalDocument {
     /// Load a PDF document from a specified file path.
     #[inline]
     pub async fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
+        Self::load_with_options(path, LoadOptions::default()).await
+    }
+
+    /// Load a PDF document from a specified file path with the given options.
+    #[inline]
+    pub async fn load_with_options<P: AsRef<Path>>(path: P, options: LoadOptions) -> Result<Self> {
         let file = File::open(path).await?;
         let metadata = file.metadata().await?;
         let capacity = Some(metadata.len() as usize);
-        Self::load_internal(file, capacity).await
+        Self::load_internal(file, capacity, options).await
     }
 
     /// Load a PDF document from an arbitrary source.
     #[inline]
     pub async fn load_from<R: AsyncRead>(source: R) -> Result<Self> {
-        Self::load_internal(source, None).await
+        Self::load_from_with_options(source, LoadOptions::default()).await
     }
 
-    async fn load_internal<R: AsyncRead>(source: R, capacity: Option<usize>) -> Result<Self> {
+    /// Load a PDF document from an arbitrary source with the given options.
+    #[inline]
+    pub async fn load_from_with_options<R: AsyncRead>(source: R, options: LoadOptions) -> Result<Self> {
+        Self::load_internal(source, None, options).await
+    }
+
+    async fn load_internal<R: AsyncRead>(source: R, capacity: Option<usize>, options: LoadOptions) -> Result<Self> {
         pin!(source);
 
         let mut buffer = capacity.map(Vec::with_capacity).unwrap_or_default();
@@ -421,18 +473,24 @@ impl IncrementalDocument {
             document: Document::new(),
             encryption_state: None,
             raw_objects: BTreeMap::new(),
-            password: None,
-            strict: false,
-            max_decompressed_size: None,
+            password: options.password,
+            strict: options.strict,
+            max_decompressed_size: options.max_decompressed_size,
+            max_xref_entries: options.max_xref_entries,
         }
-        .read(None)?;
+        .read(options.filter)?;
 
         Ok(IncrementalDocument::create_from(buffer, document))
     }
 
     /// Load a PDF document from a memory slice.
     pub fn load_mem(buffer: &[u8]) -> Result<Document> {
-        buffer.try_into()
+        Self::load_mem_with_options(buffer, LoadOptions::default())
+    }
+
+    /// Load a PDF document from a memory slice with the given options.
+    pub fn load_mem_with_options(buffer: &[u8], options: LoadOptions) -> Result<Document> {
+        Document::load_mem_with_options(buffer, options)
     }
 }
 
@@ -448,6 +506,7 @@ impl TryInto<IncrementalDocument> for &[u8] {
             password: None,
             strict: false,
             max_decompressed_size: None,
+            max_xref_entries: None,
         }
         .read(None)?;
 
@@ -467,6 +526,9 @@ pub struct Reader<'a> {
     /// `None` (the default) applies no limit; set it to guard against
     /// decompression bombs. See [`crate::LoadOptions`].
     pub max_decompressed_size: Option<usize>,
+    /// Maximum number of cross-reference entries accepted from any individual
+    /// table or stream and across merged incremental updates. `None` applies no limit.
+    pub max_xref_entries: Option<usize>,
 }
 
 /// Maximum allowed embedding of literal strings.
@@ -558,6 +620,35 @@ const STANDARD_INFO_KEYS: &[&[u8]] = &[
 ];
 
 impl Reader<'_> {
+    fn check_xref_entry_limit(&self, xref: &Xref) -> Result<()> {
+        if self.max_xref_entries.is_some_and(|limit| xref.entries.len() > limit) {
+            Err(ParseError::InvalidXref.into())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn merge_xref(&self, xref: &mut Xref, incoming: Xref) -> Result<()> {
+        let additional_entries = incoming
+            .entries
+            .keys()
+            .filter(|id| !xref.entries.contains_key(*id))
+            .try_fold(0_usize, |count, _| count.checked_add(1))
+            .ok_or(ParseError::InvalidXref)?;
+        let merged_entries = xref
+            .entries
+            .len()
+            .checked_add(additional_entries)
+            .ok_or(ParseError::InvalidXref)?;
+        if self.max_xref_entries.is_some_and(|limit| merged_entries > limit) {
+            return Err(ParseError::InvalidXref.into());
+        }
+
+        xref.merge(incoming);
+        debug_assert_eq!(xref.entries.len(), merged_entries);
+        Ok(())
+    }
+
     /// Read metadata (title and page count) without loading the entire document.
     /// This is much faster for large PDFs when you only need basic information.
     ///
@@ -574,6 +665,7 @@ impl Reader<'_> {
         }
 
         let (mut xref, mut trailer) = parser::xref_and_trailer(&self.buffer[xref_start..], &self)?;
+        self.check_xref_entry_limit(&xref)?;
 
         let mut already_seen = HashSet::new();
         let mut prev_xref_start = trailer.remove(b"Prev");
@@ -587,7 +679,7 @@ impl Reader<'_> {
             }
 
             let (prev_xref, prev_trailer) = parser::xref_and_trailer(&self.buffer[prev as usize..], &self)?;
-            xref.merge(prev_xref);
+            self.merge_xref(&mut xref, prev_xref)?;
 
             let prev_xref_stream_start = trailer.remove(b"XRefStm");
             if let Some(prev) = prev_xref_stream_start.and_then(|offset| offset.as_i64().ok()) {
@@ -596,7 +688,7 @@ impl Reader<'_> {
                 }
 
                 let (prev_xref, _) = parser::xref_and_trailer(&self.buffer[prev as usize..], &self)?;
-                xref.merge(prev_xref);
+                self.merge_xref(&mut xref, prev_xref)?;
             }
 
             prev_xref_start = prev_trailer.get(b"Prev").cloned().ok();
@@ -810,6 +902,7 @@ impl Reader<'_> {
         self.document.xref_start = xref_start;
 
         let (mut xref, mut trailer) = parser::xref_and_trailer(&self.buffer[xref_start..], &self)?;
+        self.check_xref_entry_limit(&xref)?;
 
         // Read previous Xrefs of linearized or incremental updated document.
         let mut already_seen = HashSet::new();
@@ -824,7 +917,7 @@ impl Reader<'_> {
             }
 
             let (prev_xref, prev_trailer) = parser::xref_and_trailer(&self.buffer[prev as usize..], &self)?;
-            xref.merge(prev_xref);
+            self.merge_xref(&mut xref, prev_xref)?;
 
             // Read xref stream in hybrid-reference file
             let prev_xref_stream_start = trailer.remove(b"XRefStm");
@@ -834,7 +927,7 @@ impl Reader<'_> {
                 }
 
                 let (prev_xref, _) = parser::xref_and_trailer(&self.buffer[prev as usize..], &self)?;
-                xref.merge(prev_xref);
+                self.merge_xref(&mut xref, prev_xref)?;
             }
 
             prev_xref_start = prev_trailer.get(b"Prev").cloned().ok();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -621,11 +621,13 @@ const STANDARD_INFO_KEYS: &[&[u8]] = &[
 
 impl Reader<'_> {
     fn check_xref_entry_limit(&self, xref: &Xref) -> Result<()> {
-        if self.max_xref_entries.is_some_and(|limit| xref.entries.len() > limit) {
-            Err(ParseError::InvalidXref.into())
-        } else {
-            Ok(())
+        if let Some(limit) = self.max_xref_entries
+            && xref.entries.len() > limit
+        {
+            return Err(ParseError::XrefEntryLimitExceeded { limit }.into());
         }
+
+        Ok(())
     }
 
     fn merge_xref(&self, xref: &mut Xref, incoming: Xref) -> Result<()> {
@@ -640,8 +642,10 @@ impl Reader<'_> {
             .len()
             .checked_add(additional_entries)
             .ok_or(ParseError::InvalidXref)?;
-        if self.max_xref_entries.is_some_and(|limit| merged_entries > limit) {
-            return Err(ParseError::InvalidXref.into());
+        if let Some(limit) = self.max_xref_entries
+            && merged_entries > limit
+        {
+            return Err(ParseError::XrefEntryLimitExceeded { limit }.into());
         }
 
         xref.merge(incoming);

--- a/src/xref.rs
+++ b/src/xref.rs
@@ -166,7 +166,7 @@ impl XrefSection {
     }
 }
 
-pub use crate::parser_aux::{decode_xref_stream, decode_xref_stream_with_limit};
+pub use crate::parser_aux::{decode_xref_stream, decode_xref_stream_with_limit, decode_xref_stream_with_limits};
 
 /// Encode a field value as big-endian bytes with specified width
 fn encode_field(value: u64, width: usize, output: &mut Vec<u8>) {

--- a/tests/decompression_bomb.rs
+++ b/tests/decompression_bomb.rs
@@ -316,3 +316,21 @@ fn object_stream_bomb_is_rejected_with_limit() {
         Ok(_) => panic!("object stream bomb was not caught"),
     }
 }
+
+#[test]
+fn object_stream_parsing_preserves_encoded_evidence() {
+    let decoded = b"1 0 << /Kind /ArchiveEntry /Padding (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) >>";
+    let encoded = zlib_compress(decoded);
+    let mut dict = Dictionary::new();
+    dict.set("Type", "ObjStm");
+    dict.set("N", 1i64);
+    dict.set("First", 4i64);
+    dict.set("Filter", "FlateDecode");
+    let mut stream = Stream::new(dict, encoded.clone());
+
+    let object_stream = ObjectStream::new_with_limit(&mut stream, Some(decoded.len())).unwrap();
+
+    assert!(object_stream.objects.contains_key(&(1, 0)));
+    assert_eq!(stream.content, encoded);
+    assert_eq!(stream.dict.get(b"Filter").unwrap().as_name().unwrap(), b"FlateDecode");
+}

--- a/tests/load_options_test.rs
+++ b/tests/load_options_test.rs
@@ -10,6 +10,8 @@ mod sync_tests {
         assert!(opts.password.is_none());
         assert!(opts.filter.is_none());
         assert!(!opts.strict);
+        assert!(opts.max_decompressed_size.is_none());
+        assert!(opts.max_xref_entries.is_none());
     }
 
     #[test]
@@ -29,6 +31,13 @@ mod sync_tests {
         assert!(opts.password.is_none());
         assert!(opts.filter.is_some());
         assert!(!opts.strict);
+    }
+
+    #[test]
+    fn load_options_with_max_xref_entries() {
+        let opts = LoadOptions::with_max_xref_entries(1_024);
+        assert_eq!(opts.max_xref_entries, Some(1_024));
+        assert!(opts.max_decompressed_size.is_none());
     }
 
     #[test]

--- a/tests/xref_stream_bounds.rs
+++ b/tests/xref_stream_bounds.rs
@@ -113,10 +113,10 @@ fn record_object_filter(id: (u32, u16), object: &mut Object) -> Option<((u32, u1
     Some((id, object.clone()))
 }
 
-fn assert_invalid_xref<T>(result: lopdf::Result<T>, context: &str) {
+fn assert_xref_limit_exceeded<T>(result: lopdf::Result<T>, context: &str) {
     match result {
-        Err(Error::Parse(ParseError::InvalidXref)) => {}
-        Err(other) => panic!("{context}: expected InvalidXref, got {other:?}"),
+        Err(Error::Parse(ParseError::XrefEntryLimitExceeded { limit: 3 })) => {}
+        Err(other) => panic!("{context}: expected the three-entry xref limit to be exceeded, got {other:?}"),
         Ok(_) => panic!("{context}: expected the xref entry limit to reject the PDF"),
     }
 }
@@ -166,7 +166,10 @@ fn compressed_xref_stream_over_configured_entry_limit_is_rejected() {
 
     let result = Document::load_mem_with_options(&pdf, LoadOptions::with_max_xref_entries(3));
     assert!(
-        matches!(result, Err(Error::Parse(ParseError::InvalidXref))),
+        matches!(
+            result,
+            Err(Error::Parse(ParseError::XrefEntryLimitExceeded { limit: 3 }))
+        ),
         "expected an xref entry limit error, got {result:?}"
     );
 }
@@ -177,15 +180,15 @@ fn metadata_load_options_propagate_resource_limits() {
     Document::load_metadata_mem(&pdf).expect("the compressed xref stream should provide valid metadata");
     let file = temporary_pdf(&pdf);
 
-    assert_invalid_xref(
+    assert_xref_limit_exceeded(
         Document::load_metadata_mem_with_options(&pdf, LoadOptions::with_max_xref_entries(3)),
         "memory metadata loader",
     );
-    assert_invalid_xref(
+    assert_xref_limit_exceeded(
         Document::load_metadata_from_with_options(Cursor::new(pdf.clone()), LoadOptions::with_max_xref_entries(3)),
         "source metadata loader",
     );
-    assert_invalid_xref(
+    assert_xref_limit_exceeded(
         Document::load_metadata_with_options(file.path(), LoadOptions::with_max_xref_entries(3)),
         "file metadata loader",
     );
@@ -205,15 +208,15 @@ fn incremental_load_options_propagate_resource_limits() {
     let pdf = compressed_xref_stream_pdf(4);
     let file = temporary_pdf(&pdf);
 
-    assert_invalid_xref(
+    assert_xref_limit_exceeded(
         IncrementalDocument::load_mem_with_options(&pdf, LoadOptions::with_max_xref_entries(3)),
         "memory incremental loader",
     );
-    assert_invalid_xref(
+    assert_xref_limit_exceeded(
         IncrementalDocument::load_from_with_options(Cursor::new(pdf.clone()), LoadOptions::with_max_xref_entries(3)),
         "source incremental loader",
     );
-    assert_invalid_xref(
+    assert_xref_limit_exceeded(
         IncrementalDocument::load_with_options(file.path(), LoadOptions::with_max_xref_entries(3)),
         "file incremental loader",
     );
@@ -243,7 +246,10 @@ fn cumulative_incremental_xref_entries_are_rejected_before_objects_are_parsed() 
     let result = Document::load_mem_with_options(&pdf, options);
 
     assert!(
-        matches!(result, Err(Error::Parse(ParseError::InvalidXref))),
+        matches!(
+            result,
+            Err(Error::Parse(ParseError::XrefEntryLimitExceeded { limit: 3 }))
+        ),
         "expected a cumulative xref entry limit error, got {result:?}"
     );
     assert!(
@@ -251,7 +257,7 @@ fn cumulative_incremental_xref_entries_are_rejected_before_objects_are_parsed() 
         "normal objects must not be parsed before the cumulative limit is enforced"
     );
 
-    assert_invalid_xref(
+    assert_xref_limit_exceeded(
         Document::load_metadata_mem_with_options(&pdf, LoadOptions::with_max_xref_entries(3)),
         "metadata cumulative merge",
     );

--- a/tests/xref_stream_bounds.rs
+++ b/tests/xref_stream_bounds.rs
@@ -5,7 +5,16 @@
 
 #![cfg(not(feature = "async"))]
 
-use lopdf::{Document, Error, ParseError, SaveOptions, Stream, dictionary};
+use std::io::{Cursor, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use flate2::{Compression, write::ZlibEncoder};
+use lopdf::{
+    DecompressError, Document, Error, IncrementalDocument, LoadOptions, Object, ParseError, SaveOptions, Stream,
+    dictionary,
+};
+
+static OBJECT_FILTER_CALLED: AtomicBool = AtomicBool::new(false);
 
 /// A PDF whose only cross-reference is an xref stream with the given `/W` widths,
 /// `/Index [0 count]`, and `body` as an uncompressed stream body.
@@ -29,6 +38,94 @@ fn xref_stream_pdf(w: [i64; 3], count: i64, body: &[u8]) -> Vec<u8> {
     pdf.extend_from_slice(b"\nendstream\nendobj\n");
     pdf.extend_from_slice(format!("startxref\n{obj_offset}\n%%EOF").as_bytes());
     pdf
+}
+
+fn compressed_xref_stream_pdf(entry_count: usize) -> Vec<u8> {
+    assert!(entry_count >= 3);
+
+    let mut pdf = b"%PDF-1.5\n".to_vec();
+    let catalog_offset = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog >>\nendobj\n");
+    let xref_offset = pdf.len();
+
+    let mut body = Vec::with_capacity(entry_count * 7);
+    for id in 0..entry_count {
+        let (entry_type, field_two, field_three) = match id {
+            0 => (0, 0, u16::MAX),
+            1 => (1, catalog_offset as u32, 0),
+            2 => (1, xref_offset as u32, 0),
+            _ => (0, 0, 0),
+        };
+        body.push(entry_type);
+        body.extend_from_slice(&field_two.to_be_bytes());
+        body.extend_from_slice(&field_three.to_be_bytes());
+    }
+
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&body).unwrap();
+    let compressed_body = encoder.finish().unwrap();
+
+    pdf.extend_from_slice(b"2 0 obj\n");
+    pdf.extend_from_slice(
+        format!(
+            "<< /Type /XRef /Size {entry_count} /W [1 4 2] /Index [0 {entry_count}] \
+             /Root 1 0 R /Filter /FlateDecode /Length {} >>\n",
+            compressed_body.len()
+        )
+        .as_bytes(),
+    );
+    pdf.extend_from_slice(b"stream\n");
+    pdf.extend_from_slice(&compressed_body);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+    pdf.extend_from_slice(format!("startxref\n{xref_offset}\n%%EOF").as_bytes());
+    pdf
+}
+
+fn incremental_xref_pdf() -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let object_one_offset = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog >>\nendobj\n");
+    let object_two_offset = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n42\nendobj\n");
+
+    let first_xref_offset = pdf.len();
+    pdf.extend_from_slice(b"xref\n0 3\n0000000000 65535 f \n");
+    pdf.extend_from_slice(format!("{object_one_offset:010} 00000 n \n").as_bytes());
+    pdf.extend_from_slice(format!("{object_two_offset:010} 00000 n \n").as_bytes());
+    pdf.extend_from_slice(b"trailer\n<< /Size 3 /Root 1 0 R >>\n");
+    pdf.extend_from_slice(format!("startxref\n{first_xref_offset}\n%%EOF\n").as_bytes());
+
+    let object_three_offset = pdf.len();
+    pdf.extend_from_slice(b"3 0 obj\n43\nendobj\n");
+    let object_four_offset = pdf.len();
+    pdf.extend_from_slice(b"4 0 obj\n44\nendobj\n");
+    let second_xref_offset = pdf.len();
+    pdf.extend_from_slice(b"xref\n3 2\n");
+    pdf.extend_from_slice(format!("{object_three_offset:010} 00000 n \n").as_bytes());
+    pdf.extend_from_slice(format!("{object_four_offset:010} 00000 n \n").as_bytes());
+    pdf.extend_from_slice(format!("trailer\n<< /Size 5 /Root 1 0 R /Prev {first_xref_offset} >>\n").as_bytes());
+    pdf.extend_from_slice(format!("startxref\n{second_xref_offset}\n%%EOF").as_bytes());
+    pdf
+}
+
+fn record_object_filter(id: (u32, u16), object: &mut Object) -> Option<((u32, u16), Object)> {
+    OBJECT_FILTER_CALLED.store(true, Ordering::SeqCst);
+    Some((id, object.clone()))
+}
+
+fn assert_invalid_xref<T>(result: lopdf::Result<T>, context: &str) {
+    match result {
+        Err(Error::Parse(ParseError::InvalidXref)) => {}
+        Err(other) => panic!("{context}: expected InvalidXref, got {other:?}"),
+        Ok(_) => panic!("{context}: expected the xref entry limit to reject the PDF"),
+    }
+}
+
+fn temporary_pdf(pdf: &[u8]) -> tempfile::NamedTempFile {
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(pdf).unwrap();
+    file.flush().unwrap();
+    file
 }
 
 // With `/W [0 0 0]` every entry reads zero bytes, so before the bound the loop ran
@@ -60,6 +157,104 @@ fn index_count_past_stream_length_is_rejected() {
         Err(other) => panic!("expected InvalidXref, got {other:?}"),
         Ok(_) => panic!("an /Index count far past the stream length was accepted"),
     }
+}
+
+#[test]
+fn compressed_xref_stream_over_configured_entry_limit_is_rejected() {
+    let pdf = compressed_xref_stream_pdf(4);
+    Document::load_mem(&pdf).expect("the compressed xref stream should be valid without a limit");
+
+    let result = Document::load_mem_with_options(&pdf, LoadOptions::with_max_xref_entries(3));
+    assert!(
+        matches!(result, Err(Error::Parse(ParseError::InvalidXref))),
+        "expected an xref entry limit error, got {result:?}"
+    );
+}
+
+#[test]
+fn metadata_load_options_propagate_resource_limits() {
+    let pdf = compressed_xref_stream_pdf(4);
+    Document::load_metadata_mem(&pdf).expect("the compressed xref stream should provide valid metadata");
+    let file = temporary_pdf(&pdf);
+
+    assert_invalid_xref(
+        Document::load_metadata_mem_with_options(&pdf, LoadOptions::with_max_xref_entries(3)),
+        "memory metadata loader",
+    );
+    assert_invalid_xref(
+        Document::load_metadata_from_with_options(Cursor::new(pdf.clone()), LoadOptions::with_max_xref_entries(3)),
+        "source metadata loader",
+    );
+    assert_invalid_xref(
+        Document::load_metadata_with_options(file.path(), LoadOptions::with_max_xref_entries(3)),
+        "file metadata loader",
+    );
+
+    let result = Document::load_metadata_mem_with_options(&pdf, LoadOptions::with_max_decompressed_size(1));
+    assert!(
+        matches!(
+            result,
+            Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit: 1 }))
+        ),
+        "metadata loading should propagate the decompressed-size limit, got {result:?}"
+    );
+}
+
+#[test]
+fn incremental_load_options_propagate_resource_limits() {
+    let pdf = compressed_xref_stream_pdf(4);
+    let file = temporary_pdf(&pdf);
+
+    assert_invalid_xref(
+        IncrementalDocument::load_mem_with_options(&pdf, LoadOptions::with_max_xref_entries(3)),
+        "memory incremental loader",
+    );
+    assert_invalid_xref(
+        IncrementalDocument::load_from_with_options(Cursor::new(pdf.clone()), LoadOptions::with_max_xref_entries(3)),
+        "source incremental loader",
+    );
+    assert_invalid_xref(
+        IncrementalDocument::load_with_options(file.path(), LoadOptions::with_max_xref_entries(3)),
+        "file incremental loader",
+    );
+
+    let result =
+        IncrementalDocument::load_from_with_options(Cursor::new(pdf), LoadOptions::with_max_decompressed_size(1));
+    assert!(
+        matches!(
+            result,
+            Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit: 1 }))
+        ),
+        "incremental loading should propagate the decompressed-size limit, got {result:?}"
+    );
+}
+
+#[test]
+fn cumulative_incremental_xref_entries_are_rejected_before_objects_are_parsed() {
+    let pdf = incremental_xref_pdf();
+    Document::load_mem(&pdf).expect("each incremental xref table should be valid on its own");
+
+    OBJECT_FILTER_CALLED.store(false, Ordering::SeqCst);
+    let options = LoadOptions {
+        filter: Some(record_object_filter),
+        max_xref_entries: Some(3),
+        ..Default::default()
+    };
+    let result = Document::load_mem_with_options(&pdf, options);
+
+    assert!(
+        matches!(result, Err(Error::Parse(ParseError::InvalidXref))),
+        "expected a cumulative xref entry limit error, got {result:?}"
+    );
+    assert!(
+        !OBJECT_FILTER_CALLED.load(Ordering::SeqCst),
+        "normal objects must not be parsed before the cumulative limit is enforced"
+    );
+
+    assert_invalid_xref(
+        Document::load_metadata_mem_with_options(&pdf, LoadOptions::with_max_xref_entries(3)),
+        "metadata cumulative merge",
+    );
 }
 
 // The bound is derived from the real per-entry width, so a genuine xref stream

--- a/tests/xref_stream_bounds_async.rs
+++ b/tests/xref_stream_bounds_async.rs
@@ -1,0 +1,122 @@
+#![cfg(feature = "async")]
+
+use std::io::Write;
+
+use flate2::{Compression, write::ZlibEncoder};
+use lopdf::{DecompressError, Document, Error, IncrementalDocument, LoadOptions, ParseError};
+
+fn compressed_xref_stream_pdf(entry_count: usize) -> Vec<u8> {
+    assert!(entry_count >= 3);
+
+    let mut pdf = b"%PDF-1.5\n".to_vec();
+    let catalog_offset = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog >>\nendobj\n");
+    let xref_offset = pdf.len();
+
+    let mut body = Vec::with_capacity(entry_count * 7);
+    for id in 0..entry_count {
+        let (entry_type, field_two, field_three) = match id {
+            0 => (0, 0, u16::MAX),
+            1 => (1, catalog_offset as u32, 0),
+            2 => (1, xref_offset as u32, 0),
+            _ => (0, 0, 0),
+        };
+        body.push(entry_type);
+        body.extend_from_slice(&field_two.to_be_bytes());
+        body.extend_from_slice(&field_three.to_be_bytes());
+    }
+
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&body).unwrap();
+    let compressed_body = encoder.finish().unwrap();
+
+    pdf.extend_from_slice(b"2 0 obj\n");
+    pdf.extend_from_slice(
+        format!(
+            "<< /Type /XRef /Size {entry_count} /W [1 4 2] /Index [0 {entry_count}] \
+             /Root 1 0 R /Filter /FlateDecode /Length {} >>\n",
+            compressed_body.len()
+        )
+        .as_bytes(),
+    );
+    pdf.extend_from_slice(b"stream\n");
+    pdf.extend_from_slice(&compressed_body);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+    pdf.extend_from_slice(format!("startxref\n{xref_offset}\n%%EOF").as_bytes());
+    pdf
+}
+
+fn temporary_pdf(pdf: &[u8]) -> tempfile::NamedTempFile {
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(pdf).unwrap();
+    file.flush().unwrap();
+    file
+}
+
+fn assert_invalid_xref<T>(result: lopdf::Result<T>, context: &str) {
+    match result {
+        Err(Error::Parse(ParseError::InvalidXref)) => {}
+        Err(other) => panic!("{context}: expected InvalidXref, got {other:?}"),
+        Ok(_) => panic!("{context}: expected the xref entry limit to reject the PDF"),
+    }
+}
+
+#[tokio::test]
+async fn async_metadata_load_options_propagate_resource_limits() {
+    let pdf = compressed_xref_stream_pdf(4);
+    let file = temporary_pdf(&pdf);
+
+    assert_invalid_xref(
+        Document::load_metadata_mem_with_options(&pdf, LoadOptions::with_max_xref_entries(3)),
+        "async-build memory metadata loader",
+    );
+    assert_invalid_xref(
+        Document::load_metadata_with_options(file.path(), LoadOptions::with_max_xref_entries(3)).await,
+        "async file metadata loader",
+    );
+
+    let source = tokio::fs::File::open(file.path()).await.unwrap();
+    assert_invalid_xref(
+        Document::load_metadata_from_with_options(source, LoadOptions::with_max_xref_entries(3)).await,
+        "async source metadata loader",
+    );
+
+    let result = Document::load_metadata_with_options(file.path(), LoadOptions::with_max_decompressed_size(1)).await;
+    assert!(
+        matches!(
+            result,
+            Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit: 1 }))
+        ),
+        "async metadata loading should propagate the decompressed-size limit, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn async_incremental_load_options_propagate_resource_limits() {
+    let pdf = compressed_xref_stream_pdf(4);
+    let file = temporary_pdf(&pdf);
+
+    assert_invalid_xref(
+        IncrementalDocument::load_mem_with_options(&pdf, LoadOptions::with_max_xref_entries(3)),
+        "async-build memory incremental loader",
+    );
+    assert_invalid_xref(
+        IncrementalDocument::load_with_options(file.path(), LoadOptions::with_max_xref_entries(3)).await,
+        "async file incremental loader",
+    );
+
+    let source = tokio::fs::File::open(file.path()).await.unwrap();
+    assert_invalid_xref(
+        IncrementalDocument::load_from_with_options(source, LoadOptions::with_max_xref_entries(3)).await,
+        "async source incremental loader",
+    );
+
+    let result = IncrementalDocument::load_with_options(file.path(), LoadOptions::with_max_decompressed_size(1)).await;
+    assert!(
+        matches!(
+            result,
+            Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit: 1 }))
+        ),
+        "async incremental loading should propagate the decompressed-size limit, got {result:?}"
+    );
+}

--- a/tests/xref_stream_bounds_async.rs
+++ b/tests/xref_stream_bounds_async.rs
@@ -53,10 +53,10 @@ fn temporary_pdf(pdf: &[u8]) -> tempfile::NamedTempFile {
     file
 }
 
-fn assert_invalid_xref<T>(result: lopdf::Result<T>, context: &str) {
+fn assert_xref_limit_exceeded<T>(result: lopdf::Result<T>, context: &str) {
     match result {
-        Err(Error::Parse(ParseError::InvalidXref)) => {}
-        Err(other) => panic!("{context}: expected InvalidXref, got {other:?}"),
+        Err(Error::Parse(ParseError::XrefEntryLimitExceeded { limit: 3 })) => {}
+        Err(other) => panic!("{context}: expected the three-entry xref limit to be exceeded, got {other:?}"),
         Ok(_) => panic!("{context}: expected the xref entry limit to reject the PDF"),
     }
 }
@@ -66,17 +66,17 @@ async fn async_metadata_load_options_propagate_resource_limits() {
     let pdf = compressed_xref_stream_pdf(4);
     let file = temporary_pdf(&pdf);
 
-    assert_invalid_xref(
+    assert_xref_limit_exceeded(
         Document::load_metadata_mem_with_options(&pdf, LoadOptions::with_max_xref_entries(3)),
         "async-build memory metadata loader",
     );
-    assert_invalid_xref(
+    assert_xref_limit_exceeded(
         Document::load_metadata_with_options(file.path(), LoadOptions::with_max_xref_entries(3)).await,
         "async file metadata loader",
     );
 
     let source = tokio::fs::File::open(file.path()).await.unwrap();
-    assert_invalid_xref(
+    assert_xref_limit_exceeded(
         Document::load_metadata_from_with_options(source, LoadOptions::with_max_xref_entries(3)).await,
         "async source metadata loader",
     );
@@ -96,17 +96,17 @@ async fn async_incremental_load_options_propagate_resource_limits() {
     let pdf = compressed_xref_stream_pdf(4);
     let file = temporary_pdf(&pdf);
 
-    assert_invalid_xref(
+    assert_xref_limit_exceeded(
         IncrementalDocument::load_mem_with_options(&pdf, LoadOptions::with_max_xref_entries(3)),
         "async-build memory incremental loader",
     );
-    assert_invalid_xref(
+    assert_xref_limit_exceeded(
         IncrementalDocument::load_with_options(file.path(), LoadOptions::with_max_xref_entries(3)).await,
         "async file incremental loader",
     );
 
     let source = tokio::fs::File::open(file.path()).await.unwrap();
-    assert_invalid_xref(
+    assert_xref_limit_exceeded(
         IncrementalDocument::load_from_with_options(source, LoadOptions::with_max_xref_entries(3)).await,
         "async source incremental loader",
     );


### PR DESCRIPTION
## Summary

- add an optional `LoadOptions::max_xref_entries` resource limit
- reject oversized classic xref tables and xref streams before large map insertion
- preflight the cumulative union across `/Prev` and `/XRefStm` chains before merging
- report configured entry-limit failures as `ParseError::XrefEntryLimitExceeded`
- parse object streams non-destructively so encoded bytes and filter metadata remain available
- propagate load limits through document, metadata, and incremental-document APIs

## Why

`max_decompressed_size` bounds the decoded bytes of an xref stream, but it does not bound the number of entries represented by those bytes. A highly compressible stream with a narrow `/W` record can therefore expand within the byte limit and still cause millions of `BTreeMap` insertions before an object filter runs.

The new limit is checked at the parser boundary and again before cumulative merges, so callers can constrain both the immediate and incremental-update forms of this amplification.

Existing load and xref-decoder methods retain their signatures and delegate with no entry limit. The new `LoadOptions` field defaults to `None`, preserving runtime behavior. As a Rust source-compatibility caveat, exhaustive external `LoadOptions` struct literals need to include the new field or use `..Default::default()`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --test xref_stream_bounds --test load_options_test --test metadata_test --test incremental_document` (48 passed)
- `cargo test --all-features --test xref_stream_bounds_async` (2 passed)
- `cargo test --all-features` (254 passed)
- `cargo test --test document_load_performance -- --test-threads=1` (2 passed)
- `cargo clippy --all-targets --features serde -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
