### PR TITLE
Bound cross-reference stream entries during loading

### DIFF
--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -574,31 +574,37 @@ pub fn decode_xref_stream_with_limit(
             return Err(ParseError::InvalidXref.into());
         }
 
-        let mut bytes1 = vec![0_u8; field_widths[0] as usize];
-        let mut bytes2 = vec![0_u8; field_widths[1] as usize];
-        let mut bytes3 = vec![0_u8; field_widths[2] as usize];
-
         // Total bytes one entry consumes. With every width zero an entry reads nothing, so the loop
         // below would run purely on the attacker-controlled /Index counts and never reach the end of
         // the stream. Such a stream carries no information and can only be malformed, so reject it
-        // (this also keeps max_entries below from dividing by zero).
-        let entry_width = field_widths[0] + field_widths[1] + field_widths[2];
+        // (this also keeps the body-capacity check below from dividing by zero).
+        let entry_width = (field_widths[0] + field_widths[1] + field_widths[2]) as usize;
         if entry_width == 0 {
             return Err(ParseError::InvalidXref.into());
         }
 
-        // An entry can't be read from bytes that aren't there, so no section may declare more entries
-        // than the decoded stream could possibly hold. Without this a huge /Index [0 N] still fails
-        // eventually once the reader runs dry, but only after inserting N-ish map entries first.
-        let max_entries = reader.get_ref().len() as i64 / entry_width;
+        let index_entries = section_indice.chunks_exact(2).try_fold(0_usize, |total, section| {
+            let count = usize::try_from(section[1]).map_err(|_| ParseError::InvalidXref)?;
+            total.checked_add(count).ok_or(ParseError::InvalidXref)
+        })?;
+        // An entry can't be read from bytes that aren't there. Validate the total before inserting
+        // anything so multiple individually plausible /Index sections cannot overrun the body.
+        //
+        // deliberate: Records narrower than three bytes are rejected to limit amplification from
+        // decoded bytes into retained map entries. /W [1 2 0] is a plausible three-byte record and
+        // remains accepted; lopdf's writer emits /W [1 4 2], so its output is unaffected.
+        const MIN_ENTRY_WIDTH: usize = 3;
+        if index_entries > reader.get_ref().len() / entry_width.max(MIN_ENTRY_WIDTH) {
+            return Err(ParseError::InvalidXref.into());
+        }
 
