### PR TITLE
Preserve encoded object streams during parsing

### DIFF
--- a/examples/inspect_object_stream.rs
+++ b/examples/inspect_object_stream.rs
@@ -29,8 +29,7 @@ fn main() {
                 println!("Dictionary: {:?}", stream.dict);
 
                 // Try to parse it
-                let mut stream_clone = stream.clone();
-                match ObjectStream::new(&mut stream_clone) {
+                match ObjectStream::new(stream) {
                     Ok(obj_stream) => {
                         println!("\nSuccessfully parsed object stream!");
                         println!("Contains {} objects", obj_stream.objects.len());

--- a/src/document.rs
+++ b/src/document.rs
@@ -471,8 +471,8 @@ impl Document {
         // Add the objects from the object streams now that they have been decrypted.
         let mut object_streams = vec![];
 
-        for object in self.objects.values_mut() {
-            let Ok(ref mut stream) = object.as_stream_mut() else {
+        for object in self.objects.values() {
+            let Ok(stream) = object.as_stream() else {
                 continue;
             };
 

--- a/src/object_stream.rs
+++ b/src/object_stream.rs
@@ -37,29 +37,28 @@ impl Default for ObjectStreamConfig {
 }
 
 impl ObjectStream {
-    /// Parse an existing object stream.
+    /// Parse an existing object stream without modifying its encoded content or
+    /// filter dictionary.
     ///
-    /// This decompresses the stream without any size limit. For untrusted input,
+    /// This decodes the stream without any size limit. For untrusted input,
     /// prefer [`ObjectStream::new_with_limit`] to guard against decompression
     /// bombs.
-    pub fn new(stream: &mut Stream) -> Result<ObjectStream> {
+    pub fn new(stream: &Stream) -> Result<ObjectStream> {
         Self::new_with_limit(stream, None)
     }
 
-    /// Parse an existing object stream, rejecting it if its decompressed content
-    /// would exceed `max_decompressed_size` bytes. `None` means no limit (the
-    /// behavior of [`ObjectStream::new`]).
-    pub fn new_with_limit(stream: &mut Stream, max_decompressed_size: Option<usize>) -> Result<ObjectStream> {
-        match max_decompressed_size {
-            // Object streams are decompressed while the document is loaded, so
+    /// Parse an existing object stream without modifying it, rejecting the
+    /// decoded content if it would exceed `max_decompressed_size` bytes. `None`
+    /// means no limit (the behavior of [`ObjectStream::new`]).
+    pub fn new_with_limit(stream: &Stream, max_decompressed_size: Option<usize>) -> Result<ObjectStream> {
+        let content = match max_decompressed_size {
+            // Object streams are decoded while the document is loaded, so
             // enforcing the limit here bounds the memory a single stream can use.
-            Some(max) => stream.decompress_with_limit(max)?,
-            None => {
-                let _ = stream.decompress();
-            }
-        }
+            Some(max) => stream.get_plain_content_with_limit(max)?,
+            None => stream.get_plain_content()?,
+        };
 
-        if stream.content.is_empty() {
+        if content.is_empty() {
             return Ok(ObjectStream {
                 objects: BTreeMap::new(),
                 max_objects: 100,
@@ -73,10 +72,7 @@ impl ObjectStream {
             .and_then(Object::as_i64)?
             .try_into()
             .map_err(|e: TryFromIntError| Error::NumericCast(e.to_string()))?;
-        let index_block = stream
-            .content
-            .get(..first_offset)
-            .ok_or(Error::InvalidOffset(first_offset))?;
+        let index_block = content.get(..first_offset).ok_or(Error::InvalidOffset(first_offset))?;
 
         let numbers_str = std::str::from_utf8(index_block).map_err(|e| Error::InvalidObjectStream(e.to_string()))?;
         let numbers: Vec<_> = numbers_str
@@ -94,20 +90,20 @@ impl ObjectStream {
             let id = chunk[0]?;
             let offset = first_offset + chunk[1]? as usize;
 
-            if offset >= stream.content.len() {
+            if offset >= content.len() {
                 warn!("out-of-bounds offset in object stream");
                 return None;
             }
             // Skip leading whitespace — some PDFs emit newlines before objects in ObjStm
             let mut start = offset;
-            while start < stream.content.len() && stream.content[start].is_ascii_whitespace() {
+            while start < content.len() && content[start].is_ascii_whitespace() {
                 start += 1;
             }
-            if start >= stream.content.len() {
+            if start >= content.len() {
                 warn!("only whitespace after offset in object stream");
                 return None;
             }
-            let object = parser::direct_object(&stream.content[start..])?;
+            let object = parser::direct_object(&content[start..])?;
 
             Some(((id, 0), object))
         };

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -934,8 +934,8 @@ impl Reader<'_> {
             }
 
             for (container_id, objects_in_stream) in streams_to_process {
-                if let Some(container_obj) = self.document.objects.get_mut(&(container_id, 0))
-                    && let Ok(stream) = container_obj.as_stream_mut()
+                if let Some(container_obj) = self.document.objects.get(&(container_id, 0))
+                    && let Ok(stream) = container_obj.as_stream()
                 {
                     match ObjectStream::new_with_limit(stream, self.max_decompressed_size) {
                         Ok(object_stream) => {
@@ -1015,7 +1015,7 @@ impl Reader<'_> {
                     filter_func(object_id, &mut object)?;
                 }
 
-                if let Ok(ref mut stream) = object.as_stream_mut() {
+                if let Ok(stream) = object.as_stream() {
                     if stream.dict.has_type(b"ObjStm") && !is_encrypted {
                         let obj_stream = ObjectStream::new_with_limit(stream, self.max_decompressed_size).ok()?;
                         let container_id = object_id.0;
@@ -1157,8 +1157,8 @@ impl Reader<'_> {
         let container_id = (container_id, 0);
         let mut already_seen = HashSet::new();
         let container_obj = self.get_object(container_id, &mut already_seen)?;
-        let mut container_stream = container_obj.as_stream()?.clone();
-        let object_stream = ObjectStream::new_with_limit(&mut container_stream, self.max_decompressed_size)?;
+        let container_stream = container_obj.as_stream()?;
+        let object_stream = ObjectStream::new_with_limit(container_stream, self.max_decompressed_size)?;
         object_stream.objects.get(&id).cloned().ok_or(Error::MissingXrefEntry)
     }
 

--- a/tests/decompression_bomb.rs
+++ b/tests/decompression_bomb.rs
@@ -306,9 +306,9 @@ fn object_stream_bomb_is_rejected_with_limit() {
     dict.set("N", 1i64);
     dict.set("First", 0i64);
     dict.set("Filter", "FlateDecode");
-    let mut stream = Stream::new(dict, flate_bomb(64 * MIB));
+    let stream = Stream::new(dict, flate_bomb(64 * MIB));
 
-    match ObjectStream::new_with_limit(&mut stream, Some(4 * MIB)) {
+    match ObjectStream::new_with_limit(&stream, Some(4 * MIB)) {
         Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit })) => {
             assert_eq!(limit, 4 * MIB);
         }

--- a/tests/object_stream_comprehensive_test.rs
+++ b/tests/object_stream_comprehensive_test.rs
@@ -438,7 +438,7 @@ fn test_parse_existing_object_stream() {
                     <</Type/Annot/Subtype/Text/Rect[100 100 200 200]>>\n\
                     42";
 
-    let mut stream = Stream::new(
+    let stream = Stream::new(
         dictionary! {
             "Type" => "ObjStm",
             "N" => 3,
@@ -447,7 +447,7 @@ fn test_parse_existing_object_stream() {
         content.to_vec(),
     );
 
-    let obj_stream = ObjectStream::new(&mut stream);
+    let obj_stream = ObjectStream::new(&stream);
     assert!(obj_stream.is_ok());
 
     let obj_stream = obj_stream.unwrap();

--- a/tests/object_stream_methods_test.rs
+++ b/tests/object_stream_methods_test.rs
@@ -1,8 +1,8 @@
-use lopdf::{Document, Object, ObjectStream, SaveOptions, Stream, dictionary};
+use lopdf::{Document, Error, Object, ObjectStream, SaveOptions, Stream, dictionary};
 
 #[test]
 fn test_object_stream_parse_empty() {
-    let mut stream = Stream::new(
+    let stream = Stream::new(
         dictionary! {
             "Type" => "ObjStm",
             "N" => 0,
@@ -11,8 +11,66 @@ fn test_object_stream_parse_empty() {
         vec![],
     );
 
-    let obj_stream = ObjectStream::new(&mut stream).unwrap();
+    let obj_stream = ObjectStream::new(&stream).unwrap();
     assert_eq!(obj_stream.objects.len(), 0);
+}
+
+#[test]
+fn test_object_stream_parse_preserves_encoded_content() {
+    let decoded = b"1 0 << /Kind /ArchiveEntry /Padding (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) >>";
+    let mut stream = Stream::new(
+        dictionary! {
+            "Type" => "ObjStm",
+            "N" => 1,
+            "First" => 4,
+        },
+        decoded.to_vec(),
+    );
+    stream.compress().unwrap();
+    let encoded = stream.content.clone();
+
+    let object_stream = ObjectStream::new_with_limit(&stream, Some(decoded.len())).unwrap();
+
+    assert!(object_stream.objects.contains_key(&(1, 0)));
+    assert_eq!(stream.content, encoded);
+    assert_eq!(stream.dict.get(b"Filter").unwrap().as_name().unwrap(), b"FlateDecode");
+}
+
+#[test]
+fn test_object_stream_parse_reports_unsupported_filters_without_mutating_input() {
+    let encoded = b"1 0 << >>".to_vec();
+    let stream = Stream::new(
+        dictionary! {
+            "Type" => "ObjStm",
+            "N" => 1,
+            "First" => 4,
+            "Filter" => "DCTDecode",
+        },
+        encoded.clone(),
+    );
+
+    let result = ObjectStream::new(&stream);
+
+    assert!(matches!(result, Err(Error::Unimplemented("decompression algorithms"))));
+    assert_eq!(stream.content, encoded);
+    assert_eq!(stream.dict.get(b"Filter").unwrap().as_name().unwrap(), b"DCTDecode");
+}
+
+#[test]
+fn test_object_stream_parse_with_empty_filter_array() {
+    let stream = Stream::new(
+        dictionary! {
+            "Type" => "ObjStm",
+            "N" => 1,
+            "First" => 4,
+            "Filter" => Object::Array(vec![]),
+        },
+        b"1 0 42".to_vec(),
+    );
+
+    let object_stream = ObjectStream::new(&stream).unwrap();
+
+    assert_eq!(object_stream.objects.get(&(1, 0)), Some(&Object::Integer(42)));
 }
 
 #[test]

--- a/tests/simple_object_stream_test.rs
+++ b/tests/simple_object_stream_test.rs
@@ -133,8 +133,8 @@ fn test_object_stream_parses_objects_with_leading_whitespace() {
         "First" => first_offset as i64,
     };
 
-    let mut stream = Stream::new(dict, content);
-    let obj_stream = ObjectStream::new(&mut stream).expect("should parse object stream");
+    let stream = Stream::new(dict, content);
+    let obj_stream = ObjectStream::new(&stream).expect("should parse object stream");
 
     // Both objects must be present
     assert_eq!(


### PR DESCRIPTION
## Summary

Object streams with `/Filter []` could silently lose every embedded object.

`ObjectStream` previously parsed them through `Stream::decompress()`. With an empty filter array, the filter loop produced empty output, which then replaced the original stream content. Parsing subsequently succeeded with an empty object stream.

This change parses object streams through `get_plain_content()` instead, preserving the original content for `/Filter []` and recovering the embedded objects.

As a secondary benefit, successful object-stream parsing now preserves encoded-stream provenance: it does not mutate the encoded content or filter dictionary.

## Changes

- Change `ObjectStream::new` and `new_with_limit` to accept `&Stream`.
- Update Reader, Document, tests, and example call sites to use shared borrows.
- Remove the unnecessary full `Stream` clone when resolving compressed metadata objects.
- Preserve the existing decompression-size limit behavior.
- Leave `Stream::decode_filters` unchanged.

## Tests

Coverage verifies that:

- an object stream with `/Filter []` recovers its embedded object;
- encoded content and the filter dictionary remain unchanged after parsing;
- unsupported filters still return an error without mutating the input;
- decompression limits continue to reject oversized object streams.

## Compatibility

This fixes silent object loss and narrows the constructors from mutable to shared borrowing. Existing callers passing `&mut Stream` continue to compile through reborrow coercion, although explicitly typed constructor function pointers may observe the signature change.

No dependency or serialized-format changes are introduced.
