### PR TITLE
Add BrotliDecode and bounded stream length recovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = ["/benches", "/assets", "/.chglog", "/.vscode", "/.github"]
 [dependencies]
 aes = "0.9"
 bitflags = "2.13"
+brotli-decompressor = "5.0"
 cbc = "0.2"
 chrono = { version = "0.4", optional = true, default-features = false, features = [
     "std",

--- a/src/object.rs
+++ b/src/object.rs
@@ -940,6 +940,7 @@ impl Stream {
         for filter in filters {
             output = match filter {
                 b"FlateDecode" => Self::decompress_zlib(input, params, limit)?,
+                b"BrotliDecode" => Self::decompress_brotli(input, limit)?,
                 b"LZWDecode" => Self::decompress_lzw(input, params, limit)?,
                 b"ASCII85Decode" => Self::decode_ascii85(input, limit)?,
                 b"ASCIIHexDecode" => Self::decode_ascii_hex(input, limit)?,
@@ -952,6 +953,24 @@ impl Stream {
                 return Err(DecompressError::MemoryLimitExceeded { limit: max }.into());
             }
             input = &output;
+        }
+        Ok(output)
+    }
+
+    fn decompress_brotli(input: &[u8], limit: Option<usize>) -> Result<Vec<u8>> {
+        use brotli_decompressor::Decompressor;
+
+        let initial_capacity = match limit {
+            Some(max) => input.len().saturating_mul(2).min(max.saturating_add(1)),
+            None => input.len().saturating_mul(2),
+        };
+        let mut output = Vec::with_capacity(initial_capacity);
+        Self::read_capped(Decompressor::new(input, 4096), &mut output, limit)
+            .map_err(|err| Error::InvalidStream(format!("Brotli decompression failed: {err}")))?;
+        if let Some(max) = limit
+            && output.len() > max
+        {
+            return Err(DecompressError::MemoryLimitExceeded { limit: max }.into());
         }
         Ok(output)
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -338,7 +338,43 @@ pub(crate) fn dict_dup(input: ParserInput) -> NomResult<Dictionary> {
     .parse(input)
 }
 
-fn stream<'a>(input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSet<ObjectId>) -> NomResult<'a, Object> {
+/// Recover the sole EOL-framed `endstream` immediately followed by `endobj`.
+/// The caller must bound `input` to the current indirect-object context.
+fn recover_stream_length(input: ParserInput) -> Option<(ParserInput, ParserInput)> {
+    const ENDSTREAM: &[u8] = b"endstream";
+    let mut recovered = None;
+
+    for (position, candidate) in input.windows(ENDSTREAM.len()).enumerate() {
+        if candidate != ENDSTREAM {
+            continue;
+        }
+
+        let data_end = if input[..position].ends_with(b"\r\n") {
+            position - 2
+        } else if input[..position].ends_with(b"\n") || input[..position].ends_with(b"\r") {
+            position - 1
+        } else {
+            continue;
+        };
+        let after_endstream = &input[position + ENDSTREAM.len()..];
+        let Ok((after_endobj, _)) = preceded(space, tag(&b"endobj"[..])).parse(after_endstream) else {
+            continue;
+        };
+        if after_endobj.first().is_some_and(|&byte| !is_whitespace(byte)) {
+            continue;
+        }
+        if recovered.is_some() {
+            return None;
+        }
+        recovered = Some((after_endstream, &input[..data_end]));
+    }
+
+    recovered
+}
+
+fn stream<'a>(
+    input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSet<ObjectId>, recover_length: bool,
+) -> NomResult<'a, Object> {
     let (i, dict) = terminated(dictionary, (space, tag(&b"stream"[..]), space0, eol)).parse(input)?;
 
     if let Ok(length) = dict.get(b"Length").and_then(|value| {
@@ -352,8 +388,23 @@ fn stream<'a>(input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSe
             // artificial error kind is created to allow descriptive nom errors
             return Err(nom::Err::Failure(NomError::from_error_kind(i, ErrorKind::LengthValue)));
         }
-        let (i, data) = terminated(take(length as usize), pair(opt(eol), tag(&b"endstream"[..]))).parse(i)?;
-        Ok((i, Object::Stream(Stream::new(dict, data.to_vec()))))
+        let Ok(length) = usize::try_from(length) else {
+            return Err(nom::Err::Failure(NomError::from_error_kind(i, ErrorKind::LengthValue)));
+        };
+        match terminated(take(length), pair(opt(eol), tag(&b"endstream"[..]))).parse(i) {
+            Ok((remaining, data)) => Ok((remaining, Object::Stream(Stream::new(dict, data.to_vec())))),
+            Err(_) if recover_length && !reader.strict => {
+                let Some((remaining, data)) = recover_stream_length(i) else {
+                    return Err(nom::Err::Failure(NomError::from_error_kind(i, ErrorKind::LengthValue)));
+                };
+                log::warn!(
+                    "Stream Length is {length}, but the unambiguous object boundary gives {} bytes; using the recovered length.",
+                    data.len()
+                );
+                Ok((remaining, Object::Stream(Stream::new(dict, data.to_vec()))))
+            }
+            Err(_) => Err(nom::Err::Failure(NomError::from_error_kind(i, ErrorKind::LengthValue))),
+        }
     } else {
         // Return position relative to the start of the stream dictionary.
         Ok((i, Object::Stream(Stream::with_position(dict, input.len() - i.len()))))
@@ -406,10 +457,12 @@ pub fn direct_object(input: ParserInput) -> Option<Object> {
     strip_nom(_direct_object(crate::reader::MAX_NESTING_DEPTH)(input))
 }
 
-fn object<'a>(input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSet<ObjectId>) -> NomResult<'a, Object> {
+fn object<'a>(
+    input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSet<ObjectId>, recover_stream_length: bool,
+) -> NomResult<'a, Object> {
     terminated(
         alt((
-            |input| stream(input, reader, already_seen),
+            |input| stream(input, reader, already_seen, recover_stream_length),
             _direct_objects(crate::reader::MAX_NESTING_DEPTH),
         )),
         space,
@@ -421,7 +474,7 @@ pub fn indirect_object(
     input: ParserInput, offset: usize, expected_id: Option<ObjectId>, reader: &Reader,
     already_seen: &mut HashSet<ObjectId>,
 ) -> crate::Result<(ObjectId, Object)> {
-    let (id, mut object) = _indirect_object(input.take_from(offset), offset, expected_id, reader, already_seen)?;
+    let (id, mut object) = _indirect_object(input.take_from(offset), offset, expected_id, reader, already_seen, true)?;
 
     offset_stream(&mut object, offset);
 
@@ -430,7 +483,7 @@ pub fn indirect_object(
 
 fn _indirect_object<'a>(
     input: ParserInput<'a>, offset: usize, expected_id: Option<ObjectId>, reader: &Reader,
-    already_seen: &mut HashSet<ObjectId>,
+    already_seen: &mut HashSet<ObjectId>, recover_stream_length: bool,
 ) -> crate::Result<(ObjectId, Object)> {
     let (i, (_, object_id)) = terminated((space, object_id), pair(tag(&b"obj"[..]), space))
         .parse(input)
@@ -443,7 +496,7 @@ fn _indirect_object<'a>(
 
     let object_offset = input.len() - i.len();
     let (_, mut object) = terminated(
-        |i: ParserInput<'a>| object(i, reader, already_seen),
+        |i: ParserInput<'a>| object(i, reader, already_seen, recover_stream_length),
         (space, opt(tag(&b"endobj"[..])), space),
     )
     .parse(i)
@@ -566,7 +619,7 @@ pub fn xref_and_trailer(input: ParserInput, reader: &Reader) -> crate::Result<(X
     alt((
         xref_trailer,
         (|input| {
-            _indirect_object(input, 0, None, reader, &mut HashSet::new())
+            _indirect_object(input, 0, None, reader, &mut HashSet::new(), false)
                 .map(|(_, obj)| {
                     let res = match obj {
                         Object::Stream(stream) => decode_xref_stream_with_limit(stream, reader.max_decompressed_size),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -993,31 +993,51 @@ impl Reader<'_> {
                 }
             })
             .collect();
+        let mut normal_offsets: Vec<usize> = self
+            .document
+            .reference_table
+            .entries
+            .values()
+            .filter_map(|entry| match entry {
+                XrefEntry::Normal { offset, .. } => Some(*offset as usize),
+                _ => None,
+            })
+            .collect();
+        normal_offsets.sort_unstable();
+        normal_offsets.dedup();
 
-        let entries_filter_map = |(_, entry): (&_, &_)| {
+        let entries_filter_map = |(_, entry): (&_, &_)| -> Result<Option<(ObjectId, Object)>> {
             if let XrefEntry::Normal { offset, .. } = *entry {
                 // read_object now handles decryption internally
-                let result = self.read_object(offset as usize, None, &mut HashSet::new());
+                let offset = offset as usize;
+                let next_index = normal_offsets.partition_point(|&next| next <= offset);
+                let next_object = normal_offsets.get(next_index).copied();
+                let end = self.object_end(offset, next_object);
+                let result = self.read_object_to(offset, end, None, &mut HashSet::new());
                 let (object_id, mut object) = match result {
                     Ok(obj) => obj,
                     Err(e) => {
-                        // Log error but continue
+                        // Lenient loading logs and skips malformed objects; strict loading fails.
                         if is_encrypted {
                             // Expected for some encrypted objects - but log which ones
                             warn!("Skipping encrypted object at offset {}: {:?}", offset, e);
                         } else {
                             error!("Object load error at offset {}: {e:?}", offset);
                         }
-                        return None;
+                        return if self.strict { Err(e) } else { Ok(None) };
                     }
                 };
-                if let Some(filter_func) = filter_func {
-                    filter_func(object_id, &mut object)?;
+                if let Some(filter_func) = filter_func
+                    && filter_func(object_id, &mut object).is_none()
+                {
+                    return Ok(None);
                 }
 
                 if let Ok(stream) = object.as_stream() {
                     if stream.dict.has_type(b"ObjStm") && !is_encrypted {
-                        let obj_stream = ObjectStream::new_with_limit(stream, self.max_decompressed_size).ok()?;
+                        let Ok(obj_stream) = ObjectStream::new_with_limit(stream, self.max_decompressed_size) else {
+                            return Ok(None);
+                        };
                         let container_id = object_id.0;
                         let mut object_streams = object_streams.lock().unwrap();
                         if let Some(filter_func) = filter_func {
@@ -1045,31 +1065,33 @@ impl Reader<'_> {
                     }
                 }
 
-                Some((object_id, object))
+                Ok(Some((object_id, object)))
             } else {
-                None
+                Ok(None)
             }
         };
 
         #[cfg(feature = "rayon")]
         {
-            self.document.objects = self
+            let objects = self
                 .document
                 .reference_table
                 .entries
                 .par_iter()
-                .filter_map(entries_filter_map)
-                .collect();
+                .map(entries_filter_map)
+                .collect::<Result<Vec<_>>>()?;
+            self.document.objects = objects.into_iter().flatten().collect();
         }
         #[cfg(not(feature = "rayon"))]
         {
-            self.document.objects = self
+            let objects = self
                 .document
                 .reference_table
                 .entries
                 .iter()
-                .filter_map(entries_filter_map)
-                .collect();
+                .map(entries_filter_map)
+                .collect::<Result<Vec<_>>>()?;
+            self.document.objects = objects.into_iter().flatten().collect();
         }
 
         // Only add entries, but never replace entries
@@ -1317,12 +1339,40 @@ impl Reader<'_> {
     fn read_object(
         &self, offset: usize, expected_id: Option<ObjectId>, already_seen: &mut HashSet<ObjectId>,
     ) -> Result<(ObjectId, Object)> {
-        if offset > self.buffer.len() {
+        let next_object = self
+            .document
+            .reference_table
+            .entries
+            .values()
+            .filter_map(|entry| match entry {
+                XrefEntry::Normal { offset: next, .. } if *next as usize > offset => Some(*next as usize),
+                _ => None,
+            })
+            .min();
+        let end = self.object_end(offset, next_object);
+        self.read_object_to(offset, end, expected_id, already_seen)
+    }
+
+    fn object_end(&self, offset: usize, next_object: Option<usize>) -> usize {
+        let xref_start = (self.document.xref_start > offset).then_some(self.document.xref_start);
+        next_object
+            .into_iter()
+            .chain(xref_start)
+            .min()
+            .unwrap_or(self.buffer.len())
+            .min(self.buffer.len())
+    }
+
+    fn read_object_to(
+        &self, offset: usize, end: usize, expected_id: Option<ObjectId>, already_seen: &mut HashSet<ObjectId>,
+    ) -> Result<(ObjectId, Object)> {
+        if offset > end || end > self.buffer.len() {
             return Err(Error::InvalidOffset(offset));
         }
 
-        // Just parse without decryption - we'll decrypt later
-        parser::indirect_object(self.buffer, offset, expected_id, self, already_seen)
+        // The xref-derived upper bound keeps malformed stream recovery inside
+        // the current indirect-object context.
+        parser::indirect_object(&self.buffer[..end], offset, expected_id, self, already_seen)
     }
 
     /// Parse the cross-reference section recorded at `offset`, first correcting

--- a/tests/brotli_decode.rs
+++ b/tests/brotli_decode.rs
@@ -1,0 +1,74 @@
+use lopdf::{DecompressError, Dictionary, Document, Error, LoadOptions, Object, Stream};
+
+const PAYLOAD: &[u8] = b"BrotliDecode works across filter layers.";
+const COMPRESSED_PAYLOAD: &[u8] = &[
+    27, 39, 0, 224, 28, 169, 83, 159, 59, 116, 45, 84, 246, 38, 39, 65, 136, 232, 26, 196, 37, 141, 13, 108, 192, 129,
+    75, 84, 35, 221, 153, 78, 105, 229, 184, 47, 49, 2, 83, 8, 107, 4, 164,
+];
+const COMPRESSED_ASCII_HEX: &[u8] = &[11, 5, 128, 52, 56, 54, 53, 54, 99, 54, 99, 54, 102, 62, 3];
+const COMPRESSED_XREF: &[u8] = &[
+    27, 34, 0, 0, 4, 54, 224, 26, 71, 93, 117, 151, 221, 6, 135, 28, 200, 5, 14, 196, 81, 11, 176, 12, 144, 100, 228,
+    47, 106, 153, 208, 15, 0,
+];
+
+fn brotli_stream(content: &[u8]) -> Stream {
+    let mut dict = Dictionary::new();
+    dict.set("Filter", "BrotliDecode");
+    Stream::new(dict, content.to_vec())
+}
+
+fn brotli_xref_pdf() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.5\n");
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    pdf.extend_from_slice(b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>\nendobj\n");
+    let xref_offset = pdf.len();
+    assert_eq!(xref_offset, 184, "compressed xref offsets must match the fixture body");
+    pdf.extend_from_slice(
+        b"4 0 obj\n<< /Type /XRef /Size 5 /Root 1 0 R /W [1 4 2] /Length 33 /Filter /BrotliDecode >>\nstream\n",
+    );
+    pdf.extend_from_slice(COMPRESSED_XREF);
+    pdf.extend_from_slice(b"\nendstream\nendobj\nstartxref\n184\n%%EOF\n");
+    pdf
+}
+
+#[test]
+fn brotli_filter_decodes_and_honors_output_limit() {
+    let stream = brotli_stream(COMPRESSED_PAYLOAD);
+
+    assert_eq!(stream.decompressed_content().unwrap(), PAYLOAD);
+    assert_eq!(stream.decompressed_content_with_limit(PAYLOAD.len()).unwrap(), PAYLOAD);
+    assert!(matches!(
+        stream.decompressed_content_with_limit(PAYLOAD.len() - 1),
+        Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit })) if limit == PAYLOAD.len() - 1
+    ));
+}
+
+#[test]
+fn brotli_filter_is_bounded_before_the_next_filter_layer() {
+    let mut dict = Dictionary::new();
+    dict.set(
+        "Filter",
+        vec![Object::from("BrotliDecode"), Object::from("ASCIIHexDecode")],
+    );
+    let stream = Stream::new(dict, COMPRESSED_ASCII_HEX.to_vec());
+
+    assert_eq!(stream.decompressed_content_with_limit(11).unwrap(), b"Hello");
+    assert!(matches!(
+        stream.decompressed_content_with_limit(5),
+        Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit: 5 }))
+    ));
+}
+
+#[test]
+fn brotli_xref_stream_decodes_during_load_with_the_same_limit() {
+    let pdf = brotli_xref_pdf();
+    let document = Document::load_mem_with_options(&pdf, LoadOptions::with_max_decompressed_size(35)).unwrap();
+    assert_eq!(document.get_pages().len(), 1);
+
+    assert!(matches!(
+        Document::load_mem_with_options(&pdf, LoadOptions::with_max_decompressed_size(34)),
+        Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit: 34 }))
+    ));
+}

--- a/tests/stream_length_recovery.rs
+++ b/tests/stream_length_recovery.rs
@@ -1,0 +1,84 @@
+use lopdf::{Document, LoadOptions, Object};
+
+fn pdf_with_stream(declared_length: usize, content: &[u8], trailer: &[u8]) -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.7\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] /Resources << /XObject << /Im0 4 0 R >> >> >>\nendobj\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        format!(
+            "4 0 obj\n<< /Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB \
+             /BitsPerComponent 8 /Filter [/FlateDecode /DCTDecode] /Length {declared_length} >>\nstream\n"
+        )
+        .as_bytes(),
+    );
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(trailer);
+
+    let xref_offset = pdf.len();
+    pdf.extend_from_slice(b"xref\n0 5\n0000000000 65535 f \n");
+    for offset in offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(format!("trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n").as_bytes());
+    pdf
+}
+
+#[test]
+fn lenient_load_recovers_an_unambiguous_stream_length_mismatch() {
+    let content = b"actual stream bytes";
+    let pdf = pdf_with_stream(0, content, b"\nendstream\nendobj\n");
+
+    let document = Document::load_mem(&pdf).unwrap();
+    let Object::Stream(stream) = document.get_object((4, 0)).unwrap() else {
+        panic!("recovered object must remain a stream");
+    };
+    assert_eq!(stream.content, content);
+    assert_eq!(
+        stream.dict.get(b"Length").unwrap().as_i64().unwrap(),
+        content.len() as i64
+    );
+}
+
+#[test]
+fn strict_load_rejects_a_stream_length_mismatch() {
+    let content = b"actual stream bytes";
+    let malformed = pdf_with_stream(0, content, b"\nendstream\nendobj\n");
+    let conforming = pdf_with_stream(content.len(), content, b"\nendstream\nendobj\n");
+    let strict = LoadOptions {
+        strict: true,
+        ..Default::default()
+    };
+
+    assert!(Document::load_mem_with_options(&conforming, strict.clone()).is_ok());
+    assert!(Document::load_mem_with_options(&malformed, strict).is_err());
+}
+
+#[test]
+fn lenient_load_does_not_guess_an_ambiguous_stream_boundary() {
+    let pdf = pdf_with_stream(
+        0,
+        b"first candidate\nendstream\nendobj\nbytes after the false boundary",
+        b"\nendstream\nendobj\n",
+    );
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert!(document.get_object((4, 0)).is_err());
+}
+
+#[test]
+fn lenient_load_does_not_recover_without_endstream() {
+    let pdf = pdf_with_stream(0, b"unterminated stream bytes", b"\nendobj\n");
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert!(document.get_object((4, 0)).is_err());
+}


### PR DESCRIPTION
## Summary

- add general-purpose `/BrotliDecode` support to the shared stream filter pipeline with the maintained, pure-Rust `brotli-decompressor` crate
- enforce the existing per-filter `max_decompressed_size` bound for Brotli output, including eagerly decoded xref and object streams
- recover malformed stream lengths only in lenient mode, only inside an xref-bounded indirect-object slice, and only when there is exactly one EOL-framed `endstream` followed by `endobj`
- keep strict loading exact: a declared length mismatch fails instead of silently turning the stream dictionary into a non-stream object

## Recovery and resource-limit contracts

The normal declared `/Length` path is unchanged. If that length does not land on `endstream`, strict mode rejects the object. Lenient mode may use a recovered boundary only when the caller bounded parsing by the next normal-object offset or xref start and the bounded slice has one unambiguous `endstream`/`endobj` boundary. Missing or multiple candidates fail, and xref-stream bootstrap parsing does not enable this fallback. No whole-file boundary scan was added.

Brotli decoding uses the same capped reader as the other pull-based filters. At most `max_decompressed_size + 1` output bytes are materialized before `MemoryLimitExceeded`, and every filter layer is checked independently. A `[BrotliDecode ASCIIHexDecode]` regression test verifies that an oversized intermediate Brotli layer is rejected even when the final layer would fit.

## Real fixtures

External binaries were tested from `/tmp` and were not committed:

- `pdfjs-brotli-prototype.pdf` (`sha256: 88d7f8b3f6e8cb26fdde69bbcd27990f2f61f807472afce7b5dbe2ae8f4f3ff7`): loaded 84 objects and 25 pages; decoded 30 Brotli streams totaling 12,120,492 bytes and 10,821,518 bytes of page content
- `pdfjs-multiple-filters-zero-length.pdf` (`sha256: 7988a74a1a2a383c42a80631ce196d1a895ce88fe9b16d0bf9fdab9c6d63542f`): lenient loading recovered object 6 as a 17,081-byte stream with `[FlateDecode DCTDecode]`; strict loading rejected the mismatch

## Verification

- `cargo +nightly fmt --all -- --check`
- `cargo test --verbose -- --test-threads=1 --skip performance` — 310 passed, 3 ignored, 5 filtered out
- `cargo test --verbose --no-default-features -- --test-threads=1 --skip performance` — 304 passed, 3 ignored, 5 filtered out
- `cargo test --verbose --all-features -- --test-threads=1 --skip performance` — 263 passed, 3 filtered out
- `cargo clippy --all-targets --features serde -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --verbose --manifest-path pdfutil/Cargo.toml`
- `cargo clippy --manifest-path pdfutil/Cargo.toml --all-targets -- -D warnings`
- `cargo +1.88.0 check`
- `cargo +1.88.0 test --no-default-features --test brotli_decode --test stream_length_recovery` — 7 passed
- `cargo build --verbose --target wasm32-wasip1`
- `cargo build --verbose --target wasm32-wasip2`