-        for i in 0..section_indice.len() / 2 {
-            let start = section_indice[2 * i];
-            let count = section_indice[2 * i + 1];
+        let mut bytes1 = vec![0_u8; field_widths[0] as usize];
+        let mut bytes2 = vec![0_u8; field_widths[1] as usize];
+        let mut bytes3 = vec![0_u8; field_widths[2] as usize];
 
-            if count > max_entries {
-                return Err(ParseError::InvalidXref.into());
-            }
+        for section in section_indice.chunks_exact(2) {
+            let start = section[0];
+            let count = section[1];
 
             for j in 0..count {
                 let entry_type = if !bytes1.is_empty() {

--- a/tests/xref_stream_bounds.rs
+++ b/tests/xref_stream_bounds.rs
@@ -5,18 +5,25 @@
 
 #![cfg(not(feature = "async"))]
 
-use lopdf::{Document, Error, ParseError, SaveOptions, Stream, dictionary};
+use std::io::Write;
+
+use flate2::{Compression, write::ZlibEncoder};
+use lopdf::{Document, Error, LoadOptions, ParseError, SaveOptions, Stream, dictionary};
 
 /// A PDF whose only cross-reference is an xref stream with the given `/W` widths,
 /// `/Index [0 count]`, and `body` as an uncompressed stream body.
 fn xref_stream_pdf(w: [i64; 3], count: i64, body: &[u8]) -> Vec<u8> {
+    xref_stream_pdf_with_index(w, &format!("0 {count}"), body)
+}
+
+fn xref_stream_pdf_with_index(w: [i64; 3], index: &str, body: &[u8]) -> Vec<u8> {
     let mut pdf = Vec::new();
     pdf.extend_from_slice(b"%PDF-1.5\n");
     let obj_offset = pdf.len();
     pdf.extend_from_slice(b"1 0 obj\n");
     pdf.extend_from_slice(
         format!(
-            "<< /Type /XRef /Size 4 /W [{} {} {}] /Index [0 {count}] /Root 1 0 R /Length {} >>\n",
+            "<< /Type /XRef /Size 4 /W [{} {} {}] /Index [{index}] /Root 1 0 R /Length {} >>\n",
             w[0],
             w[1],
             w[2],
@@ -28,6 +35,71 @@ fn xref_stream_pdf(w: [i64; 3], count: i64, body: &[u8]) -> Vec<u8> {
     pdf.extend_from_slice(body);
     pdf.extend_from_slice(b"\nendstream\nendobj\n");
     pdf.extend_from_slice(format!("startxref\n{obj_offset}\n%%EOF").as_bytes());
+    pdf
+}
+
+fn compressed_xref_stream_pdf(entries: usize) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.5\n".to_vec();
+    let catalog_offset = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog >>\nendobj\n");
+    let xref_offset = pdf.len();
+
+    let mut body = Vec::with_capacity(entries * 5);
+    for id in 0..entries {
+        let (entry_type, offset): (u8, u32) = match id {
+            1 => (1, catalog_offset as u32),
+            2 => (1, xref_offset as u32),
+            _ => (0, 0),
+        };
+        body.push(entry_type);
+        body.extend_from_slice(&offset.to_be_bytes()[1..4]);
+        body.push(0);
+    }
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&body).unwrap();
+    let compressed_body = encoder.finish().unwrap();
+
+    pdf.extend_from_slice(b"2 0 obj\n");
+    pdf.extend_from_slice(
+        format!(
+            "<< /Type /XRef /Size {entries} /W [1 3 1] /Index [0 {entries}] /Root 1 0 R \
+             /Filter /FlateDecode /Length {} >>\n",
+            compressed_body.len()
+        )
+        .as_bytes(),
+    );
+    pdf.extend_from_slice(b"stream\n");
+    pdf.extend_from_slice(&compressed_body);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+    pdf.extend_from_slice(format!("startxref\n{xref_offset}\n%%EOF").as_bytes());
+    pdf
+}
+
+fn incremental_classic_xref_pdf(objects: usize) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = Vec::with_capacity(objects);
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog >>\nendobj\n");
+    for id in 2..=objects {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n{id}\nendobj\n").as_bytes());
+    }
+
+    let first_xref = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n0000000000 65535 f \n", objects + 1).as_bytes());
+    for offset in offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(format!("trailer\n<< /Size {} /Root 1 0 R >>\n", objects + 1).as_bytes());
+    pdf.extend_from_slice(format!("startxref\n{first_xref}\n%%EOF\n").as_bytes());
+
+    let new_offset = pdf.len();
+    let new_id = objects + 1;
+    pdf.extend_from_slice(format!("{new_id} 0 obj\n99\nendobj\n").as_bytes());
+    let second_xref = pdf.len();
+    pdf.extend_from_slice(format!("xref\n{new_id} 1\n{new_offset:010} 00000 n \n").as_bytes());
+    pdf.extend_from_slice(format!("trailer\n<< /Size {} /Root 1 0 R /Prev {first_xref} >>\n", new_id + 1).as_bytes());
+    pdf.extend_from_slice(format!("startxref\n{second_xref}\n%%EOF").as_bytes());
     pdf
 }
 
@@ -60,6 +132,62 @@ fn index_count_past_stream_length_is_rejected() {
         Err(other) => panic!("expected InvalidXref, got {other:?}"),
         Ok(_) => panic!("an /Index count far past the stream length was accepted"),
     }
+}
+
+#[test]
+fn negative_index_count_is_rejected() {
+    let pdf = xref_stream_pdf([1, 1, 1], -1, &[]);
+    assert!(matches!(
+        Document::load_mem(&pdf),
+        Err(Error::Parse(ParseError::InvalidXref))
+    ));
+}
+
+#[test]
+fn three_byte_xref_records_are_accepted() {
+    let pdf = xref_stream_pdf([1, 2, 0], 2, &[0, 0, 0, 1, 0, 9]);
+    Document::load_mem(&pdf).expect("/W [1 2 0] records should remain accepted");
+}
+
+#[test]
+fn single_index_section_matching_stream_length_is_accepted() {
+    let body = [1, 0, 0, 0, 9, 0, 0];
+    let pdf = xref_stream_pdf_with_index([1, 4, 2], "0 1", &body);
+    Document::load_mem(&pdf).expect("one seven-byte record should fit a seven-byte body");
+}
+
+#[test]
+fn total_index_count_past_stream_length_is_rejected() {
+    let body = [1, 0, 0, 0, 9, 0, 0];
+    let pdf = xref_stream_pdf_with_index([1, 4, 2], "0 1 2 1", &body);
+    assert!(matches!(
+        Document::load_mem(&pdf),
+        Err(Error::Parse(ParseError::InvalidXref))
+    ));
+}
+
+// `/W [0 1 0]` records consume one decoded byte but retain a full map entry.
+// Floor the effective width so a valid-sized body cannot amplify into a much
+// larger in-memory xref table, independently of any decompression budget.
+#[test]
+fn degenerate_narrow_xref_records_are_rejected() {
+    let pdf = xref_stream_pdf([0, 1, 0], 4, &[0; 4]);
+    let result = Document::load_mem(&pdf);
+    assert!(matches!(result, Err(Error::Parse(ParseError::InvalidXref))));
+}
+
+#[test]
+fn realistic_compressed_xref_stream_loads_under_budget() {
+    let pdf = compressed_xref_stream_pdf(300);
+    Document::load_mem_with_options(&pdf, LoadOptions::with_max_decompressed_size(2_000))
+        .expect("a 1,500-byte xref stream should load under a 2,000-byte budget");
+}
+
+#[test]
+fn incremental_classic_xref_loads_under_budget() {
+    let pdf = incremental_classic_xref_pdf(400);
+    Document::load_mem_with_options(&pdf, LoadOptions::with_max_decompressed_size(2_000))
+        .expect("classic xref entries should not consume the decompression budget");
 }
 
 // The bound is derived from the real per-entry width, so a genuine xref stream


### PR DESCRIPTION
## Summary

This hardens cross-reference stream decoding against degenerate `/W` layouts that can amplify a small decoded body into a much larger retained cross-reference map.

Before inserting entries, the decoder now:

- sums counts across every `/Index` section;
- rejects negative counts and arithmetic overflow;
- validates the summed `/Index` count against the decoded body capacity;
- derives the per-stream bound from the real `/W` record width, with a `MIN_ENTRY_WIDTH` floor of three bytes to limit amplification from records such as `/W [0 1 0]`.

The change introduces zero public API surface, configuration, or error variants. It is therefore a 0.44 patch candidate rather than a breaking minor change.

## Compatibility

This intentionally makes two input classes stricter:

1. Negative `/Index` counts, which were previously skipped silently, now fail with `InvalidXref`.
2. Records narrower than three bytes are rejected to bound decoded-byte-to-map-entry amplification. A plausible three-byte `/W [1 2 0]` record remains accepted. lopdf's own writer emits `/W [1 4 2]`, so its output is unaffected.

## Tests

Regression coverage includes:

- zero-width and degenerate narrow records;
- acceptance of valid `/W [1 2 0]` records;
- negative `/Index` counts;
- the original single-section body-length regression;
- positive and negative controls proving that summed `/Index` counts use total body capacity;
- a realistic 300-entry compressed `/W [1 3 1]` stream under its decompression budget;
- a 401-entry classic incremental cross-reference document;
- ordinary xref streams emitted by lopdf's writer.
