### PR TITLE
fix: recover stream /Length mismatches within xref-bounded objects

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -338,7 +338,43 @@ pub(crate) fn dict_dup(input: ParserInput) -> NomResult<Dictionary> {
     .parse(input)
 }
 
-fn stream<'a>(input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSet<ObjectId>) -> NomResult<'a, Object> {
+/// Recover the sole EOL-framed `endstream` immediately followed by `endobj`.
+/// The caller must bound `input` to the current indirect-object context.
+fn recover_stream_length(input: ParserInput) -> Option<(ParserInput, ParserInput)> {
+    const ENDSTREAM: &[u8] = b"endstream";
+    let mut recovered = None;
+
+    for (position, candidate) in input.windows(ENDSTREAM.len()).enumerate() {
+        if candidate != ENDSTREAM {
+            continue;
+        }
+
+        let data_end = if input[..position].ends_with(b"\r\n") {
+            position - 2
+        } else if input[..position].ends_with(b"\n") || input[..position].ends_with(b"\r") {
+            position - 1
+        } else {
+            continue;
+        };
+        let after_endstream = &input[position + ENDSTREAM.len()..];
+        let Ok((after_endobj, _)) = preceded(space, tag(&b"endobj"[..])).parse(after_endstream) else {
+            continue;
+        };
+        if after_endobj.first().is_some_and(|&byte| !is_whitespace(byte)) {
+            continue;
+        }
+        if recovered.is_some() {
+            return None;
+        }
+        recovered = Some((after_endstream, &input[..data_end]));
+    }
+
+    recovered
+}
+
+fn stream<'a>(
+    input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSet<ObjectId>, recover_length: bool,
+) -> NomResult<'a, Object> {
     let (i, dict) = terminated(dictionary, (space, tag(&b"stream"[..]), space0, eol)).parse(input)?;
 
     if let Ok(length) = dict.get(b"Length").and_then(|value| {
@@ -352,8 +388,23 @@ fn stream<'a>(input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSe
             // artificial error kind is created to allow descriptive nom errors
             return Err(nom::Err::Failure(NomError::from_error_kind(i, ErrorKind::LengthValue)));
         }
-        let (i, data) = terminated(take(length as usize), pair(opt(eol), tag(&b"endstream"[..]))).parse(i)?;
-        Ok((i, Object::Stream(Stream::new(dict, data.to_vec()))))
+        let Ok(length) = usize::try_from(length) else {
+            return Err(nom::Err::Failure(NomError::from_error_kind(i, ErrorKind::LengthValue)));
+        };
+        match terminated(take(length), pair(opt(eol), tag(&b"endstream"[..]))).parse(i) {
+            Ok((remaining, data)) => Ok((remaining, Object::Stream(Stream::new(dict, data.to_vec())))),
+            Err(_) if recover_length && !reader.strict => {
+                let Some((remaining, data)) = recover_stream_length(i) else {
+                    return Err(nom::Err::Failure(NomError::from_error_kind(i, ErrorKind::LengthValue)));
+                };
+                log::warn!(
+                    "Stream Length is {length}, but the unambiguous object boundary gives {} bytes; using the recovered length.",
+                    data.len()
+                );
+                Ok((remaining, Object::Stream(Stream::new(dict, data.to_vec()))))
+            }
+            Err(_) => Err(nom::Err::Failure(NomError::from_error_kind(i, ErrorKind::LengthValue))),
+        }
     } else {
         // Return position relative to the start of the stream dictionary.
         Ok((i, Object::Stream(Stream::with_position(dict, input.len() - i.len()))))
@@ -406,10 +457,12 @@ pub fn direct_object(input: ParserInput) -> Option<Object> {
     strip_nom(_direct_object(crate::reader::MAX_NESTING_DEPTH)(input))
 }
 
-fn object<'a>(input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSet<ObjectId>) -> NomResult<'a, Object> {
+fn object<'a>(
+    input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSet<ObjectId>, recover_stream_length: bool,
+) -> NomResult<'a, Object> {
     terminated(
         alt((
-            |input| stream(input, reader, already_seen),
+            |input| stream(input, reader, already_seen, recover_stream_length),
             _direct_objects(crate::reader::MAX_NESTING_DEPTH),
         )),
         space,
@@ -421,7 +474,7 @@ pub fn indirect_object(
     input: ParserInput, offset: usize, expected_id: Option<ObjectId>, reader: &Reader,
     already_seen: &mut HashSet<ObjectId>,
 ) -> crate::Result<(ObjectId, Object)> {
-    let (id, mut object) = _indirect_object(input.take_from(offset), offset, expected_id, reader, already_seen)?;
+    let (id, mut object) = _indirect_object(input.take_from(offset), offset, expected_id, reader, already_seen, true)?;
 
     offset_stream(&mut object, offset);
 
@@ -430,7 +483,7 @@ pub fn indirect_object(
 
 fn _indirect_object<'a>(
     input: ParserInput<'a>, offset: usize, expected_id: Option<ObjectId>, reader: &Reader,
-    already_seen: &mut HashSet<ObjectId>,
+    already_seen: &mut HashSet<ObjectId>, recover_stream_length: bool,
 ) -> crate::Result<(ObjectId, Object)> {
     let (i, (_, object_id)) = terminated((space, object_id), pair(tag(&b"obj"[..]), space))
         .parse(input)
@@ -443,7 +496,7 @@ fn _indirect_object<'a>(
 
     let object_offset = input.len() - i.len();
     let (_, mut object) = terminated(
-        |i: ParserInput<'a>| object(i, reader, already_seen),
+        |i: ParserInput<'a>| object(i, reader, already_seen, recover_stream_length),
         (space, opt(tag(&b"endobj"[..])), space),
     )
     .parse(i)
@@ -566,7 +619,7 @@ pub fn xref_and_trailer(input: ParserInput, reader: &Reader) -> crate::Result<(X
     alt((
         xref_trailer,
         (|input| {
-            _indirect_object(input, 0, None, reader, &mut HashSet::new())
+            _indirect_object(input, 0, None, reader, &mut HashSet::new(), false)
                 .map(|(_, obj)| {
                     let res = match obj {
                         Object::Stream(stream) => decode_xref_stream_with_limit(stream, reader.max_decompressed_size),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -339,7 +339,8 @@ pub(crate) fn dict_dup(input: ParserInput) -> NomResult<Dictionary> {
 }
 
 /// Recover the sole EOL-framed `endstream` immediately followed by `endobj`.
-/// The caller must bound `input` to the current indirect-object context.
+/// The caller must pass only bytes up to the current indirect-object boundary
+/// so the scan cannot cross into a neighboring object.
 fn recover_stream_length(input: ParserInput) -> Option<(ParserInput, ParserInput)> {
     const ENDSTREAM: &[u8] = b"endstream";
     let mut recovered = None;
@@ -374,6 +375,7 @@ fn recover_stream_length(input: ParserInput) -> Option<(ParserInput, ParserInput
 
 fn stream<'a>(
     input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSet<ObjectId>, recover_length: bool,
+    recovery_bound: Option<usize>,
 ) -> NomResult<'a, Object> {
     let (i, dict) = terminated(dictionary, (space, tag(&b"stream"[..]), space0, eol)).parse(input)?;
 
@@ -394,7 +396,13 @@ fn stream<'a>(
         match terminated(take(length), pair(opt(eol), tag(&b"endstream"[..]))).parse(i) {
             Ok((remaining, data)) => Ok((remaining, Object::Stream(Stream::new(dict, data.to_vec())))),
             Err(_) if recover_length && !reader.strict => {
-                let Some((remaining, data)) = recover_stream_length(i) else {
+                // The scan must not cross into a neighbouring indirect object,
+                // so it stops at the xref-derived bound; parsing itself stays
+                // unbounded. The bound arrived here as `input.len() - end`, and
+                // `i` starts `input.len() - i.len()` bytes later, so the scan
+                // covers exactly the first `i.len() - bound` bytes of `i`.
+                let scan_end = recovery_bound.map_or(i.len(), |bound| i.len().saturating_sub(bound));
+                let Some((remaining, data)) = recover_stream_length(&i[..scan_end]) else {
                     return Err(nom::Err::Failure(NomError::from_error_kind(i, ErrorKind::LengthValue)));
                 };
                 log::warn!(
@@ -459,10 +467,11 @@ pub fn direct_object(input: ParserInput) -> Option<Object> {
 
 fn object<'a>(
     input: ParserInput<'a>, reader: &Reader, already_seen: &mut HashSet<ObjectId>, recover_stream_length: bool,
+    recovery_bound: Option<usize>,
 ) -> NomResult<'a, Object> {
     terminated(
         alt((
-            |input| stream(input, reader, already_seen, recover_stream_length),
+            |input| stream(input, reader, already_seen, recover_stream_length, recovery_bound),
             _direct_objects(crate::reader::MAX_NESTING_DEPTH),
         )),
         space,
@@ -472,9 +481,20 @@ fn object<'a>(
 
 pub fn indirect_object(
     input: ParserInput, offset: usize, expected_id: Option<ObjectId>, reader: &Reader,
-    already_seen: &mut HashSet<ObjectId>,
+    already_seen: &mut HashSet<ObjectId>, recovery_bound: Option<usize>,
 ) -> crate::Result<(ObjectId, Object)> {
-    let (id, mut object) = _indirect_object(input.take_from(offset), offset, expected_id, reader, already_seen, true)?;
+    // Every downstream slice is a suffix of `input`, so express the absolute
+    // end offset as the maximum length a suffix may have.
+    let recovery_bound = recovery_bound.map(|end| input.len().saturating_sub(end));
+    let (id, mut object) = _indirect_object(
+        input.take_from(offset),
+        offset,
+        expected_id,
+        reader,
+        already_seen,
+        true,
+        recovery_bound,
+    )?;
 
     offset_stream(&mut object, offset);
 
@@ -483,7 +503,7 @@ pub fn indirect_object(
 
 fn _indirect_object<'a>(
     input: ParserInput<'a>, offset: usize, expected_id: Option<ObjectId>, reader: &Reader,
-    already_seen: &mut HashSet<ObjectId>, recover_stream_length: bool,
+    already_seen: &mut HashSet<ObjectId>, recover_stream_length: bool, recovery_bound: Option<usize>,
 ) -> crate::Result<(ObjectId, Object)> {
     let (i, (_, object_id)) = terminated((space, object_id), pair(tag(&b"obj"[..]), space))
         .parse(input)
@@ -496,7 +516,7 @@ fn _indirect_object<'a>(
 
     let object_offset = input.len() - i.len();
     let (_, mut object) = terminated(
-        |i: ParserInput<'a>| object(i, reader, already_seen, recover_stream_length),
+        |i: ParserInput<'a>| object(i, reader, already_seen, recover_stream_length, recovery_bound),
         (space, opt(tag(&b"endobj"[..])), space),
     )
     .parse(i)
@@ -619,7 +639,7 @@ pub fn xref_and_trailer(input: ParserInput, reader: &Reader) -> crate::Result<(X
     alt((
         xref_trailer,
         (|input| {
-            _indirect_object(input, 0, None, reader, &mut HashSet::new(), false)
+            _indirect_object(input, 0, None, reader, &mut HashSet::new(), false, None)
                 .map(|(_, obj)| {
                     let res = match obj {
                         Object::Stream(stream) => decode_xref_stream_with_limit(stream, reader.max_decompressed_size),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -993,31 +993,51 @@ impl Reader<'_> {
                 }
             })
             .collect();
+        let mut normal_offsets: Vec<usize> = self
+            .document
+            .reference_table
+            .entries
+            .values()
+            .filter_map(|entry| match entry {
+                XrefEntry::Normal { offset, .. } => Some(*offset as usize),
+                _ => None,
+            })
+            .collect();
+        normal_offsets.sort_unstable();
+        normal_offsets.dedup();
 
-        let entries_filter_map = |(_, entry): (&_, &_)| {
+        let entries_filter_map = |(_, entry): (&_, &_)| -> Result<Option<(ObjectId, Object)>> {
             if let XrefEntry::Normal { offset, .. } = *entry {
                 // read_object now handles decryption internally
-                let result = self.read_object(offset as usize, None, &mut HashSet::new());
+                let offset = offset as usize;
+                let next_index = normal_offsets.partition_point(|&next| next <= offset);
+                let next_object = normal_offsets.get(next_index).copied();
+                let end = self.object_end(offset, next_object);
+                let result = self.read_object_to(offset, end, None, &mut HashSet::new());
                 let (object_id, mut object) = match result {
                     Ok(obj) => obj,
                     Err(e) => {
-                        // Log error but continue
+                        // Lenient loading logs and skips malformed objects; strict loading fails.
                         if is_encrypted {
                             // Expected for some encrypted objects - but log which ones
                             warn!("Skipping encrypted object at offset {}: {:?}", offset, e);
                         } else {
                             error!("Object load error at offset {}: {e:?}", offset);
                         }
-                        return None;
+                        return if self.strict { Err(e) } else { Ok(None) };
                     }
                 };
-                if let Some(filter_func) = filter_func {
-                    filter_func(object_id, &mut object)?;
+                if let Some(filter_func) = filter_func
+                    && filter_func(object_id, &mut object).is_none()
+                {
+                    return Ok(None);
                 }
 
                 if let Ok(stream) = object.as_stream() {
                     if stream.dict.has_type(b"ObjStm") && !is_encrypted {
-                        let obj_stream = ObjectStream::new_with_limit(stream, self.max_decompressed_size).ok()?;
+                        let Ok(obj_stream) = ObjectStream::new_with_limit(stream, self.max_decompressed_size) else {
+                            return Ok(None);
+                        };
                         let container_id = object_id.0;
                         let mut object_streams = object_streams.lock().unwrap();
                         if let Some(filter_func) = filter_func {
@@ -1045,31 +1065,33 @@ impl Reader<'_> {
                     }
                 }
 
-                Some((object_id, object))
+                Ok(Some((object_id, object)))
             } else {
-                None
+                Ok(None)
             }
         };
 
         #[cfg(feature = "rayon")]
         {
-            self.document.objects = self
+            let objects = self
                 .document
                 .reference_table
                 .entries
                 .par_iter()
-                .filter_map(entries_filter_map)
-                .collect();
+                .map(entries_filter_map)
+                .collect::<Result<Vec<_>>>()?;
+            self.document.objects = objects.into_iter().flatten().collect();
         }
         #[cfg(not(feature = "rayon"))]
         {
-            self.document.objects = self
+            let objects = self
                 .document
                 .reference_table
                 .entries
                 .iter()
-                .filter_map(entries_filter_map)
-                .collect();
+                .map(entries_filter_map)
+                .collect::<Result<Vec<_>>>()?;
+            self.document.objects = objects.into_iter().flatten().collect();
         }
 
         // Only add entries, but never replace entries
@@ -1317,12 +1339,40 @@ impl Reader<'_> {
     fn read_object(
         &self, offset: usize, expected_id: Option<ObjectId>, already_seen: &mut HashSet<ObjectId>,
     ) -> Result<(ObjectId, Object)> {
-        if offset > self.buffer.len() {
+        let next_object = self
+            .document
+            .reference_table
+            .entries
+            .values()
+            .filter_map(|entry| match entry {
+                XrefEntry::Normal { offset: next, .. } if *next as usize > offset => Some(*next as usize),
+                _ => None,
+            })
+            .min();
+        let end = self.object_end(offset, next_object);
+        self.read_object_to(offset, end, expected_id, already_seen)
+    }
+
+    fn object_end(&self, offset: usize, next_object: Option<usize>) -> usize {
+        let xref_start = (self.document.xref_start > offset).then_some(self.document.xref_start);
+        next_object
+            .into_iter()
+            .chain(xref_start)
+            .min()
+            .unwrap_or(self.buffer.len())
+            .min(self.buffer.len())
+    }
+
+    fn read_object_to(
+        &self, offset: usize, end: usize, expected_id: Option<ObjectId>, already_seen: &mut HashSet<ObjectId>,
+    ) -> Result<(ObjectId, Object)> {
+        if offset > end || end > self.buffer.len() {
             return Err(Error::InvalidOffset(offset));
         }
 
-        // Just parse without decryption - we'll decrypt later
-        parser::indirect_object(self.buffer, offset, expected_id, self, already_seen)
+        // The xref-derived upper bound keeps malformed stream recovery inside
+        // the current indirect-object context.
+        parser::indirect_object(&self.buffer[..end], offset, expected_id, self, already_seen)
     }
 
     /// Parse the cross-reference section recorded at `offset`, first correcting

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -987,7 +987,7 @@ impl Reader<'_> {
 
     fn parse_raw_object(&self, raw_bytes: &[u8]) -> Result<(ObjectId, Object)> {
         // Parse the raw bytes as an indirect object
-        parser::indirect_object(raw_bytes, 0, None, self, &mut HashSet::new())
+        parser::indirect_object(raw_bytes, 0, None, self, &mut HashSet::new(), None)
     }
 
     /// Install a fully merged cross-reference table and derive its sorted
@@ -1042,13 +1042,15 @@ impl Reader<'_> {
                 let (object_id, mut object) = match result {
                     Ok(obj) => obj,
                     Err(e) => {
-                        // Lenient loading logs and skips malformed objects; strict loading fails.
                         if is_encrypted {
-                            // Expected for some encrypted objects - but log which ones
+                            // Expected for some encrypted objects - but log which
+                            // ones. These failures stay non-fatal even in strict
+                            // mode because they do not indicate a malformed file.
                             warn!("Skipping encrypted object at offset {}: {:?}", offset, e);
-                        } else {
-                            error!("Object load error at offset {}: {e:?}", offset);
+                            return Ok(None);
                         }
+                        // Lenient loading logs and skips malformed objects; strict loading fails.
+                        error!("Object load error at offset {}: {e:?}", offset);
                         return if self.strict { Err(e) } else { Ok(None) };
                     }
                 };
@@ -1060,8 +1062,14 @@ impl Reader<'_> {
 
                 if let Ok(stream) = object.as_stream() {
                     if stream.dict.has_type(b"ObjStm") && !is_encrypted {
-                        let Ok(obj_stream) = ObjectStream::new_with_limit(stream, self.max_decompressed_size) else {
-                            return Ok(None);
+                        let obj_stream = match ObjectStream::new_with_limit(stream, self.max_decompressed_size) {
+                            Ok(obj_stream) => obj_stream,
+                            // Not an encryption-related loss, so it obeys the same
+                            // strict-mode policy as any other load error.
+                            Err(e) => {
+                                error!("Object stream load error for {object_id:?}: {e:?}");
+                                return if self.strict { Err(e) } else { Ok(None) };
+                            }
                         };
                         let container_id = object_id.0;
                         let mut object_streams = object_streams.lock().unwrap();
@@ -1098,25 +1106,25 @@ impl Reader<'_> {
 
         #[cfg(feature = "rayon")]
         {
-            let objects = self
+            self.document.objects = self
                 .document
                 .reference_table
                 .entries
                 .par_iter()
                 .map(entries_filter_map)
-                .collect::<Result<Vec<_>>>()?;
-            self.document.objects = objects.into_iter().flatten().collect();
+                .filter_map(Result::transpose)
+                .collect::<Result<BTreeMap<_, _>>>()?;
         }
         #[cfg(not(feature = "rayon"))]
         {
-            let objects = self
+            self.document.objects = self
                 .document
                 .reference_table
                 .entries
                 .iter()
                 .map(entries_filter_map)
-                .collect::<Result<Vec<_>>>()?;
-            self.document.objects = objects.into_iter().flatten().collect();
+                .filter_map(Result::transpose)
+                .collect::<Result<BTreeMap<_, _>>>()?;
         }
 
         // Only add entries, but never replace entries
@@ -1386,9 +1394,10 @@ impl Reader<'_> {
             return Err(Error::InvalidOffset(offset));
         }
 
-        // The xref-derived upper bound keeps malformed stream recovery inside
-        // the current indirect-object context.
-        parser::indirect_object(&self.buffer[..end], offset, expected_id, self, already_seen)
+        // Objects are parsed against the full buffer so a wrong *neighbor*
+        // xref offset cannot truncate a well-formed object; `end` only limits
+        // how far malformed-stream length recovery may scan.
+        parser::indirect_object(self.buffer, offset, expected_id, self, already_seen, Some(end))
     }
 
     /// Parse the cross-reference section recorded at `offset`, first correcting

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -86,6 +86,7 @@ impl Document {
             password: options.password,
             strict: options.strict,
             max_decompressed_size: options.max_decompressed_size,
+            normal_offsets: Vec::new(),
         }
         .read(options.filter)
     }
@@ -105,6 +106,7 @@ impl Document {
             password: options.password,
             strict: options.strict,
             max_decompressed_size: options.max_decompressed_size,
+            normal_offsets: Vec::new(),
         }
         .read(options.filter)
     }
@@ -155,6 +157,7 @@ impl Document {
             password: None,
             strict: false,
             max_decompressed_size: None,
+            normal_offsets: Vec::new(),
         }
         .read_metadata()
     }
@@ -170,6 +173,7 @@ impl Document {
             password: Some(password.to_string()),
             strict: false,
             max_decompressed_size: None,
+            normal_offsets: Vec::new(),
         }
         .read_metadata()
     }
@@ -188,6 +192,7 @@ impl Document {
             password,
             strict: false,
             max_decompressed_size: None,
+            normal_offsets: Vec::new(),
         }
         .read_metadata()
     }
@@ -231,6 +236,7 @@ impl Document {
             password: options.password,
             strict: options.strict,
             max_decompressed_size: options.max_decompressed_size,
+            normal_offsets: Vec::new(),
         }
         .read(options.filter)
     }
@@ -250,6 +256,7 @@ impl Document {
             password: options.password,
             strict: options.strict,
             max_decompressed_size: options.max_decompressed_size,
+            normal_offsets: Vec::new(),
         }
         .read(options.filter)
     }
@@ -296,6 +303,7 @@ impl Document {
             password: None,
             strict: false,
             max_decompressed_size: None,
+            normal_offsets: Vec::new(),
         }
         .read_metadata()
     }
@@ -311,6 +319,7 @@ impl Document {
             password: Some(password.to_string()),
             strict: false,
             max_decompressed_size: None,
+            normal_offsets: Vec::new(),
         }
         .read_metadata()
     }
@@ -331,6 +340,7 @@ impl Document {
             password,
             strict: false,
             max_decompressed_size: None,
+            normal_offsets: Vec::new(),
         }
         .read_metadata()
     }
@@ -348,6 +358,7 @@ impl TryInto<Document> for &[u8] {
             password: None,
             strict: false,
             max_decompressed_size: None,
+            normal_offsets: Vec::new(),
         }
         .read(None)
     }
@@ -381,6 +392,7 @@ impl IncrementalDocument {
             password: None,
             strict: false,
             max_decompressed_size: None,
+            normal_offsets: Vec::new(),
         }
         .read(None)?;
 
@@ -424,6 +436,7 @@ impl IncrementalDocument {
             password: None,
             strict: false,
             max_decompressed_size: None,
+            normal_offsets: Vec::new(),
         }
         .read(None)?;
 
@@ -448,6 +461,7 @@ impl TryInto<IncrementalDocument> for &[u8] {
             password: None,
             strict: false,
             max_decompressed_size: None,
+            normal_offsets: Vec::new(),
         }
         .read(None)?;
 
@@ -467,6 +481,11 @@ pub struct Reader<'a> {
     /// `None` (the default) applies no limit; set it to guard against
     /// decompression bombs. See [`crate::LoadOptions`].
     pub max_decompressed_size: Option<usize>,
+    /// Sorted unique byte offsets of every `XrefEntry::Normal` entry in the
+    /// final cross-reference table. Built once when the table is complete so
+    /// object-boundary lookups can binary-search the successor offset instead
+    /// of scanning all xref entries on each call.
+    normal_offsets: Vec<usize>,
 }
 
 /// Maximum allowed embedding of literal strings.
@@ -610,9 +629,8 @@ impl Reader<'_> {
             xref.size = xref_entry_count;
         }
 
-        self.document.reference_table = xref;
+        self.set_reference_table(xref);
         self.document.trailer = trailer.clone();
-
         let encrypted = self.document.trailer.get(b"Encrypt").is_ok();
         // For encrypted PDFs, set up decryption so the Info dictionary can be
         // read. If the document is protected by a password we cannot supply,
@@ -852,7 +870,7 @@ impl Reader<'_> {
         self.document.version = version;
         self.document.max_id = xref.size - 1;
         self.document.trailer = trailer;
-        self.document.reference_table = xref;
+        self.set_reference_table(xref);
 
         // Check if encrypted
         let is_encrypted = self.document.trailer.get(b"Encrypt").is_ok();
@@ -972,6 +990,24 @@ impl Reader<'_> {
         parser::indirect_object(raw_bytes, 0, None, self, &mut HashSet::new())
     }
 
+    /// Install a fully merged cross-reference table and derive its sorted
+    /// offset index. All later object-boundary lookups go through that index,
+    /// so it must be rebuilt whenever the table is replaced.
+    fn set_reference_table(&mut self, xref: Xref) {
+        let mut normal_offsets: Vec<usize> = xref
+            .entries
+            .values()
+            .filter_map(|entry| match entry {
+                XrefEntry::Normal { offset, .. } => Some(*offset as usize),
+                _ => None,
+            })
+            .collect();
+        normal_offsets.sort_unstable();
+        normal_offsets.dedup();
+        self.normal_offsets = normal_offsets;
+        self.document.reference_table = xref;
+    }
+
     fn load_objects_raw(&mut self, filter_func: Option<FilterFunc>) -> Result<()> {
         let is_encrypted = self.document.trailer.get(b"Encrypt").is_ok();
         let zero_length_streams = Mutex::new(vec![]);
@@ -993,18 +1029,7 @@ impl Reader<'_> {
                 }
             })
             .collect();
-        let mut normal_offsets: Vec<usize> = self
-            .document
-            .reference_table
-            .entries
-            .values()
-            .filter_map(|entry| match entry {
-                XrefEntry::Normal { offset, .. } => Some(*offset as usize),
-                _ => None,
-            })
-            .collect();
-        normal_offsets.sort_unstable();
-        normal_offsets.dedup();
+        let normal_offsets = &self.normal_offsets;
 
         let entries_filter_map = |(_, entry): (&_, &_)| -> Result<Option<(ObjectId, Object)>> {
             if let XrefEntry::Normal { offset, .. } = *entry {
@@ -1339,17 +1364,8 @@ impl Reader<'_> {
     fn read_object(
         &self, offset: usize, expected_id: Option<ObjectId>, already_seen: &mut HashSet<ObjectId>,
     ) -> Result<(ObjectId, Object)> {
-        let next_object = self
-            .document
-            .reference_table
-            .entries
-            .values()
-            .filter_map(|entry| match entry {
-                XrefEntry::Normal { offset: next, .. } if *next as usize > offset => Some(*next as usize),
-                _ => None,
-            })
-            .min();
-        let end = self.object_end(offset, next_object);
+        let next_index = self.normal_offsets.partition_point(|&next| next <= offset);
+        let end = self.object_end(offset, self.normal_offsets.get(next_index).copied());
         self.read_object_to(offset, end, expected_id, already_seen)
     }
 

--- a/tests/stream_length_recovery.rs
+++ b/tests/stream_length_recovery.rs
@@ -1,0 +1,84 @@
+use lopdf::{Document, LoadOptions, Object};
+
+fn pdf_with_stream(declared_length: usize, content: &[u8], trailer: &[u8]) -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.7\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] /Resources << /XObject << /Im0 4 0 R >> >> >>\nendobj\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        format!(
+            "4 0 obj\n<< /Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB \
+             /BitsPerComponent 8 /Filter [/FlateDecode /DCTDecode] /Length {declared_length} >>\nstream\n"
+        )
+        .as_bytes(),
+    );
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(trailer);
+
+    let xref_offset = pdf.len();
+    pdf.extend_from_slice(b"xref\n0 5\n0000000000 65535 f \n");
+    for offset in offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(format!("trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n").as_bytes());
+    pdf
+}
+
+#[test]
+fn lenient_load_recovers_an_unambiguous_stream_length_mismatch() {
+    let content = b"actual stream bytes";
+    let pdf = pdf_with_stream(0, content, b"\nendstream\nendobj\n");
+
+    let document = Document::load_mem(&pdf).unwrap();
+    let Object::Stream(stream) = document.get_object((4, 0)).unwrap() else {
+        panic!("recovered object must remain a stream");
+    };
+    assert_eq!(stream.content, content);
+    assert_eq!(
+        stream.dict.get(b"Length").unwrap().as_i64().unwrap(),
+        content.len() as i64
+    );
+}
+
+#[test]
+fn strict_load_rejects_a_stream_length_mismatch() {
+    let content = b"actual stream bytes";
+    let malformed = pdf_with_stream(0, content, b"\nendstream\nendobj\n");
+    let conforming = pdf_with_stream(content.len(), content, b"\nendstream\nendobj\n");
+    let strict = LoadOptions {
+        strict: true,
+        ..Default::default()
+    };
+
+    assert!(Document::load_mem_with_options(&conforming, strict.clone()).is_ok());
+    assert!(Document::load_mem_with_options(&malformed, strict).is_err());
+}
+
+#[test]
+fn lenient_load_does_not_guess_an_ambiguous_stream_boundary() {
+    let pdf = pdf_with_stream(
+        0,
+        b"first candidate\nendstream\nendobj\nbytes after the false boundary",
+        b"\nendstream\nendobj\n",
+    );
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert!(document.get_object((4, 0)).is_err());
+}
+
+#[test]
+fn lenient_load_does_not_recover_without_endstream() {
+    let pdf = pdf_with_stream(0, b"unterminated stream bytes", b"\nendobj\n");
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert!(document.get_object((4, 0)).is_err());
+}

--- a/tests/stream_length_recovery.rs
+++ b/tests/stream_length_recovery.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use lopdf::{Document, LoadOptions, Object};
 
 fn pdf_with_stream(declared_length: usize, content: &[u8], trailer: &[u8]) -> Vec<u8> {
@@ -80,5 +82,172 @@ fn lenient_load_does_not_recover_without_endstream() {
     let pdf = pdf_with_stream(0, b"unterminated stream bytes", b"\nendobj\n");
 
     let document = Document::load_mem(&pdf).unwrap();
+    assert!(document.get_object((4, 0)).is_err());
+}
+
+/// Assemble a PDF from whole `"<id> 0 obj ... endobj"` blobs laid out in the
+/// given order. `xref_overrides` lets tests record an offset that differs from
+/// the physical one; the returned map holds the true physical offsets.
+fn pdf_from_objects(objects: &[(u32, &[u8])], xref_overrides: &[(u32, usize)]) -> (Vec<u8>, HashMap<u32, usize>) {
+    let mut pdf = Vec::new();
+    let mut physical = HashMap::new();
+
+    pdf.extend_from_slice(b"%PDF-1.7\n");
+    for (id, body) in objects {
+        physical.insert(*id, pdf.len());
+        pdf.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        pdf.extend_from_slice(body);
+        pdf.extend_from_slice(b"endobj\n");
+    }
+
+    let xref_offset = pdf.len();
+    let size = objects.iter().map(|(id, _)| *id).max().unwrap_or(0) + 1;
+    pdf.extend_from_slice(b"xref\n");
+    pdf.extend_from_slice(format!("0 {size}\n0000000000 65535 f \n").as_bytes());
+    for object_number in 1..size {
+        let offset = xref_overrides
+            .iter()
+            .find(|&&(id, _)| id == object_number)
+            .map(|&(_, offset)| offset)
+            .or_else(|| physical.get(&object_number).copied())
+            .expect("xref entry missing for object");
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n").as_bytes(),
+    );
+    (pdf, physical)
+}
+
+fn catalog() -> &'static [u8] {
+    b"<< /Type /Catalog /Pages 2 0 R >>\n"
+}
+
+fn pages(kids: &str) -> Vec<u8> {
+    format!("<< /Type /Pages /Kids [{kids}] /Count 1 >>\n").into_bytes()
+}
+
+fn page(xobjects: &str) -> Vec<u8> {
+    format!("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] /Resources << /XObject << {xobjects} >> >> >>\n")
+        .into_bytes()
+}
+
+/// Body of an image stream object with a *correct* `/Length`, ending right
+/// before the `endobj` keyword appended by `pdf_from_objects`.
+fn image_stream_body(content: &[u8]) -> Vec<u8> {
+    let mut body = format!(
+        "<< /Type /XObject /Subtype /Image /Width {} /Height 1 /ColorSpace /DeviceRGB \
+         /BitsPerComponent 8 /Length {} >>\nstream\n",
+        content.len() / 3,
+        content.len()
+    )
+    .into_bytes();
+    body.extend_from_slice(content);
+    body.extend_from_slice(b"\nendstream\n");
+    body
+}
+
+#[test]
+fn accurate_but_out_of_order_xref_offsets_load_every_object() {
+    // Physical order: catalog, pages, image stream, page. The xref rows are
+    // still emitted in ascending object-number order, so the recorded offsets
+    // do not increase in file order.
+    let content = vec![b'A'; 48];
+    let objects: Vec<(u32, Vec<u8>)> = vec![
+        (1, catalog().to_vec()),
+        (2, pages("3 0 R")),
+        (4, image_stream_body(&content)),
+        (3, page("/Im0 4 0 R")),
+    ];
+    let bodies: Vec<(u32, &[u8])> = objects.iter().map(|(id, body)| (*id, body.as_slice())).collect();
+    let (pdf, _) = pdf_from_objects(&bodies, &[]);
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert!(document.get_object((1, 0)).is_ok());
+    assert!(document.get_object((2, 0)).is_ok());
+    assert!(document.get_object((3, 0)).is_ok());
+    let Object::Stream(stream) = document.get_object((4, 0)).unwrap() else {
+        panic!("image object must remain a stream");
+    };
+    assert_eq!(stream.content, content);
+}
+
+/// Byte position just after the only `stream` keyword's EOL in the document.
+fn stream_data_start(pdf: &[u8]) -> usize {
+    pdf.windows(7)
+        .position(|window| window == b"stream\n")
+        .expect("no stream keyword")
+        + 7
+}
+
+#[test]
+fn inaccurate_xref_offset_inside_stream_data_drops_the_stream() {
+    // Object 5 physically follows object 4, but its xref offset is miswritten
+    // to point into object 4's stream payload. Parsing object 4 is therefore
+    // truncated before its real endstream, and the object is lost.
+    let content = vec![b'A'; 48];
+    let objects: Vec<(u32, Vec<u8>)> = vec![
+        (1, catalog().to_vec()),
+        (2, pages("3 0 R")),
+        (3, page("/Im0 4 0 R /F1 5 0 R")),
+        (4, image_stream_body(&content)),
+        (5, b"<< /Type /Font >>\n".to_vec()),
+    ];
+    let bodies: Vec<(u32, &[u8])> = objects.iter().map(|(id, body)| (*id, body.as_slice())).collect();
+    let (pdf, _) = pdf_from_objects(&bodies, &[]);
+    let false_offset = stream_data_start(&pdf) + 16;
+    let (pdf, _) = pdf_from_objects(&bodies, &[(5, false_offset)]);
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert!(document.get_object((1, 0)).is_ok());
+    assert!(document.get_object((2, 0)).is_ok());
+    assert!(document.get_object((3, 0)).is_ok());
+    assert!(document.get_object((4, 0)).is_err());
+    assert!(document.get_object((5, 0)).is_err());
+}
+
+#[test]
+fn strict_mode_aborts_when_an_xref_offset_lands_inside_a_stream() {
+    let content = vec![b'A'; 48];
+    let objects: Vec<(u32, Vec<u8>)> = vec![
+        (1, catalog().to_vec()),
+        (2, pages("3 0 R")),
+        (3, page("/Im0 4 0 R")),
+        (4, image_stream_body(&content)),
+        (5, b"<< /Type /Font >>\n".to_vec()),
+    ];
+    let bodies: Vec<(u32, &[u8])> = objects.iter().map(|(id, body)| (*id, body.as_slice())).collect();
+    let (pdf, _) = pdf_from_objects(&bodies, &[]);
+    let false_offset = stream_data_start(&pdf) + 16;
+    let (pdf, _) = pdf_from_objects(&bodies, &[(5, false_offset)]);
+    let strict = LoadOptions {
+        strict: true,
+        ..Default::default()
+    };
+
+    assert!(Document::load_mem_with_options(&pdf, strict).is_err());
+}
+
+#[test]
+fn out_of_order_xref_with_offset_inside_stream_data_drops_the_stream() {
+    // Object 3 physically sits after the image stream of object 4, but its
+    // recorded xref offset lands inside object 4's payload. Both the truncated
+    // stream (4 0 obj) and the mislocated object (3 0 obj) disappear.
+    let content = vec![b'A'; 48];
+    let objects: Vec<(u32, Vec<u8>)> = vec![
+        (1, catalog().to_vec()),
+        (2, pages("3 0 R")),
+        (4, image_stream_body(&content)),
+        (3, page("/Im0 4 0 R")),
+    ];
+    let bodies: Vec<(u32, &[u8])> = objects.iter().map(|(id, body)| (*id, body.as_slice())).collect();
+    let (pdf, _) = pdf_from_objects(&bodies, &[]);
+    let false_offset = stream_data_start(&pdf) + 16;
+    let (pdf, _) = pdf_from_objects(&bodies, &[(3, false_offset)]);
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert!(document.get_object((1, 0)).is_ok());
+    assert!(document.get_object((2, 0)).is_ok());
+    assert!(document.get_object((3, 0)).is_err());
     assert!(document.get_object((4, 0)).is_err());
 }

--- a/tests/stream_length_recovery.rs
+++ b/tests/stream_length_recovery.rs
@@ -181,10 +181,11 @@ fn stream_data_start(pdf: &[u8]) -> usize {
 }
 
 #[test]
-fn inaccurate_xref_offset_inside_stream_data_drops_the_stream() {
+fn inaccurate_xref_offset_inside_a_stream_only_loses_the_mislocated_object() {
     // Object 5 physically follows object 4, but its xref offset is miswritten
-    // to point into object 4's stream payload. Parsing object 4 is therefore
-    // truncated before its real endstream, and the object is lost.
+    // to point into object 4's stream payload. Object 4 itself is well-formed
+    // (its /Length is correct), so it still loads; only the mislocated object
+    // is lost.
     let content = vec![b'A'; 48];
     let objects: Vec<(u32, Vec<u8>)> = vec![
         (1, catalog().to_vec()),
@@ -202,12 +203,19 @@ fn inaccurate_xref_offset_inside_stream_data_drops_the_stream() {
     assert!(document.get_object((1, 0)).is_ok());
     assert!(document.get_object((2, 0)).is_ok());
     assert!(document.get_object((3, 0)).is_ok());
-    assert!(document.get_object((4, 0)).is_err());
+    let Object::Stream(stream) = document.get_object((4, 0)).unwrap() else {
+        panic!("image object must remain a stream");
+    };
+    assert_eq!(stream.content, content);
     assert!(document.get_object((5, 0)).is_err());
 }
 
 #[test]
-fn strict_mode_aborts_when_an_xref_offset_lands_inside_a_stream() {
+fn strict_mode_aborts_when_an_xref_offset_is_unparseable() {
+    // Strict mode fails the whole load when any object cannot be parsed —
+    // here object 5, whose xref offset points into object 4's payload.
+    // Object 4 itself survives parsing; the abort is caused solely by the
+    // unparseable neighbor offset.
     let content = vec![b'A'; 48];
     let objects: Vec<(u32, Vec<u8>)> = vec![
         (1, catalog().to_vec()),
@@ -229,10 +237,10 @@ fn strict_mode_aborts_when_an_xref_offset_lands_inside_a_stream() {
 }
 
 #[test]
-fn out_of_order_xref_with_offset_inside_stream_data_drops_the_stream() {
+fn out_of_order_xref_with_offset_inside_a_stream_only_loses_the_mislocated_object() {
     // Object 3 physically sits after the image stream of object 4, but its
-    // recorded xref offset lands inside object 4's payload. Both the truncated
-    // stream (4 0 obj) and the mislocated object (3 0 obj) disappear.
+    // recorded xref offset lands inside object 4's payload. Object 4 parses
+    // fine; only the mislocated object disappears.
     let content = vec![b'A'; 48];
     let objects: Vec<(u32, Vec<u8>)> = vec![
         (1, catalog().to_vec()),
@@ -249,5 +257,50 @@ fn out_of_order_xref_with_offset_inside_stream_data_drops_the_stream() {
     assert!(document.get_object((1, 0)).is_ok());
     assert!(document.get_object((2, 0)).is_ok());
     assert!(document.get_object((3, 0)).is_err());
+    let Object::Stream(stream) = document.get_object((4, 0)).unwrap() else {
+        panic!("image object must remain a stream");
+    };
+    assert_eq!(stream.content, content);
+}
+
+/// Body of a stream whose declared `/Length` is deliberately wrong (too
+/// small), so loading has to rely on boundary recovery.
+fn wrong_length_stream_body(content: &[u8]) -> Vec<u8> {
+    let mut body = format!(
+        "<< /Type /XObject /Subtype /Image /Width {} /Height 1 /ColorSpace /DeviceRGB \
+             /BitsPerComponent 8 /Length 0 >>\nstream\n",
+        content.len() / 3
+    )
+    .into_bytes();
+    body.extend_from_slice(content);
+    body.extend_from_slice(b"\nendstream\n");
+    body
+}
+
+#[test]
+fn stream_length_recovery_stops_at_the_next_recorded_xref_offset() {
+    // A stream with a wrong /Length can only be recovered if its unambiguous
+    // `endstream` lies before the next recorded xref offset: recovery must
+    // not cross into a neighboring object even when that offset is itself
+    // inaccurate. Here object 5's offset points into object 4's payload, so
+    // the recovery window ends mid-data and object 4 is dropped.
+    let content = vec![b'A'; 48];
+    let objects: Vec<(u32, Vec<u8>)> = vec![
+        (1, catalog().to_vec()),
+        (2, pages("3 0 R")),
+        (3, page("/Im0 4 0 R")),
+        (4, wrong_length_stream_body(&content)),
+        (5, b"<< /Type /Font >>\n".to_vec()),
+    ];
+    let bodies: Vec<(u32, &[u8])> = objects.iter().map(|(id, body)| (*id, body.as_slice())).collect();
+    let (pdf, _) = pdf_from_objects(&bodies, &[]);
+    let false_offset = stream_data_start(&pdf) + 16;
+    let (pdf, _) = pdf_from_objects(&bodies, &[(5, false_offset)]);
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert!(document.get_object((1, 0)).is_ok());
+    assert!(document.get_object((2, 0)).is_ok());
+    assert!(document.get_object((3, 0)).is_ok());
     assert!(document.get_object((4, 0)).is_err());
+    assert!(document.get_object((5, 0)).is_err());
 }


### PR DESCRIPTION
## Summary

Streams whose `/Length` disagrees with their content used to fall through the parser's `alt` combinator and degrade into a `Dictionary`, corrupting the loaded document. This PR recovers the real `endstream` boundary when it is unambiguous (EOL-framed `endstream` immediately followed by `endobj`) and rejects the object otherwise. The recovery scan is bounded by the next recorded xref offset so it can never cross into a neighboring indirect object; ordinary parsing stays unbounded, so a wrong *neighbor* offset never truncates a well-formed object. A follow-up commit shares one sorted xref-offset index between batch loading and lazy object resolution (binary search instead of an O(n) scan per object) and adds regression tests for inaccurate/out-of-order xref offsets.

## Behavior changes

1. **Strict mode aborts on unexpected per-object load errors** (src/reader.rs, `load_objects_raw`). Before: any object that failed to parse was logged and silently skipped, even under `LoadOptions { strict: true }`. After: strict mode propagates the error and fails the whole load — except in encrypted documents, where per-object failures are often inherent to encryption; those keep the previous warn-and-skip behavior even under strict.
2. **A bad-`/Length` stream no longer becomes a garbage `Dictionary`.** Before: the parser's `alt` fallthrough returned the partially-parsed stream dictionary as an object. After: the stream path returns `nom::Err::Failure`, so the object disappears from the document entirely — see `tests/stream_length_recovery.rs::lenient_load_does_not_guess_an_ambiguous_stream_boundary`, which asserts `get_object((4, 0)).is_err()`.
3. **Malformed-stream length recovery stops at the next recorded xref offset.** Ordinary objects are parsed against the full buffer, so inaccurate or out-of-order xref offsets no longer truncate well-formed objects (`inaccurate_xref_offset_inside_a_stream_only_loses_the_mislocated_object`). Only recovery is bounded: a bad-`/Length` stream whose real `endstream` lies beyond the next recorded offset cannot be recovered and is dropped (`stream_length_recovery_stops_at_the_next_recorded_xref_offset`). This keeps the safety property — recovery never crosses into another indirect object. Note the deliberate trade-off: because `take(length)` itself runs against the full buffer, an over-long `/Length` that happens to land on an `endstream` is still accepted exactly as on `main`; bounding `take(length)` as well would reintroduce the neighbor-offset collateral damage described above.
4. **A bad-`/Length` cross-reference stream fails hard during bootstrap** (`recover_length = false` path): it now yields `nom::Err::Failure` instead of falling through to a `Dictionary`. Practically unobservable — such a dictionary failed `decode_xref_stream_with_limit` anyway, so the document errored either way; only the error shape differs.