### PR TITLE
Accept an integral real /Length when resolving deferred streams

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1116,7 +1116,18 @@ impl Reader<'_> {
             .dict
             .get(b"Length")
             .and_then(|value| self.document.dereference(value))
-            .and_then(|(_id, obj)| obj.as_i64())
+            .and_then(|(_id, obj)| match obj.as_i64() {
+                Ok(length) => Ok(length),
+                // ISO 32000-1 s7.3.8.2 requires /Length to be an integer, but some producers
+                // write it as a real ("42." instead of "42"). Accept one whose value is
+                // integral and in range rather than dropping the stream's content.
+                Err(err) => match obj.as_f32() {
+                    Ok(value) if value.fract() == 0.0 && value >= -(2f32.powi(63)) && value < 2f32.powi(63) => {
+                        Ok(value as i64)
+                    }
+                    _ => Err(err),
+                },
+            })
             .inspect_err(|_err| {
                 error!(
                     "stream dictionary of '{} {} R' is missing the Length entry",
@@ -1635,4 +1646,42 @@ startxref
         },
     );
     assert!(strict.is_err());
+}
+
+#[cfg(all(test, not(feature = "async")))]
+#[test]
+fn stream_length_written_as_real() {
+    // ISO 32000-1 s7.3.8.2 requires /Length to be an integer, but some generators
+    // emit "/Length 42." instead of "/Length 42". Such a stream must still resolve
+    // to its content rather than silently loading as empty.
+    let obj4 = "4 0 obj\n<< /Length 42. >>\nstream\nBT /F1 12 Tf 20 100 Td (Hello World) Tj ET\nendstream\nendobj\n";
+    let header = "%PDF-1.7\n";
+    let obj1 = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+    let obj2 = "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n";
+    let obj3 = "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>\nendobj\n";
+    let o1 = header.len();
+    let o2 = o1 + obj1.len();
+    let o3 = o2 + obj2.len();
+    let o4 = o3 + obj3.len();
+    let body = format!("{header}{obj1}{obj2}{obj3}{obj4}");
+    let xref_pos = body.len();
+    let doc = format!(
+        "{body}xref
+0 5
+0000000000 65535 f 
+{o1:010} 00000 n 
+{o2:010} 00000 n 
+{o3:010} 00000 n 
+{o4:010} 00000 n 
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+{xref_pos}
+%%EOF
+"
+    );
+
+    let loaded = Document::load_mem(doc.as_bytes()).unwrap();
+    let stream = loaded.get_object((4, 0)).unwrap().as_stream().unwrap();
+    assert_eq!(stream.content, b"BT /F1 12 Tf 20 100 Td (Hello World) Tj ET");
 }


### PR DESCRIPTION
When a stream dictionary's `/Length` is written as a **real** rather than an integer, lopdf loads the document with `Ok` and stores **empty content** for that stream — no error, no warning. A load → save round-trip with no modification silently drops the stream's bytes.

Reproduced on `main` (ed42c15); originally found on 0.44.0.

## Problem

ISO 32000-1 §7.3.8.2 requires `/Length` to be an integer, but some producers emit `/Length 42.` instead of `/Length 42`. lopdf accepts such a file, reports no problem, and writes back a stream dictionary claiming 42 bytes next to zero bytes of content — a self-inconsistent PDF, from an input that was intact apart from that one trailing dot.

<details>
<summary>Self-contained reproducer (no fixture file needed)</summary>

```rust
fn main() {
    // A minimal one-page PDF. Object 4 is the page's content stream, and its dictionary
    // reads "/Length 42." -- a real, where ISO 32000-1 s7.3.8.2 requires an integer.
    // Everything else, including the xref offsets, is correct.
    let input: &[u8] = b"%PDF-1.7\x0a%\xe2\xe3\xcf\xd3\x0a1 0 obj\x0a<< /Type /Catalog /Pages 2 0 R >>\x0aendobj\x0a2 0 obj\x0a<< /Type /Pages /Kids [3 0 R] /Count 1 >>\x0aendobj\x0a3 0 obj\x0a<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\x0aendobj\x0a4 0 obj\x0a<< /Length 42. >>\x0astream\x0aBT /F1 12 Tf 20 100 Td (Hello World) Tj ET\x0aendstream\x0aendobj\x0a5 0 obj\x0a<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\x0aendobj\x0axref\x0a0 6\x0a0000000000 65535 f \x0a0000000015 00000 n \x0a0000000064 00000 n \x0a0000000121 00000 n \x0a0000000247 00000 n \x0a0000000340 00000 n \x0atrailer\x0a<< /Size 6 /Root 1 0 R >>\x0astartxref\x0a410\x0a%%EOF\x0a";

    let mut doc = lopdf::Document::load_mem(input).expect("load_mem failed");
    for (id, object) in doc.objects.iter() {
        if let Ok(stream) = object.as_stream() {
            println!("  object {id:?}: /Length = {:?}, content = {} bytes",
                stream.dict.get(b"Length").ok(), stream.content.len());
        }
    }
    let mut output = Vec::new();
    doc.save_to(&mut output).expect("save_to failed");

    let needle = b"Hello World";
    let has = |h: &[u8]| h.windows(needle.len()).any(|w| w == needle);
    println!("page content present in input : {}", has(input));
    println!("page content present in output: {}", has(&output));
}
```

