### PR TITLE
Bound cross-reference subsection object numbers to u32

### DIFF
--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -888,7 +888,7 @@ mod tests {
             // Reencode cipher from a hex string to a Vec<u8>
             let cipher = cipher.as_bytes();
             let mut cipher_bytes = Vec::with_capacity(cipher.len() / 2);
-            for hex_pair in cipher.chunks_exact(2) {
+            for hex_pair in cipher.as_chunks::<2>().0 {
                 cipher_bytes.push(u8::from_str_radix(std::str::from_utf8(hex_pair).unwrap(), 16).unwrap());
             }
 

--- a/src/encryption/algorithms.rs
+++ b/src/encryption/algorithms.rs
@@ -428,7 +428,7 @@ impl PasswordAlgorithm {
             let mut owner_encrypted = self.owner_encrypted.clone();
             let mut decryptor = Aes256CbcDec::new(&key.into(), &iv.into());
 
-            for block in owner_encrypted.chunks_exact_mut(16) {
+            for block in owner_encrypted.as_chunks_mut::<16>().0 {
                 decryptor.decrypt_block(aes_block_mut(block));
             }
 
@@ -458,7 +458,7 @@ impl PasswordAlgorithm {
             let mut user_encrypted = self.user_encrypted.clone();
             let mut decryptor = Aes256CbcDec::new(&key.into(), &iv.into());
 
-            for block in user_encrypted.chunks_exact_mut(16) {
+            for block in user_encrypted.as_chunks_mut::<16>().0 {
                 decryptor.decrypt_block(aes_block_mut(block));
             }
 
@@ -542,7 +542,7 @@ impl PasswordAlgorithm {
 
             let mut encryptor = Aes128CbcEnc::new(key.into(), iv.into());
 
-            for block in k1.chunks_exact_mut(16) {
+            for block in k1.as_chunks_mut::<16>().0 {
                 encryptor.encrypt_block(aes_block_mut(block));
             }
 
@@ -959,7 +959,7 @@ impl PasswordAlgorithm {
         let mut user_encrypted = file_encryption_key.to_vec();
         let mut encryptor = Aes256CbcEnc::new(&key.into(), &iv.into());
 
-        for block in user_encrypted.chunks_exact_mut(16) {
+        for block in user_encrypted.as_chunks_mut::<16>().0 {
             encryptor.encrypt_block(aes_block_mut(block));
         }
 
@@ -1013,7 +1013,7 @@ impl PasswordAlgorithm {
         let mut owner_encrypted = file_encryption_key.to_vec();
         let mut encryptor = Aes256CbcEnc::new(&key.into(), &iv.into());
 
-        for block in owner_encrypted.chunks_exact_mut(16) {
+        for block in owner_encrypted.as_chunks_mut::<16>().0 {
             encryptor.encrypt_block(aes_block_mut(block));
         }
 
@@ -1050,7 +1050,7 @@ impl PasswordAlgorithm {
 
         let mut encryptor = Aes256EbcEnc::new(&key.into());
 
-        for block in bytes.chunks_exact_mut(16) {
+        for block in bytes.as_chunks_mut::<16>().0 {
             encryptor.encrypt_block(aes_block_mut(block));
         }
 
@@ -1144,7 +1144,7 @@ impl PasswordAlgorithm {
 
         let mut decryptor = Aes256EbcDec::new(&key.into());
 
-        for block in bytes.chunks_exact_mut(16) {
+        for block in bytes.as_chunks_mut::<16>().0 {
             decryptor.decrypt_block(aes_block_mut(block));
         }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -523,10 +523,25 @@ fn xref(input: ParserInput, strict: bool) -> NomResult<Xref> {
             xref_section,
             || -> Xref { Xref::new(0, XrefType::CrossReferenceTable) },
             |mut xref, ((start, _count), entries)| {
+                let mut skipped = 0usize;
                 for (index, ((offset, generation), is_normal)) in entries.into_iter().enumerate() {
                     if is_normal && let Ok(generation) = generation.try_into() {
-                        xref.insert((start + index) as u32, XrefEntry::Normal { offset, generation });
+                        // `start` is read from the subsection header, so it is untrusted:
+                        // `start + index` can overflow, and object numbers are u32, so a
+                        // `start` above u32::MAX would truncate into a valid-looking number
+                        // that silently displaces a legitimate entry. Skip whatever cannot
+                        // be represented, as an out-of-range generation is skipped above.
+                        match start.checked_add(index).and_then(|id| u32::try_from(id).ok()) {
+                            Some(id) => xref.insert(id, XrefEntry::Normal { offset, generation }),
+                            None => skipped += 1,
+                        }
                     }
+                }
+                if skipped > 0 {
+                    log::warn!(
+                        "cross-reference subsection starting at {start} has {skipped} entr{} with an object number beyond u32; skipping",
+                        if skipped == 1 { "y" } else { "ies" }
+                    );
                 }
                 xref
             },
@@ -1116,6 +1131,58 @@ EI";
                     Ok((_, re)) => assert_eq!(re.entries.len(), 2, "{name} (strict={strict}) lost an entry"),
                     Err(err) => panic!("conforming {name} entries should parse (strict={strict}): {err:?}"),
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn xref_subsection_start_near_usize_max_is_skipped() {
+        // A subsection header's start is read straight from the file, so it is untrusted.
+        // A start of usize::MAX made `start + index` overflow: a panic wherever overflow
+        // checks are on (a denial of service for any consumer parsing untrusted PDFs), and
+        // a silent wrap to object 0 where they are not.
+        let input = &b"xref\n18446744073709551615 2\n0000000000 65535 f \n0000000009 00000 n \ntrailer\n<</Size 2/Root 1 0 R>>\n"[..];
+        for strict in [false, true] {
+            match xref(test_span(input), strict) {
+                Ok((_, re)) => assert!(
+                    re.entries.is_empty(),
+                    "unrepresentable object number was inserted (strict={strict}): {:?}",
+                    re.entries
+                ),
+                Err(err) => panic!("xref should still parse (strict={strict}): {err:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn xref_subsection_start_beyond_u32_does_not_displace_entries() {
+        // Object numbers are u32, but the subsection start is parsed as usize and was cast
+        // with `as u32`. A start above u32::MAX truncated into a valid-looking number --
+        // 4294967297 becomes 1 -- silently overwriting a legitimate entry with an arbitrary
+        // offset. No overflow occurs here, so a checked add alone would not catch it.
+        let input = &b"xref\n0 2\n0000000000 65535 f \n0000000009 00000 n \n4294967297 1\n0000000999 00000 n \ntrailer\n<</Size 2/Root 1 0 R>>\n"[..];
+        for strict in [false, true] {
+            match xref(test_span(input), strict) {
+                Ok((_, re)) => {
+                    assert_eq!(
+                        re.entries.len(),
+                        1,
+                        "(strict={strict}) unexpected entries: {:?}",
+                        re.entries
+                    );
+                    assert!(
+                        matches!(
+                            re.get(1),
+                            Some(XrefEntry::Normal {
+                                offset: 9,
+                                generation: 0
+                            })
+                        ),
+                        "entry for object 1 was displaced (strict={strict}): {:?}",
+                        re.get(1)
+                    );
+                }
+                Err(err) => panic!("xref should still parse (strict={strict}): {err:?}"),
             }
         }
     }

--- a/src/parser_aux.rs
+++ b/src/parser_aux.rs
@@ -583,10 +583,14 @@ pub fn decode_xref_stream_with_limit(
             return Err(ParseError::InvalidXref.into());
         }
 
-        let index_entries = section_indice.chunks_exact(2).try_fold(0_usize, |total, section| {
-            let count = usize::try_from(section[1]).map_err(|_| ParseError::InvalidXref)?;
-            total.checked_add(count).ok_or(ParseError::InvalidXref)
-        })?;
+        let index_entries = section_indice
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .try_fold(0_usize, |total, section| {
+                let count = usize::try_from(section[1]).map_err(|_| ParseError::InvalidXref)?;
+                total.checked_add(count).ok_or(ParseError::InvalidXref)
+            })?;
         // An entry can't be read from bytes that aren't there. Validate the total before inserting
         // anything so multiple individually plausible /Index sections cannot overrun the body.
         //
@@ -602,7 +606,7 @@ pub fn decode_xref_stream_with_limit(
         let mut bytes2 = vec![0_u8; field_widths[1] as usize];
         let mut bytes3 = vec![0_u8; field_widths[2] as usize];
 
-        for section in section_indice.chunks_exact(2) {
+        for section in section_indice.as_chunks::<2>().0 {
             let start = section[0];
             let count = section[1];
 

--- a/src/toc.rs
+++ b/src/toc.rs
@@ -105,9 +105,8 @@ impl Document {
         let page_id_to_page_numbers = self.setup_page_id_to_num();
         for (title, page_id, level) in outline_page_ids {
             if let Some(page_num) = page_id_to_page_numbers.get(&page_id) {
-                let s;
-                if title.len() < 2 {
-                    s = String::from_utf8_lossy(&title).to_string();
+                let s = if title.len() < 2 {
+                    String::from_utf8_lossy(&title).to_string()
                 } else if title[0] == 0xfe && title[1] == 0xff {
                     if title.len() & 1 != 0 {
                         toc.errors
@@ -119,7 +118,7 @@ impl Document {
                         .skip(1)
                         .map(|x| ((x[0] as u16) << 8) | x[1] as u16)
                         .collect();
-                    s = String::from_utf16_lossy(&t16);
+                    String::from_utf16_lossy(&t16)
                 } else if title[0] == 0xff && title[1] == 0xfe {
                     if title.len() & 1 != 0 {
                         toc.errors
@@ -131,10 +130,10 @@ impl Document {
                         .skip(1)
                         .map(|x| ((x[1] as u16) << 8) | x[0] as u16)
                         .collect();
-                    s = String::from_utf16_lossy(&t16);
+                    String::from_utf16_lossy(&t16)
                 } else {
-                    s = String::from_utf8_lossy(&title).to_string();
-                }
+                    String::from_utf8_lossy(&title).to_string()
+                };
                 toc.toc.push(TocType {
                     level,
                     title: s,


### PR DESCRIPTION
A cross-reference subsection header's `start` is read straight from the file, so it is fully untrusted, but it was combined with the entry index and cast unchecked:

```rust
xref.insert((start + index) as u32, XrefEntry::Normal { offset, generation });
```

Two distinct defects follow from that one line, both reachable from a 166-byte PDF.

## Problem

**1. Integer overflow.** `start` is parsed as a `usize`, so a subsection header declaring `start = 18446744073709551615` makes `start + index` overflow:

- with overflow checks on (debug, and any release profile that enables them) it **panics** — `attempt to add with overflow`. A library that panics on untrusted input is a denial of service for every downstream consumer.
- with them off it **wraps silently** and inserts the entry under object 0 — the reserved free-list head.

**2. Truncation.** Object numbers are `u32`, so a `start` above `u32::MAX` truncates under `as u32` into a valid-looking number. `4294967297` becomes `1`. Since `Xref::insert` is a plain map insert, it **overwrites**, so a malformed file can silently redirect any object number to an arbitrary file offset.

This second case needs **no overflow at all** — `4294967297` fits in a `usize` fine — so a checked add alone does not address it. It is also the more serious of the two, because it corrupts rather than crashes:

| | on `main` | with this PR |
|---|---|---|
| `xref[1]` | `Normal { offset: 999 }` — the real offset 9 destroyed | `Normal { offset: 9 }` |
| document | `Ok`, **0 objects** — catalog unreachable | `Ok`, 1 object |

The fix restores correct parsing here rather than merely averting harm.

<details>
<summary>Reproducers</summary>

The overflow case, a 166-byte file:

```python
body = b"%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n"
x = len(body)
out = body + (
    b"xref\n"
    b"18446744073709551615 2\n"
    b"0000000000 65535 f \n"
    b"0000000009 00000 n \n"
    b"trailer\n<< /Size 2 /Root 1 0 R >>\n"
    b"startxref\n" + str(x).encode() + b"\n%%EOF\n"
)
open("lopdf-overflow-min.pdf", "wb").write(out)
```

```rust
let b = std::fs::read("lopdf-overflow-min.pdf").unwrap();
let _ = lopdf::Document::load_mem(&b);   // panics at parser/mod.rs:528
```

The truncation case adds a second subsection whose start truncates onto object 1:

```
xref
0 2
0000000000 65535 f 
0000000009 00000 n 
4294967297 1
0000000999 00000 n 
trailer
<< /Size 2 /Root 1 0 R >>
```

</details>

## Fix

Compute the object number with a checked add followed by a `u32` conversion, and skip entries whose number cannot be represented.

Two judgement calls worth surfacing, since both could reasonably go the other way:

- **Skip rather than reject the file.** The loop already skips entries whose generation is out of range, so this matches the established behaviour of the same block, and it cannot reject any file that loads correctly today. Entries beyond `u32::MAX` lose nothing real: object numbers *are* `u32` (`XrefEntry::Normal { offset: u32, generation: u16 }`) and indirect references are parsed as `u32`, so such an entry is unreferenceable by construction. If you would prefer `strict: true` to hard-reject these instead, that is an easy follow-up — I left it out because it is a behaviour change rather than a fix, and #564 suggested being careful there.
- **A `warn!` rather than silence.** Dropping entries without a word is the failure mode #560 addressed, so this reports how many were skipped. `log::warn!` is already used in this file, so no new dependency. It fires once per subsection, not once per entry, so a hostile file cannot use it to spam the log.

## Testing

Two regression tests alongside the #564 ones, each exercising `strict` in both directions. Confirmed both fail on `main`, in the two *distinct* ways — one panics with the overflow, the other reports `entry for object 1 was displaced: Some(Normal { offset: 999, generation: 0 })` — so neither is passing vacuously.

- Full suite green under the CI invocation (`cargo test -- --test-threads=1 --skip performance`), and under `--all-features` and `--no-default-features`. No existing test changed behaviour.
- `cargo +nightly fmt --all -- --check` clean; `cargo clippy --all-targets` clean for both `--features serde` and `--all-features` with `-D warnings`, on the same toolchain CI uses.

CI is green on all 11 jobs.

## Second commit: the Rust 1.98 lints (why encryption/ is touched)

The second commit is unrelated to the bug above and touches `encryption/algorithms.rs`, `parser_aux.rs`, `encryption.rs` and `toc.rs`, so it deserves an explanation rather than being taken as scope creep.

**CI was already failing on unmodified `main` before this PR.** Rust 1.98.0 was released 2026-08-18 and added `chunks_exact_to_as_chunks`; its `needless_late_init` also now fires on `get_toc`. The workflow resolves `stable` to the newest release and runs clippy with `-D warnings`, so the clippy job breaks for every pull request. The three green runs currently on `main` all predate 1.98.0. Reproduced by checking out `main` clean and running the workflow's own command:

```
$ cargo +1.98.0 clippy --all-targets --features serde -- -D warnings   # on pristine main
error: could not compile `lopdf` (lib) due to 10 previous errors
```

The changes are mechanical:

- `chunks_exact(N)` / `chunks_exact_mut(N)` at a constant N become `as_chunks::<N>().0` / `as_chunks_mut::<N>().0` — 7 AES block loops, plus 3 elsewhere.
- The title in `get_toc` gets a single initializer instead of a deferred one.

**The AES loops are unchanged in behaviour.** `as_chunks::<N>().0` yields exactly the complete chunks `chunks_exact(N)` produced, discarding the same remainder. The item type becomes an array reference, which still coerces at the `aes_block_mut(&mut [u8])` call, so no call site changed. All 14 encryption tests pass.

**MSRV was checked explicitly.** `Cargo.toml` declares `rust-version = "1.88"` and CI does not test it, so a fix using a newer API would have broken the declared minimum silently. Both `as_chunks` and `as_chunks_mut` are stable as of 1.88, verified by building the crate with 1.88.0.

Happy to split this into its own PR if you would rather keep the two apart — though as it stands, whatever merges it also unblocks CI for everyone else.

## One question, and one aside

Since this is a panic reachable from untrusted input in a published crate, you may consider it worth a RUSTSEC advisory. That is your call as maintainer, so I have not filed anything — happy to help with the paperwork if you want it.

Unrelated but noticed nearby: the subsection header's `count` is parsed and discarded (`(start, _count)`), so the entry list length is never validated against it. Not reachable from this bug and deliberately out of scope; glad to file it separately if it is of interest.
