### PR TITLE
Accept 19-byte cross-reference entries when parsing leniently

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -493,8 +493,20 @@ pub fn binary_mark(input: ParserInput) -> Option<Vec<u8>> {
 }
 
 /// Decode CrossReferenceTable
-fn xref(input: ParserInput) -> NomResult<Xref> {
-    let xref_eol = map(alt((tag(&b" \r"[..]), tag(&b" \n"[..]), tag(&b"\r\n"[..]))), |_| ());
+fn xref(input: ParserInput, strict: bool) -> NomResult<Xref> {
+    // ISO 32000-1 s7.5.4 requires every entry to be exactly 20 bytes, ending in one of the
+    // 2-byte terminators SP CR, SP LF or CR LF. Many generators instead emit 19-byte entries
+    // ending in a bare LF, which qpdf, pikepdf, PDFium and PDF.js all accept. Accept those
+    // too when parsing leniently, but keep the conforming 2-byte forms first in the `alt` so
+    // that a bare CR never matches the CR of a conforming CR LF and strands its LF.
+    let xref_eol = move |i| {
+        let conforming = alt((tag(&b" \r"[..]), tag(&b" \n"[..]), tag(&b"\r\n"[..])));
+        if strict {
+            map(conforming, |_| ()).parse(i)
+        } else {
+            map(alt((conforming, tag(&b"\n"[..]), tag(&b"\r"[..]))), |_| ()).parse(i)
+        }
+    };
     let xref_entry = pair(
         separated_pair(unsigned_int, tag(&b" "[..]), unsigned_int::<u32>),
         delimited(tag(&b" "[..]), map(one_of("nf"), |k| k == 'n'), xref_eol),
@@ -529,7 +541,7 @@ fn trailer(input: ParserInput) -> NomResult<Dictionary> {
 }
 
 pub fn xref_and_trailer(input: ParserInput, reader: &Reader) -> crate::Result<(Xref, Dictionary)> {
-    let xref_trailer = map(pair(xref, trailer), |(mut xref, trailer)| {
+    let xref_trailer = map(pair(|i| xref(i, reader.strict), trailer), |(mut xref, trailer)| {
         xref.size = trailer
             .get(b"Size")
             .and_then(Object::as_i64)
@@ -870,7 +882,7 @@ startxref
 153804\x20
 %%EOF
 ";
-        match xref(test_span(input)) {
+        match xref(test_span(input), false) {
             Ok((_, re)) => assert_eq!(re.entries.len(), 15),
             Err(err) => panic!("unexpected {:?}", err),
         }
@@ -998,9 +1010,113 @@ EI";
     fn xref_trailing_space_after_keyword() {
         // Some PDF generators emit "xref \n" with a trailing space.
         let input = b"xref \n0 3\n0000000000 65535 f \n0000000017 00000 n \n0000000081 00000 n \ntrailer\n<</Size 3/Root 1 0 R>>\nstartxref\n175\n%%EOF\n";
-        match xref(test_span(input)) {
+        match xref(test_span(input), false) {
             Ok((_, re)) => assert_eq!(re.entries.len(), 2),
             Err(err) => panic!("xref with trailing space should parse: {:?}", err),
+        }
+    }
+
+    #[test]
+    fn xref_entries_with_bare_eol_terminator() {
+        // ISO 32000-1 s7.5.4 requires 20-byte entries, so the terminator is two bytes
+        // (" \r", " \n" or "\r\n"). Many generators drop the padding space and emit
+        // 19-byte entries ending in a bare "\n"; qpdf, pikepdf, PDFium and PDF.js all
+        // accept these, so lenient parsing accepts them too.
+        for (name, input) in [
+            (
+                "bare LF",
+                &b"xref\n0 3\n0000000000 65535 f\n0000000017 00000 n\n0000000081 00000 n\ntrailer\n<</Size 3/Root 1 0 R>>\n"[..],
+            ),
+            (
+                "bare CR",
+                &b"xref\n0 3\n0000000000 65535 f\r0000000017 00000 n\r0000000081 00000 n\rtrailer\n<</Size 3/Root 1 0 R>>\n"[..],
+            ),
+        ] {
+            match xref(test_span(input), false) {
+                Ok((_, re)) => assert_eq!(re.entries.len(), 2, "{name} should yield both normal entries"),
+                Err(err) => panic!("19-byte entries ({name}) should parse when lenient: {err:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn xref_entries_with_bare_eol_rejected_when_strict() {
+        // The 19-byte form is non-conforming, so strict mode must keep rejecting it.
+        // At this level the rejection is indirect: the entries simply are not recognised,
+        // leaving an empty section whose unconsumed lines then displace `trailer`. Assert
+        // both halves -- the empty table here, and the document-level failure below.
+        let input =
+            b"xref\n0 3\n0000000000 65535 f\n0000000017 00000 n\n0000000081 00000 n\ntrailer\n<</Size 3/Root 1 0 R>>\n";
+        if let Ok((_, re)) = xref(test_span(input), true) {
+            assert_eq!(re.entries.len(), 0, "strict must not accept 19-byte entries");
+        }
+
+        // The contract that matters to callers: a document with 19-byte entries loads
+        // leniently and is refused under `LoadOptions::strict`. The 20-byte build of the
+        // very same document is the control -- it must load in *both* modes, so that the
+        // strict rejection below is attributable to the terminator and nothing else.
+        let load = |bytes: &[u8], strict: bool| {
+            crate::Document::load_mem_with_options(
+                bytes,
+                crate::LoadOptions {
+                    strict,
+                    ..Default::default()
+                },
+            )
+        };
+
+        for (name, term, strict_should_load) in [("19-byte", "\n", false), ("20-byte", " \n", true)] {
+            let header = "%PDF-1.7\n";
+            let obj1 = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+            let obj2 = "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n";
+            let obj3 = "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>\nendobj\n";
+            let o1 = header.len();
+            let o2 = o1 + obj1.len();
+            let o3 = o2 + obj2.len();
+            let body = format!("{header}{obj1}{obj2}{obj3}");
+            let xref_pos = body.len();
+            let doc = format!(
+                "{body}xref\n0 4\n0000000000 65535 f{term}{o1:010} 00000 n{term}{o2:010} 00000 n{term}\
+                 {o3:010} 00000 n{term}trailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n"
+            );
+
+            assert!(
+                load(doc.as_bytes(), false).is_ok(),
+                "{name} entries should load when lenient"
+            );
+            assert_eq!(
+                load(doc.as_bytes(), true).is_ok(),
+                strict_should_load,
+                "{name} entries under strict parsing"
+            );
+        }
+    }
+
+    #[test]
+    fn xref_entries_with_conforming_terminators() {
+        // The three 20-byte terminators of s7.5.4 must keep parsing in both modes. In
+        // particular the bare-CR alternative must not match the CR of a "\r\n" pair and
+        // strand its LF, which would break the following entry.
+        for (name, input) in [
+            (
+                "SP LF",
+                &b"xref\n0 3\n0000000000 65535 f \n0000000017 00000 n \n0000000081 00000 n \ntrailer\n<</Size 3/Root 1 0 R>>\n"[..],
+            ),
+            (
+                "SP CR",
+                &b"xref\n0 3\n0000000000 65535 f \r0000000017 00000 n \r0000000081 00000 n \rtrailer\n<</Size 3/Root 1 0 R>>\n"[..],
+            ),
+            (
+                "CR LF",
+                &b"xref\n0 3\n0000000000 65535 f\r\n0000000017 00000 n\r\n0000000081 00000 n\r\ntrailer\n<</Size 3/Root 1 0 R>>\n"[..],
+            ),
+        ] {
+            for strict in [false, true] {
+                match xref(test_span(input), strict) {
+                    Ok((_, re)) => assert_eq!(re.entries.len(), 2, "{name} (strict={strict}) lost an entry"),
+                    Err(err) => panic!("conforming {name} entries should parse (strict={strict}): {err:?}"),
+                }
+            }
         }
     }
 


### PR DESCRIPTION
lopdf rejects any PDF whose cross-reference entries are 19 bytes rather than 20 — entries ending `n\n` instead of `n \n` — with `Parse(InvalidTrailer)`.

Unlike #560 this is a **behaviour change, not a defect fix**, so the reasoning below is mostly about blast radius.

## Problem

ISO 32000-1 §7.5.4 requires each entry to be exactly 20 bytes, so these files are non-conforming and refusing them is defensible. The case for accepting them is that `LoadOptions::strict` defaults to `false` and is documented as lenient parsing, yet this — probably the most common xref malformation in the wild — fails in lenient mode. qpdf, pikepdf, PDFium and PDF.js all accept these files.

Two documents identical apart from the entry terminator:

```
20-byte entries: Ok(5)
19-byte entries: Err(Parse(InvalidTrailer))
```

`qpdf --check` reports no errors on *either* file, and `pdftotext` extracts the page text from both.

<details>
<summary>Why it fails</summary>

`xref_eol` implements §7.5.4 exactly:

```rust
let xref_eol = map(alt((tag(&b" \r"[..]), tag(&b" \n"[..]), tag(&b"\r\n"[..]))), |_| ());
```

A bare `\n` matches none of the three, so `many0(xref_entry)` yields zero entries. The parser then reads the next line as another subsection header (`0000000000 65535` parses as `start`/`count`) which fails at the following `eol`; `fold_many1` stops with one empty section; `trailer` is no longer where it is expected; both `alt` branches in `xref_and_trailer` fall through, giving `InvalidTrailer`.

</details>

## Fix

Accept a bare `\n` or `\r` terminator when `strict` is false. `xref` gains a `strict` parameter, following the existing precedent of `pub fn header(input: ParserInput, strict: bool)`; the value comes from `Reader::strict` at the one call site.

The conforming 2-byte forms stay **first** in the `alt`, so a bare `\r` can never match the CR of a conforming CR LF and strand its LF — which would silently corrupt the following entry. There is a regression test for exactly this.

Under `strict: true` the behaviour is byte-for-byte unchanged.

## Does this let malformed tables partially parse?

This is the obvious objection — a plausible-but-wrong xref is worse than a clean failure — so I tested it rather than argued it. Each malformed shape was built twice, once with the conforming `" \n"` terminator and once with bare `"\n"`, and run against both `main` and this branch. That isolates the terminator from the malformation.

| shape | `main`, 20-byte | this PR, 20-byte | this PR, 19-byte |
|---|---|---|---|
| well-formed (control) | `Ok(objs=5, xref=5)` | unchanged | `Ok(objs=5, xref=5)` |
| count says 6, 3 entries present | `Ok(objs=2, xref=2)` | unchanged | `Ok(objs=2, xref=2)` |
| entry missing its `n`/`f` | `Ok(objs=4, xref=2)` | unchanged | `Ok(objs=4, xref=2)` |
| valid entries, junk offsets | `Ok(objs=0, xref=5)` | unchanged | `Ok(objs=0, xref=5)` |
| garbage line mid-table | `Err(InvalidTrailer)` | unchanged | `Err(InvalidTrailer)` |
| truncated, no trailer | `Err(InvalidTrailer)` | unchanged | `Err(InvalidTrailer)` |

Two things follow. The 20-byte column is identical before and after, so conforming files are untouched. And the 19-byte column now equals the 20-byte column row for row — a malformed table behaves exactly as the same table with conforming terminators already behaved. The terminator stops being load-bearing, which is the intent.

The reason width was never what protected this: an entry is distinguished from a subsection header by its `n`/`f` type marker, not by its byte count.

```
entry:  uint SP uint SP (n|f) eol
header: uint SP uint [SP] eol
```

A header can never parse as an entry (no `n`/`f`) and an entry can never parse as a header (the `n`/`f` blocks the `eol`), at any width. What actually guards against truncation is `trailer`: any residue the entry parser cannot consume sits between the last entry and `trailer`, so the tag fails and the whole branch collapses to `InvalidTrailer`. That is why the garbage-line and truncated rows still error everywhere.

## A pre-existing weakness this does *not* address

The table above also shows that lopdf already tolerates silently incomplete tables on conforming input: a table declaring `0 6` with three entries loads as `Ok` with two, and one with valid-looking entries pointing at junk offsets loads as `Ok` with zero objects.

The cause is in the fold, which discards the declared count and never checks it against what was parsed:

```rust
|mut xref, ((start, _count), entries)| {
```

I deliberately left this alone. Validating `_count` would start *rejecting* files that load today — a much wider change than this one, and the mirror image of the argument for making lenient mode more lenient. Flagging it as a separate observation; happy to open an issue or a PR if you want it pursued.

One related case also left alone: a 21-byte `n \r\n` terminator is still rejected, before and after. The conforming `" \r"` matches and strands the `\n`. It is a different malformation from the one here and I did not want to widen the change without a view from you.

## Testing

Three tests in the existing `#[cfg(test)] mod tests` in `src/parser/mod.rs`:

- bare LF **and** bare CR entries parse when lenient;
- all three conforming terminators still parse in **both** modes — the guard for the `alt`-ordering hazard above;
- 19-byte entries are rejected under `strict: true`, with the 20-byte build of the same document as a control that must load under strict, so the rejection is attributable to the terminator and nothing else.

All three were verified to fail with the relaxation removed, except the conforming-terminator guard, which correctly keeps passing.

Full suite green under the CI invocation (`cargo test -- --test-threads=1 --skip performance`, 291 passed), plus `--no-default-features` (285) and `--all-features` (251). `cargo +nightly fmt --all -- --check` clean; clippy clean on `--features serde`, `--all-features`, and pdfutil.