</details>

On `main`:

```
  object (4, 0): /Length = Some(42), content = 0 bytes
page content present in input : true
page content present in output: false   <-- silently lost
```

(`Some(42)` is an `Object::Real(42.0)` — its `Debug` prints without the decimal point, which is part of why this is easy to miss when inspecting a dictionary.)

External tools confirm the saved file is corrupt, independently of lopdf:

| | `main` | with this PR |
|---|---|---|
| `stream.content` after load | 0 bytes | 42 bytes |
| saved size | 513 bytes | 555 bytes |
| `qpdf --check` on the output | `expected endstream`, `attempting to recover stream length`, `recovered stream length: 1` (exit 3) | `No syntax or stream encoding errors found` (exit 0) |
| `qpdf --show-object=4 --raw-stream-data` | 1 byte, empty — while the dictionary still reads `<< /Length 42 >>` | 42 bytes, `BT /F1 12 Tf 20 100 Td (Hello World) Tj ET` |
| `pdftotext output.pdf -` | *(empty)* | `Hello World` |

## Cause

Three things line up to make the failure silent:

1. `parser::stream()` reads `/Length` via `Object::as_i64()`, which matches only `Object::Integer` — there is no coercion from `Real` (`as_i64` in `src/object.rs`). `42.` parses as `Object::Real`, so this fails.
2. The `else` branch then returns `Stream::with_position(dict, …)`: a deferred stream with a recorded offset and no content. That is the right design for an *indirect* `/Length`, but it catches this case too.
3. The retry pass over deferred streams at the end of `load_objects_raw` calls `read_stream_content` → `get_stream_length`, which calls `as_i64()` again and fails identically — and the error is dropped by `let _ =`.

So the mechanism meant to rescue deferred streams cannot rescue this one, and its failure is swallowed. `load_objects_raw` returns `Ok(())`.

## Fix

`get_stream_length` falls back to the real's value when it is integral and in range, so the stream resolves through the existing `start_position` path:

```rust
             .and_then(|value| self.document.dereference(value))
-            .and_then(|(_id, obj)| obj.as_i64())
+            .and_then(|(_id, obj)| match obj.as_i64() {
+                Ok(length) => Ok(length),
+                // ISO 32000-1 s7.3.8.2 requires /Length to be an integer, but some producers
+                // write it as a real ("42." instead of "42"). Accept one whose value is
+                // integral and in range rather than dropping the stream's content.
+                Err(err) => match obj.as_f32() {
+                    Ok(value) if value.fract() == 0.0 && value >= -(2f32.powi(63)) && value < 2f32.powi(63) => {
+                        Ok(value as i64)
+                    }
+                    _ => Err(err),
+                },
+            })
```

- **Purely additive.** It only turns a hard failure into a success. Non-integral, non-finite, out-of-range and non-numeric `/Length` values still return the original error, so no document that loads today changes behaviour.
- **The range check is not redundant with the integrality check.** `value.fract() == 0.0` is already false for NaN and ±∞, but without an explicit `[-2⁶³, 2⁶³)` bound a large finite real (say `1e30`) saturates under `as i64` to `i64::MAX`; `read_stream_content` then evaluates `let end = start + length` on a `usize`, which overflows and panics in debug builds. With the bound the cast is always exact, and an oversized value falls through to the existing *"stream extends after document end"* error instead. Negative values remain caught by the pre-existing `length < 0` check.

One adjacent observation, not addressed here: that same `start + length` can overflow for a literal `Object::Integer(i64::MAX)` `/Length`. It predates this change and is unreachable from it, so I've left it alone — happy to file it separately if you'd like.

## What I deliberately did not do

I did not fix this by propagating the discarded error at the `let _ =` line. That looks like the obvious fix and I don't think it is: documents whose streams are unresolvable for other reasons — a genuinely absent `/Length` — currently load with empty content, and would begin failing outright. That is a much wider behaviour change than this bug requires. If you want it, it seems better as its own PR, probably gated on `LoadOptions::strict`; glad to open one.

## Testing

- New regression test `stream_length_written_as_real` in `src/reader.rs`, next to `recovers_from_miswritten_startxref_offset` from #555. It asserts the stream's **content** equals the expected 42 bytes — asserting only that `load_mem` returns `Ok` would have passed before this fix, which is the whole point. Confirmed it fails on `main` (`left: []`) and passes with the fix.
- Full suite green under the CI invocation (`cargo test -- --test-threads=1 --skip performance`), and also under `--all-features` and `--no-default-features`. No existing test changed behaviour.
- `cargo +nightly fmt --all -- --check` clean; `cargo clippy --all-targets --features serde -- -D warnings` and `--all-features` both clean.
