### PR TITLE
feat: support /BrotliDecode stream filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ weezl = "0.2"
 skrifa = { version = "0.45.1", optional = true }
 
 [dev-dependencies]
+brotli = "8"
 clap = { version = "4.6", features = ["derive"] }
 env_logger = "0.11"
 flate2 = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ weezl = "0.2"
 skrifa = { version = "0.45.1", optional = true }
 
 [dev-dependencies]
-brotli = "8"
 clap = { version = "4.6", features = ["derive"] }
 env_logger = "0.11"
 flate2 = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = ["/benches", "/assets", "/.chglog", "/.vscode", "/.github"]
 [dependencies]
 aes = "0.9"
 bitflags = "2.13"
+brotli-decompressor = "5.0"
 cbc = "0.2"
 chrono = { version = "0.4", optional = true, default-features = false, features = [
     "std",

--- a/src/object.rs
+++ b/src/object.rs
@@ -940,6 +940,7 @@ impl Stream {
         for filter in filters {
             output = match filter {
                 b"FlateDecode" => Self::decompress_zlib(input, params, limit)?,
+                b"BrotliDecode" => Self::decompress_brotli(input, limit)?,
                 b"LZWDecode" => Self::decompress_lzw(input, params, limit)?,
                 b"ASCII85Decode" => Self::decode_ascii85(input, limit)?,
                 b"ASCIIHexDecode" => Self::decode_ascii_hex(input, limit)?,
@@ -952,6 +953,24 @@ impl Stream {
                 return Err(DecompressError::MemoryLimitExceeded { limit: max }.into());
             }
             input = &output;
+        }
+        Ok(output)
+    }
+
+    fn decompress_brotli(input: &[u8], limit: Option<usize>) -> Result<Vec<u8>> {
+        use brotli_decompressor::Decompressor;
+
+        let initial_capacity = match limit {
+            Some(max) => input.len().saturating_mul(2).min(max.saturating_add(1)),
+            None => input.len().saturating_mul(2),
+        };
+        let mut output = Vec::with_capacity(initial_capacity);
+        Self::read_capped(Decompressor::new(input, 4096), &mut output, limit)
+            .map_err(|err| Error::InvalidStream(format!("Brotli decompression failed: {err}")))?;
+        if let Some(max) = limit
+            && output.len() > max
+        {
+            return Err(DecompressError::MemoryLimitExceeded { limit: max }.into());
         }
         Ok(output)
     }

--- a/src/object.rs
+++ b/src/object.rs
@@ -940,7 +940,7 @@ impl Stream {
         for filter in filters {
             output = match filter {
                 b"FlateDecode" => Self::decompress_zlib(input, params, limit)?,
-                b"BrotliDecode" => Self::decompress_brotli(input, limit)?,
+                b"BrotliDecode" => Self::decompress_brotli(input, params, limit)?,
                 b"LZWDecode" => Self::decompress_lzw(input, params, limit)?,
                 b"ASCII85Decode" => Self::decode_ascii85(input, limit)?,
                 b"ASCIIHexDecode" => Self::decode_ascii_hex(input, limit)?,
@@ -957,9 +957,12 @@ impl Stream {
         Ok(output)
     }
 
-    fn decompress_brotli(input: &[u8], limit: Option<usize>) -> Result<Vec<u8>> {
+    fn decompress_brotli(input: &[u8], params: Option<&Dictionary>, limit: Option<usize>) -> Result<Vec<u8>> {
         use brotli_decompressor::Decompressor;
 
+        // Unlike the Flate path there is no fallback (e.g. raw deflate), so a
+        // truncated or corrupt stream fails hard instead of yielding partial
+        // output — intentional for a new filter, not an oversight.
         let initial_capacity = match limit {
             Some(max) => input.len().saturating_mul(2).min(max.saturating_add(1)),
             None => input.len().saturating_mul(2),
@@ -972,7 +975,10 @@ impl Stream {
         {
             return Err(DecompressError::MemoryLimitExceeded { limit: max }.into());
         }
-        Ok(output)
+        // ISO/TS 32001 gives /BrotliDecode the same /DecodeParms predictor
+        // entries as /FlateDecode; MuPDF applies them identically after
+        // decompression (fz_open_image_decomp_stream, FZ_IMAGE_BROTLI).
+        Self::decompress_predictor(output, params)
     }
 
     /// Read `reader` to end, appending to `output`. When `limit` is `Some(max)`,

--- a/src/object.rs
+++ b/src/object.rs
@@ -940,7 +940,7 @@ impl Stream {
         for filter in filters {
             output = match filter {
                 b"FlateDecode" => Self::decompress_zlib(input, params, limit)?,
-                b"BrotliDecode" => Self::decompress_brotli(input, params, limit)?,
+                b"BrotliDecode" => Self::decompress_brotli(input, limit)?,
                 b"LZWDecode" => Self::decompress_lzw(input, params, limit)?,
                 b"ASCII85Decode" => Self::decode_ascii85(input, limit)?,
                 b"ASCIIHexDecode" => Self::decode_ascii_hex(input, limit)?,
@@ -957,7 +957,7 @@ impl Stream {
         Ok(output)
     }
 
-    fn decompress_brotli(input: &[u8], params: Option<&Dictionary>, limit: Option<usize>) -> Result<Vec<u8>> {
+    fn decompress_brotli(input: &[u8], limit: Option<usize>) -> Result<Vec<u8>> {
         use brotli_decompressor::Decompressor;
 
         // Unlike the Flate path there is no fallback (e.g. raw deflate), so a
@@ -975,10 +975,14 @@ impl Stream {
         {
             return Err(DecompressError::MemoryLimitExceeded { limit: max }.into());
         }
-        // ISO/TS 32001 gives /BrotliDecode the same /DecodeParms predictor
-        // entries as /FlateDecode; MuPDF applies them identically after
-        // decompression (fz_open_image_decomp_stream, FZ_IMAGE_BROTLI).
-        Self::decompress_predictor(output, params)
+        // /DecodeParms predictors are deliberately NOT applied here. The PDF
+        // Association's prototype files never pair /BrotliDecode with a
+        // /Predictor (their Brotli xref streams store raw W entries), pdf.js
+        // and pypdf ignore the parameters too; only MuPDF applies them.
+        // Applying them would also corrupt [/BrotliDecode /FlateDecode]
+        // chains, since the shared dict-form /DecodeParms is passed to every
+        // filter and a predictor there belongs to the Flate layer.
+        Ok(output)
     }
 
     /// Read `reader` to end, appending to `output`. When `limit` is `Some(max)`,

--- a/tests/brotli_decode.rs
+++ b/tests/brotli_decode.rs
@@ -1,0 +1,74 @@
+use lopdf::{DecompressError, Dictionary, Document, Error, LoadOptions, Object, Stream};
+
+const PAYLOAD: &[u8] = b"BrotliDecode works across filter layers.";
+const COMPRESSED_PAYLOAD: &[u8] = &[
+    27, 39, 0, 224, 28, 169, 83, 159, 59, 116, 45, 84, 246, 38, 39, 65, 136, 232, 26, 196, 37, 141, 13, 108, 192, 129,
+    75, 84, 35, 221, 153, 78, 105, 229, 184, 47, 49, 2, 83, 8, 107, 4, 164,
+];
+const COMPRESSED_ASCII_HEX: &[u8] = &[11, 5, 128, 52, 56, 54, 53, 54, 99, 54, 99, 54, 102, 62, 3];
+const COMPRESSED_XREF: &[u8] = &[
+    27, 34, 0, 0, 4, 54, 224, 26, 71, 93, 117, 151, 221, 6, 135, 28, 200, 5, 14, 196, 81, 11, 176, 12, 144, 100, 228,
+    47, 106, 153, 208, 15, 0,
+];
+
+fn brotli_stream(content: &[u8]) -> Stream {
+    let mut dict = Dictionary::new();
+    dict.set("Filter", "BrotliDecode");
+    Stream::new(dict, content.to_vec())
+}
+
+fn brotli_xref_pdf() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.5\n");
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    pdf.extend_from_slice(b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>\nendobj\n");
+    let xref_offset = pdf.len();
+    assert_eq!(xref_offset, 184, "compressed xref offsets must match the fixture body");
+    pdf.extend_from_slice(
+        b"4 0 obj\n<< /Type /XRef /Size 5 /Root 1 0 R /W [1 4 2] /Length 33 /Filter /BrotliDecode >>\nstream\n",
+    );
+    pdf.extend_from_slice(COMPRESSED_XREF);
+    pdf.extend_from_slice(b"\nendstream\nendobj\nstartxref\n184\n%%EOF\n");
+    pdf
+}
+
+#[test]
+fn brotli_filter_decodes_and_honors_output_limit() {
+    let stream = brotli_stream(COMPRESSED_PAYLOAD);
+
+    assert_eq!(stream.decompressed_content().unwrap(), PAYLOAD);
+    assert_eq!(stream.decompressed_content_with_limit(PAYLOAD.len()).unwrap(), PAYLOAD);
+    assert!(matches!(
+        stream.decompressed_content_with_limit(PAYLOAD.len() - 1),
+        Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit })) if limit == PAYLOAD.len() - 1
+    ));
+}
+
+#[test]
+fn brotli_filter_is_bounded_before_the_next_filter_layer() {
+    let mut dict = Dictionary::new();
+    dict.set(
+        "Filter",
+        vec![Object::from("BrotliDecode"), Object::from("ASCIIHexDecode")],
+    );
+    let stream = Stream::new(dict, COMPRESSED_ASCII_HEX.to_vec());
+
+    assert_eq!(stream.decompressed_content_with_limit(11).unwrap(), b"Hello");
+    assert!(matches!(
+        stream.decompressed_content_with_limit(5),
+        Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit: 5 }))
+    ));
+}
+
+#[test]
+fn brotli_xref_stream_decodes_during_load_with_the_same_limit() {
+    let pdf = brotli_xref_pdf();
+    let document = Document::load_mem_with_options(&pdf, LoadOptions::with_max_decompressed_size(35)).unwrap();
+    assert_eq!(document.get_pages().len(), 1);
+
+    assert!(matches!(
+        Document::load_mem_with_options(&pdf, LoadOptions::with_max_decompressed_size(34)),
+        Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit: 34 }))
+    ));
+}

--- a/tests/brotli_decode.rs
+++ b/tests/brotli_decode.rs
@@ -72,3 +72,67 @@ fn brotli_xref_stream_decodes_during_load_with_the_same_limit() {
         Err(Error::Decompress(DecompressError::MemoryLimitExceeded { limit: 34 }))
     ));
 }
+
+fn brotli_compress(data: &[u8]) -> Vec<u8> {
+    use std::io::Write;
+
+    let mut writer = brotli::CompressorWriter::new(Vec::new(), 4096, 11, 22);
+    writer.write_all(data).unwrap();
+    writer.flush().unwrap();
+    writer.into_inner()
+}
+
+/// Build the raw cross-reference entries (`W [1 2 1]`, one row per object),
+/// then apply the PNG `Up` predictor (12) exactly as a producer would:
+/// every 4-byte row is prefixed with its filter byte and XOR-differenced
+/// against the previous row.
+fn predicted_xref_rows(offsets: &[u16]) -> Vec<u8> {
+    let mut rows: Vec<[u8; 4]> = vec![[0x00, 0x00, 0x00, 0xFF]]; // object 0: free, gen 65535
+    for &offset in offsets {
+        rows.push([0x01, (offset >> 8) as u8, offset as u8, 0x00]);
+    }
+
+    let mut payload = Vec::with_capacity(rows.len() * 5);
+    let mut previous = [0u8; 4];
+    for row in rows {
+        payload.push(0x02); // PNG Up filter
+        for (index, byte) in row.iter().enumerate() {
+            payload.push(byte.wrapping_sub(previous[index]));
+        }
+        previous = row;
+    }
+    payload
+}
+
+#[test]
+fn brotli_xref_stream_honors_the_flate_style_png_predictor() {
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.5\n");
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    pdf.extend_from_slice(b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>\nendobj\n");
+    let xref_offset = pdf.len() as u16;
+    let base = "%PDF-1.5\n".len() as u16;
+    let first = base;
+    let second = first + b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n".len() as u16;
+    let third = second + b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n".len() as u16;
+    let entries = predicted_xref_rows(&[first, second, third, xref_offset]);
+
+    let compressed = brotli_compress(&entries);
+    pdf.extend_from_slice(
+        format!(
+            "4 0 obj\n<< /Type /XRef /Size 5 /Root 1 0 R /W [1 2 1] /Filter /BrotliDecode \
+             /DecodeParms << /Predictor 12 /Columns 4 >> /Length {} >>\nstream\n",
+            compressed.len()
+        )
+        .as_bytes(),
+    );
+    pdf.extend_from_slice(&compressed);
+    pdf.extend_from_slice(format!("\nendstream\nendobj\nstartxref\n{xref_offset}\n%%EOF\n").as_bytes());
+
+    // The predictor must be applied after Brotli decompression: without it the
+    // xref entries are garbage and no object can be resolved.
+    let document = Document::load_mem(&pdf).unwrap();
+    assert_eq!(document.get_pages().len(), 1);
+    assert!(document.get_object((3, 0)).unwrap().as_dict().is_ok());
+}

--- a/tests/brotli_decode.rs
+++ b/tests/brotli_decode.rs
@@ -73,66 +73,20 @@ fn brotli_xref_stream_decodes_during_load_with_the_same_limit() {
     ));
 }
 
-fn brotli_compress(data: &[u8]) -> Vec<u8> {
-    use std::io::Write;
-
-    let mut writer = brotli::CompressorWriter::new(Vec::new(), 4096, 11, 22);
-    writer.write_all(data).unwrap();
-    writer.flush().unwrap();
-    writer.into_inner()
-}
-
-/// Build the raw cross-reference entries (`W [1 2 1]`, one row per object),
-/// then apply the PNG `Up` predictor (12) exactly as a producer would:
-/// every 4-byte row is prefixed with its filter byte and XOR-differenced
-/// against the previous row.
-fn predicted_xref_rows(offsets: &[u16]) -> Vec<u8> {
-    let mut rows: Vec<[u8; 4]> = vec![[0x00, 0x00, 0x00, 0xFF]]; // object 0: free, gen 65535
-    for &offset in offsets {
-        rows.push([0x01, (offset >> 8) as u8, offset as u8, 0x00]);
-    }
-
-    let mut payload = Vec::with_capacity(rows.len() * 5);
-    let mut previous = [0u8; 4];
-    for row in rows {
-        payload.push(0x02); // PNG Up filter
-        for (index, byte) in row.iter().enumerate() {
-            payload.push(byte.wrapping_sub(previous[index]));
-        }
-        previous = row;
-    }
-    payload
-}
-
 #[test]
-fn brotli_xref_stream_honors_the_flate_style_png_predictor() {
-    let mut pdf = Vec::new();
-    pdf.extend_from_slice(b"%PDF-1.5\n");
-    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
-    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
-    pdf.extend_from_slice(b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>\nendobj\n");
-    let xref_offset = pdf.len() as u16;
-    let base = "%PDF-1.5\n".len() as u16;
-    let first = base;
-    let second = first + b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n".len() as u16;
-    let third = second + b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n".len() as u16;
-    let entries = predicted_xref_rows(&[first, second, third, xref_offset]);
+fn brotli_filter_ignores_decode_parms() {
+    // Producers do not pair /BrotliDecode with predictors — the PDF
+    // Association's prototype files carry no /DecodeParms on any Brotli
+    // stream (their xref streams store raw W entries) — and pdf.js/pypdf
+    // likewise ignore the parameters. The decompressed bytes must therefore
+    // pass through unmodified even when a /DecodeParms dictionary is present.
+    let mut parms = Dictionary::new();
+    parms.set("Predictor", 12);
+    parms.set("Columns", 4);
+    let mut dict = Dictionary::new();
+    dict.set("Filter", Object::from("BrotliDecode"));
+    dict.set("DecodeParms", Object::Dictionary(parms));
+    let stream = Stream::new(dict, COMPRESSED_PAYLOAD.to_vec());
 
-    let compressed = brotli_compress(&entries);
-    pdf.extend_from_slice(
-        format!(
-            "4 0 obj\n<< /Type /XRef /Size 5 /Root 1 0 R /W [1 2 1] /Filter /BrotliDecode \
-             /DecodeParms << /Predictor 12 /Columns 4 >> /Length {} >>\nstream\n",
-            compressed.len()
-        )
-        .as_bytes(),
-    );
-    pdf.extend_from_slice(&compressed);
-    pdf.extend_from_slice(format!("\nendstream\nendobj\nstartxref\n{xref_offset}\n%%EOF\n").as_bytes());
-
-    // The predictor must be applied after Brotli decompression: without it the
-    // xref entries are garbage and no object can be resolved.
-    let document = Document::load_mem(&pdf).unwrap();
-    assert_eq!(document.get_pages().len(), 1);
-    assert!(document.get_object((3, 0)).unwrap().as_dict().is_ok());
+    assert_eq!(stream.decompressed_content().unwrap(), PAYLOAD);
 }


### PR DESCRIPTION
## Summary

Adds decoding support for streams compressed with the `/BrotliDecode` filter. Previously such streams fell through to `Error::Unimplemented`; they now decompress via the pure-Rust [`brotli-decompressor`](https://crates.io/crates/brotli-decompressor) crate, subject to the same memory-limit guard as the other filters. Decoding is intentionally strict (a corrupt stream fails rather than yielding partial output — there is no raw-deflate-style fallback), and `/DecodeParms` are ignored, see below.

## Context

- The PDF Association has published `/BrotliDecode` as an industry extension to ISO 32000-2: ["Brotli compression in PDF 2.0"](https://pdfa.org/resource/extension-brotli), registered in [`pdf-association/pdf-extensions`](https://github.com/pdf-association/pdf-extensions) under prefix `PDFa`, BaseVersion 2.0, ExtensionLevel 1. It introduces `BrotliDecode` for stream data compressed with Brotli as defined in [RFC 7932](https://www.rfc-editor.org/rfc/rfc7932). Incorporation into PDF 2.0 is expected; pdfium and pdf.js already implement it.
- Correction: an earlier revision of this description cited ISO/TS 32001 for this filter. That technical specification actually covers SHA-3/SHAKE256 hash support in PDF 2.0 ([iso.org/standard/45874](https://www.iso.org/standard/45874.html)); it has nothing to do with Brotli. The Brotli extension has no assigned ISO number yet.
- `brotli-decompressor` 5.0 is pure Rust, decode-only, and `no_std`-capable; its only transitive dependencies are `alloc-no-stdlib` / `alloc-stdlib`, so it stays wasm-safe.

## /DecodeParms handling

This PR follows the observable producer/implementer consensus and **ignores** `/DecodeParms`, pinned by a test. One extra reason to ignore them here: lopdf passes a single dict-form `/DecodeParms` to *every* filter of a chain, so applying predictors after Brotli would double-apply a Flate-layer predictor on e.g. `/Filter [/BrotliDecode /FlateDecode]`. If you'd rather match MuPDF's defensive behavior instead, I'm happy to flip it.

## Dependency note

This makes `brotli-decompressor` a mandatory dependency. If you'd prefer to keep the default dependency footprint unchanged, I can put it behind a feature gate (`brotli = ["dep:brotli-decompressor"]`) with the filter arm returning `Unimplemented` when disabled — happy to switch.
