### PR TITLE
feat: reconstruct cross-reference table when startxref resolution fails

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -78,7 +78,11 @@ impl Document {
     /// Create a new PDF document that is an incremental update to a previous document.
     pub fn new_from_prev(prev: &Document) -> Self {
         let mut new_trailer = prev.trailer.clone();
-        new_trailer.set("Prev", Object::Integer(prev.xref_start as i64));
+        // A zero xref_start marks a document with no known on-disk table
+        // (e.g. recovered by scanning); emitting `/Prev 0` would corrupt the chain.
+        if prev.xref_start != 0 {
+            new_trailer.set("Prev", Object::Integer(prev.xref_start as i64));
+        }
         Self {
             version: "1.4".to_string(),
             binary_mark: vec![0xBB, 0xAD, 0xC0, 0xDE],

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -824,6 +824,13 @@ impl Reader<'_> {
             self.load_objects_raw(filter_func)?;
         }
 
+        // Object-stream members join `objects` only during loading, after
+        // `max_id` was derived from the xref size. Keep the ceiling at least
+        // at the highest loaded object so new ids cannot collide with live ones.
+        if let Some(&max_loaded_id) = self.document.objects.keys().next_back() {
+            self.document.max_id = self.document.max_id.max(max_loaded_id.0);
+        }
+
         Ok(self.document)
     }
 
@@ -1420,11 +1427,15 @@ impl Reader<'_> {
             // Incremental updates append, so later revisions win.
             xref.insert(number, XrefEntry::Normal { offset, generation });
         }
+        // Normalize like `resolve_xref_and_trailer`: size spans object numbers
+        // up to the highest, not physical copies across incremental updates.
+        xref.size = xref.max_id().saturating_add(1);
 
         let (_trailer_pos, trailer) = self.find_latest_trailer(&xref)?;
-        // deliberate: end-of-file, since each scanned offset carries its own
-        // read boundary and there is no real on-disk table to point at.
-        self.document.xref_start = self.buffer.len();
+        // deliberate: no on-disk table exists to point at. Zero marks the
+        // offset "unknown" so `Document::new_from_prev` omits `/Prev` instead
+        // of recording end-of-file; `object_end` clamps to the buffer either way.
+        self.document.xref_start = 0;
 
         warn!(
             "reconstructed cross-reference table with {} objects by scanning for indirect objects",
@@ -1434,24 +1445,137 @@ impl Reader<'_> {
     }
 
     /// Collect `(offset, id)` of every indirect-object header in one pass.
+    /// Only headers starting a line (optional leading blanks allowed) count,
+    /// stream payloads are skipped wholesale, and object numbers beyond
+    /// [`MAX_RECONSTRUCTED_OBJECTS`] are rejected so a forged header can
+    /// neither shadow a genuine entry nor poison the reconstructed size.
     fn scan_object_markers(buffer: &[u8]) -> Vec<(u32, ObjectId)> {
+        const STREAM_KEYWORD: &[u8] = b"stream";
+        const END_STREAM_KEYWORD: &[u8] = b"endstream";
+
         let mut markers = Vec::new();
-        for pos in 0..buffer.len() {
-            // Anchor at digit-run starts to avoid overlapping matches.
-            if !buffer[pos].is_ascii_digit() || pos > 0 && buffer[pos - 1].is_ascii_digit() {
-                continue;
-            }
-            if let Some(id) = Self::parse_object_header(&buffer[pos..]) {
-                if markers.len() == MAX_RECONSTRUCTED_OBJECTS {
-                    warn!(
-                        "object marker scan stopped at the {MAX_RECONSTRUCTED_OBJECTS}-marker cap; reconstruction may be incomplete"
-                    );
-                    break;
+        let mut oversized_number_warned = false;
+        let mut at_line_start = true;
+        let mut pos = 0;
+        while pos < buffer.len() {
+            // Skip raw stream data: an uncompressed payload may embed
+            // convincing `N G obj` lines whose later offsets would otherwise
+            // override the genuine entries for those object numbers.
+            if buffer[pos..].starts_with(STREAM_KEYWORD)
+                && !buffer[..pos].ends_with(b"end")
+                && matches!(buffer.get(pos + STREAM_KEYWORD.len()), Some(b'\r' | b'\n'))
+            {
+                let after_keyword = pos + STREAM_KEYWORD.len();
+                if let Some(relative) = buffer[after_keyword..]
+                    .windows(END_STREAM_KEYWORD.len())
+                    .position(|window| window == END_STREAM_KEYWORD)
+                {
+                    pos = after_keyword + relative + END_STREAM_KEYWORD.len();
+                    at_line_start = false;
+                    continue;
                 }
-                markers.push((pos as u32, id));
+                // Damaged stream without terminator: fall back to the
+                // dictionary's /Length hint so the payload cannot hide
+                // line-start pseudo headers, while objects written after it
+                // stay reachable.
+                if let Some(resume) = Self::payload_end_by_length(buffer, pos) {
+                    pos = resume;
+                    at_line_start = false;
+                    continue;
+                }
+                // Unusable /Length too: nothing bounds the payload, so keep
+                // scanning byte by byte rather than dropping what follows.
             }
+            // Anchor at line starts so pseudo headers buried after another
+            // token (string literal, comment) are never mistaken for markers.
+            if at_line_start
+                && buffer[pos].is_ascii_digit()
+                && let Some(id) = Self::parse_object_header(&buffer[pos..])
+            {
+                // A huge bogus number would inflate `size` (and thus
+                // `max_id`) via `Xref::insert`; genuine numbering stays
+                // within the same cap as the marker count.
+                if id.0 > MAX_RECONSTRUCTED_OBJECTS as u32 {
+                    if !oversized_number_warned {
+                        warn!("ignoring object headers numbered above {MAX_RECONSTRUCTED_OBJECTS}");
+                        oversized_number_warned = true;
+                    }
+                } else {
+                    if markers.len() == MAX_RECONSTRUCTED_OBJECTS {
+                        warn!(
+                            "object marker scan stopped at the {MAX_RECONSTRUCTED_OBJECTS}-marker cap; reconstruction may be incomplete"
+                        );
+                        break;
+                    }
+                    markers.push((pos as u32, id));
+                }
+            }
+            match buffer[pos] {
+                b'\r' | b'\n' => at_line_start = true,
+                b' ' | b'\t' => {}
+                _ => at_line_start = false,
+            }
+            pos += 1;
         }
         markers
+    }
+
+    /// Resume offset past a stream payload according to a *direct* `/Length`
+    /// integer in the dictionary preceding the `stream` keyword at
+    /// `stream_pos`. The search is scoped to the current object (after the
+    /// nearest preceding `obj` keyword) so a missing `/Length` cannot latch
+    /// onto a previous object's value. Returns `None` when the hint is
+    /// absent, indirect, or points outside the buffer — damaged files tend
+    /// to carry wrong `/Length` values, so it must stay a hint, never a hard
+    /// boundary.
+    fn payload_end_by_length(buffer: &[u8], stream_pos: usize) -> Option<usize> {
+        const LENGTH_KEY: &[u8] = b"/Length";
+        const OBJ_KEYWORD: &[u8] = b"obj";
+        const STREAM_KEYWORD_LEN: usize = b"stream".len();
+
+        let head = &buffer[..stream_pos];
+        let obj_pos = head
+            .windows(OBJ_KEYWORD.len())
+            .rposition(|window| window == OBJ_KEYWORD)?;
+        let dict_region = &buffer[obj_pos + OBJ_KEYWORD.len()..stream_pos];
+        // Nearest `/Length` in this object's dictionary; parsing it validates
+        // that the match really is a key with an integer value.
+        let key_pos = dict_region
+            .windows(LENGTH_KEY.len())
+            .rposition(|window| window == LENGTH_KEY)?;
+        let rest = &dict_region[key_pos + LENGTH_KEY.len()..];
+        let digits_start = rest.iter().position(u8::is_ascii_digit)?;
+        let digits_len = rest[digits_start..]
+            .iter()
+            .take_while(|byte| byte.is_ascii_digit())
+            .count();
+        if digits_len > 10 {
+            return None;
+        }
+        // An indirect reference (`/Length 5 0 R`) continues with another
+        // number token; a direct integer ends at a name, `>>`, or the keyword.
+        match rest[digits_start + digits_len..]
+            .iter()
+            .copied()
+            .find(|byte| !byte.is_ascii_whitespace())
+        {
+            Some(b'/') | Some(b'>') => {}
+            _ => return None,
+        }
+        let length: usize = std::str::from_utf8(&rest[digits_start..digits_start + digits_len])
+            .ok()?
+            .parse()
+            .ok()?;
+        // Spec: the EOL after the `stream` keyword counts as CRLF or LF.
+        let eol_len = match (
+            buffer.get(stream_pos + STREAM_KEYWORD_LEN),
+            buffer.get(stream_pos + STREAM_KEYWORD_LEN + 1),
+        ) {
+            (Some(b'\r'), Some(b'\n')) => 2,
+            _ => 1,
+        };
+        let end = (stream_pos + STREAM_KEYWORD_LEN + eol_len).checked_add(length)?;
+        (buffer.len() >= end).then_some(end)
     }
 
     /// Parse an `N G obj` header; the byte after `obj` must end the token.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -24,7 +24,7 @@ use crate::error::{ParseError, XrefError};
 use crate::load_options::{FilterFunc, LoadOptions};
 use crate::object_stream::ObjectStream;
 use crate::parser;
-use crate::xref::{Xref, XrefEntry};
+use crate::xref::{Xref, XrefEntry, XrefType};
 use crate::{Dictionary, Document, Error, IncrementalDocument, Object, ObjectId, Result};
 
 #[cfg(not(feature = "async"))]
@@ -493,6 +493,16 @@ pub const MAX_BRACKET: usize = 100;
 
 pub const MAX_NESTING_DEPTH: usize = 100;
 
+/// Hard cap on the number of indirect-object headers collected while
+/// reconstructing a cross-reference table from raw bytes. The scan is already
+/// bounded by input length; this bounds the memory of the rebuilt table when a
+/// hostile file consists almost entirely of `N G obj` byte sequences.
+const MAX_RECONSTRUCTED_OBJECTS: usize = 1_000_000;
+
+/// Hard cap on how many trailing `trailer` dictionaries cross-reference
+/// reconstruction inspects while looking for one with a usable `/Root`.
+const MAX_TRAILER_CANDIDATES: usize = 16;
+
 /// PDF metadata extracted without loading the entire document.
 /// This is useful for quickly getting basic information about large PDFs.
 #[derive(Debug, Clone)]
@@ -587,47 +597,18 @@ impl Reader<'_> {
 
         let version = parser::header(self.buffer, self.strict).ok_or(ParseError::InvalidFileHeader)?;
 
-        let xref_start = Self::get_xref_start(self.buffer)?;
-        if xref_start > self.buffer.len() {
-            return Err(Error::Xref(XrefError::Start));
-        }
-
-        let (mut xref, mut trailer) = self.xref_and_trailer_at(xref_start)?;
-
-        let mut already_seen = HashSet::new();
-        let mut prev_xref_start = trailer.remove(b"Prev");
-        while let Some(prev) = prev_xref_start.and_then(|offset| offset.as_i64().ok()) {
-            if already_seen.contains(&prev) {
-                break;
-            }
-            already_seen.insert(prev);
-            if prev < 0 || prev as usize > self.buffer.len() {
-                return Err(Error::Xref(XrefError::PrevStart));
-            }
-
-            let (prev_xref, prev_trailer) = self.xref_and_trailer_at(prev as usize)?;
-            xref.merge(prev_xref);
-
-            let prev_xref_stream_start = trailer.remove(b"XRefStm");
-            if let Some(prev) = prev_xref_stream_start.and_then(|offset| offset.as_i64().ok()) {
-                if prev < 0 || prev as usize > self.buffer.len() {
-                    return Err(Error::Xref(XrefError::StreamStart));
+        // Same resolution order as `read`, including the brute-force
+        // reconstruction fallback.
+        let (xref, trailer) = match self.resolve_xref_and_trailer() {
+            Ok(resolved) => resolved,
+            Err(err) => match self.reconstruct_xref_and_trailer() {
+                Some(reconstructed) => {
+                    warn!("cross-reference resolution failed ({err}); recovered by scanning for indirect objects");
+                    reconstructed
                 }
-
-                let (prev_xref, _) = self.xref_and_trailer_at(prev as usize)?;
-                xref.merge(prev_xref);
-            }
-
-            prev_xref_start = prev_trailer.get(b"Prev").cloned().ok();
-        }
-        let xref_entry_count = xref.max_id().checked_add(1).ok_or(ParseError::InvalidXref)?;
-        if xref.size != xref_entry_count {
-            warn!(
-                "Size entry of trailer dictionary is {}, correct value is {}.",
-                xref.size, xref_entry_count
-            );
-            xref.size = xref_entry_count;
-        }
+                None => return Err(err),
+            },
+        };
 
         self.set_reference_table(xref);
         self.document.trailer = trailer.clone();
@@ -821,51 +802,21 @@ impl Reader<'_> {
             self.document.binary_mark = binary_mark;
         }
 
-        let xref_start = Self::get_xref_start(self.buffer)?;
-        if xref_start > self.buffer.len() {
-            return Err(Error::Xref(XrefError::Start));
-        }
-        let xref_start = self.correct_xref_offset(xref_start);
-        self.document.xref_start = xref_start;
-
-        let (mut xref, mut trailer) = self.xref_and_trailer_at(xref_start)?;
-
-        // Read previous Xrefs of linearized or incremental updated document.
-        let mut already_seen = HashSet::new();
-        let mut prev_xref_start = trailer.remove(b"Prev");
-        while let Some(prev) = prev_xref_start.and_then(|offset| offset.as_i64().ok()) {
-            if already_seen.contains(&prev) {
-                break;
-            }
-            already_seen.insert(prev);
-            if prev < 0 || prev as usize > self.buffer.len() {
-                return Err(Error::Xref(XrefError::PrevStart));
-            }
-
-            let (prev_xref, prev_trailer) = self.xref_and_trailer_at(prev as usize)?;
-            xref.merge(prev_xref);
-
-            // Read xref stream in hybrid-reference file
-            let prev_xref_stream_start = trailer.remove(b"XRefStm");
-            if let Some(prev) = prev_xref_stream_start.and_then(|offset| offset.as_i64().ok()) {
-                if prev < 0 || prev as usize > self.buffer.len() {
-                    return Err(Error::Xref(XrefError::StreamStart));
+        // Resolve the cross-reference table/stream and trailer following the
+        // standard order: `startxref`, slight-offset correction, then the
+        // `/Prev` and `/XRefStm` chain. Only if every step of that pipeline
+        // fails, fall back to reconstructing the table from object markers
+        // scanned in the raw bytes.
+        let (xref, trailer) = match self.resolve_xref_and_trailer() {
+            Ok(resolved) => resolved,
+            Err(err) => match self.reconstruct_xref_and_trailer() {
+                Some(reconstructed) => {
+                    warn!("cross-reference resolution failed ({err}); recovered by scanning for indirect objects");
+                    reconstructed
                 }
-
-                let (prev_xref, _) = self.xref_and_trailer_at(prev as usize)?;
-                xref.merge(prev_xref);
-            }
-
-            prev_xref_start = prev_trailer.get(b"Prev").cloned().ok();
-        }
-        let xref_entry_count = xref.max_id().checked_add(1).ok_or(ParseError::InvalidXref)?;
-        if xref.size != xref_entry_count {
-            warn!(
-                "Size entry of trailer dictionary is {}, correct value is {}.",
-                xref.size, xref_entry_count
-            );
-            xref.size = xref_entry_count;
-        }
+                None => return Err(err),
+            },
+        };
 
         self.document.version = version;
         self.document.max_id = xref.size - 1;
@@ -1407,6 +1358,198 @@ impl Reader<'_> {
         parser::xref_and_trailer(&self.buffer[offset..], self)
     }
 
+    /// Resolve the cross-reference table/stream and trailer dictionary,
+    /// including the `/Prev` chain of linearized or incrementally updated
+    /// documents, and record the resolved start offset on the document.
+    fn resolve_xref_and_trailer(&mut self) -> Result<(Xref, Dictionary)> {
+        let xref_start = Self::get_xref_start(self.buffer)?;
+        if xref_start > self.buffer.len() {
+            return Err(Error::Xref(XrefError::Start));
+        }
+        let xref_start = self.correct_xref_offset(xref_start);
+        self.document.xref_start = xref_start;
+
+        let (mut xref, mut trailer) = self.xref_and_trailer_at(xref_start)?;
+
+        // Read previous Xrefs of linearized or incremental updated document.
+        let mut already_seen = HashSet::new();
+        let mut prev_xref_start = trailer.remove(b"Prev");
+        while let Some(prev) = prev_xref_start.and_then(|offset| offset.as_i64().ok()) {
+            if already_seen.contains(&prev) {
+                break;
+            }
+            already_seen.insert(prev);
+            if prev < 0 || prev as usize > self.buffer.len() {
+                return Err(Error::Xref(XrefError::PrevStart));
+            }
+
+            let (prev_xref, prev_trailer) = self.xref_and_trailer_at(prev as usize)?;
+            xref.merge(prev_xref);
+
+            // Read xref stream in hybrid-reference file
+            let prev_xref_stream_start = trailer.remove(b"XRefStm");
+            if let Some(prev) = prev_xref_stream_start.and_then(|offset| offset.as_i64().ok()) {
+                if prev < 0 || prev as usize > self.buffer.len() {
+                    return Err(Error::Xref(XrefError::StreamStart));
+                }
+
+                let (prev_xref, _) = self.xref_and_trailer_at(prev as usize)?;
+                xref.merge(prev_xref);
+            }
+
+            prev_xref_start = prev_trailer.get(b"Prev").cloned().ok();
+        }
+        let xref_entry_count = xref.max_id().checked_add(1).ok_or(ParseError::InvalidXref)?;
+        if xref.size != xref_entry_count {
+            warn!(
+                "Size entry of trailer dictionary is {}, correct value is {}.",
+                xref.size, xref_entry_count
+            );
+            xref.size = xref_entry_count;
+        }
+
+        Ok((xref, trailer))
+    }
+
+    /// Last-resort recovery: rebuild a cross-reference table by scanning the
+    /// raw bytes for indirect-object headers (`N G obj`) and locating the
+    /// newest parsable `trailer` dictionary with a usable `/Root`. This mirrors
+    /// the reconstruction mode of pdf.js, qpdf, poppler and pypdf for files
+    /// whose `startxref`, cross-reference table or cross-reference stream
+    /// cannot be resolved at all.
+    ///
+    /// Object streams need no special treatment: their container objects are
+    /// ordinary top-level markers, so the regular loading pass decompresses
+    /// them once the rebuilt table points at the containers.
+    ///
+    /// Returns `None` when strict mode forbids recovery or nothing usable was
+    /// found; the caller then surfaces the original resolution error.
+    fn reconstruct_xref_and_trailer(&mut self) -> Option<(Xref, Dictionary)> {
+        if self.strict {
+            return None;
+        }
+        // `XrefEntry::Normal` offsets are u32; refuse inputs whose byte offsets
+        // cannot be represented instead of wrapping them.
+        u32::try_from(self.buffer.len()).ok()?;
+
+        let markers = Self::scan_object_markers(self.buffer);
+        if markers.is_empty() {
+            return None;
+        }
+
+        let mut xref = Xref::new(markers.len() as u32, XrefType::CrossReferenceTable);
+        for (offset, (number, generation)) in markers {
+            // Later revisions of an object win because incremental updates
+            // append, so the scan meets their headers last.
+            xref.insert(number, XrefEntry::Normal { offset, generation });
+        }
+
+        let (_trailer_pos, trailer) = self.find_latest_trailer(&xref)?;
+        // deliberate: record end-of-file rather than the trailer position.
+        // Every scanned marker provides its own boundary through the sorted
+        // offset index, so no object read must stop early, and no misleading
+        // `/Prev` target exists for a table that was never on disk.
+        self.document.xref_start = self.buffer.len();
+
+        warn!(
+            "reconstructed cross-reference table with {} objects by scanning for indirect objects",
+            xref.entries.len()
+        );
+        Some((xref, trailer))
+    }
+
+    /// Collect byte offsets and IDs of every indirect-object header
+    /// (`N G obj`) in the buffer with one left-to-right pass. Offsets come
+    /// from scan positions, never from numbers read out of the file, so the
+    /// result cannot be inflated by attacker-controlled values beyond the
+    /// [`MAX_RECONSTRUCTED_OBJECTS`] cap.
+    fn scan_object_markers(buffer: &[u8]) -> Vec<(u32, ObjectId)> {
+        let mut markers = Vec::new();
+        for pos in 0..buffer.len() {
+            // Anchor at digit-run starts so overlapping headers inside longer
+            // digit runs ("12 0 obj" vs "2 0 obj") match only once.
+            if !buffer[pos].is_ascii_digit() || pos > 0 && buffer[pos - 1].is_ascii_digit() {
+                continue;
+            }
+            if let Some(id) = Self::parse_object_header(&buffer[pos..]) {
+                if markers.len() == MAX_RECONSTRUCTED_OBJECTS {
+                    warn!(
+                        "object marker scan stopped at the {MAX_RECONSTRUCTED_OBJECTS}-marker cap; reconstruction may be incomplete"
+                    );
+                    break;
+                }
+                markers.push((pos as u32, id));
+            }
+        }
+        markers
+    }
+
+    /// Parse an indirect-object header (`N G obj`) at the start of `input`.
+    /// The byte following `obj` must be whitespace, a delimiter, or
+    /// end-of-input so tokens such as `objects` never match.
+    fn parse_object_header(input: &[u8]) -> Option<ObjectId> {
+        // deliberate: digit runs are capped at the widths of u32/u16; longer
+        // runs cannot be conforming object numbers but could be pathological
+        // padding whose per-position rescans would waste time.
+        fn digits(input: &[u8], cap: usize) -> Option<(&[u8], &[u8])> {
+            let n = input.iter().take_while(|b| b.is_ascii_digit()).count();
+            (0 < n && n <= cap).then(|| input.split_at(n))
+        }
+        fn spaces(input: &[u8]) -> Option<&[u8]> {
+            let n = input
+                .iter()
+                .take_while(|&&b| matches!(b, b' ' | b'\t' | b'\r' | b'\n'))
+                .count();
+            (n > 0).then(|| &input[n..])
+        }
+
+        let (number, rest) = digits(input, 10)?;
+        let number: u32 = std::str::from_utf8(number).ok()?.parse().ok()?;
+        let rest = spaces(rest)?;
+        let (generation, rest) = digits(rest, 5)?;
+        let generation: u16 = std::str::from_utf8(generation).ok()?.parse().ok()?;
+        let rest = spaces(rest)?;
+        let tail = rest.strip_prefix(b"obj")?;
+        match tail.first() {
+            None => {}
+            Some(&byte) if !byte.is_ascii_alphanumeric() => {}
+            _ => return None,
+        }
+        Some((number, generation))
+    }
+
+    /// Scan backwards for the newest parsable `trailer` dictionary whose
+    /// `/Root` entry references an object found by the marker scan; later
+    /// revisions win because incremental updates append their trailers.
+    /// Returns the keyword's byte position alongside the dictionary.
+    fn find_latest_trailer(&self, xref: &Xref) -> Option<(usize, Dictionary)> {
+        let mut bound = self.buffer.len();
+        for _ in 0..MAX_TRAILER_CANDIDATES {
+            let Some(pos) = Reader::search_substring(&self.buffer[..bound], b"trailer", 0) else {
+                break;
+            };
+            bound = pos;
+
+            let after_keyword = &self.buffer[pos + b"trailer".len()..];
+            let Some(dict_start) = after_keyword.iter().position(|byte| !byte.is_ascii_whitespace()) else {
+                continue;
+            };
+            let Ok((_, dict)) = parser::dictionary(&after_keyword[dict_start..]) else {
+                continue;
+            };
+            // A trailer is only usable when its catalog is among the scanned
+            // objects; otherwise keep looking in older revisions.
+            let root_is_present = dict
+                .get(b"Root")
+                .and_then(Object::as_reference)
+                .is_ok_and(|root| xref.entries.contains_key(&root.0));
+            if root_is_present {
+                return Some((pos, dict));
+            }
+        }
+        None
+    }
+
     /// Some generators write `startxref` (or trailer `Prev`) values that are
     /// slightly off — most commonly the offset of the line *after* the `xref`
     /// keyword instead of the keyword itself. Such files are otherwise intact,
@@ -1455,22 +1598,7 @@ impl Reader<'_> {
     /// Whether `input` begins with an indirect-object header (`N G obj`), the
     /// form a cross-reference stream starts with.
     fn starts_indirect_object(input: &[u8]) -> bool {
-        fn digits(input: &[u8]) -> Option<&[u8]> {
-            let n = input.iter().take_while(|b| b.is_ascii_digit()).count();
-            (n > 0).then(|| &input[n..])
-        }
-        fn spaces(input: &[u8]) -> Option<&[u8]> {
-            let n = input
-                .iter()
-                .take_while(|&&b| matches!(b, b' ' | b'\t' | b'\r' | b'\n'))
-                .count();
-            (n > 0).then(|| &input[n..])
-        }
-        digits(input)
-            .and_then(spaces)
-            .and_then(digits)
-            .and_then(spaces)
-            .is_some_and(|rest| rest.starts_with(b"obj"))
+        Self::parse_object_header(input).is_some()
     }
 
     fn get_xref_start(buffer: &[u8]) -> Result<usize> {
@@ -1759,4 +1887,23 @@ startxref
     let loaded = Document::load_mem(doc.as_bytes()).unwrap();
     let stream = loaded.get_object((4, 0)).unwrap().as_stream().unwrap();
     assert_eq!(stream.content, b"BT /F1 12 Tf 20 100 Td (Hello World) Tj ET");
+}
+
+#[cfg(all(test, not(feature = "async")))]
+#[test]
+fn object_marker_parsing_accepts_only_real_headers() {
+    assert_eq!(Reader::parse_object_header(b"12 0 obj<<"), Some((12, 0)));
+    assert_eq!(Reader::parse_object_header(b"007 0 obj\n"), Some((7, 0)));
+    assert_eq!(Reader::parse_object_header(b"5 2 obj>>"), Some((5, 2)));
+    assert_eq!(Reader::parse_object_header(b"12\t3\r\nobj["), Some((12, 3)));
+
+    // The token after `obj` must not run into further letters or digits.
+    assert_eq!(Reader::parse_object_header(b"2 0 objects"), None);
+    assert_eq!(Reader::parse_object_header(b"99 88 objx"), None);
+    // Numbers beyond u32/u16 and malformed separators are rejected.
+    assert_eq!(Reader::parse_object_header(b"12345678901 0 obj"), None);
+    assert_eq!(Reader::parse_object_header(b"1 70000 obj"), None);
+    assert_eq!(Reader::parse_object_header(b"1 0obj"), None);
+    assert_eq!(Reader::parse_object_header(b"1  obj"), None);
+    assert_eq!(Reader::parse_object_header(b"x 0 obj"), None);
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -493,14 +493,10 @@ pub const MAX_BRACKET: usize = 100;
 
 pub const MAX_NESTING_DEPTH: usize = 100;
 
-/// Hard cap on the number of indirect-object headers collected while
-/// reconstructing a cross-reference table from raw bytes. The scan is already
-/// bounded by input length; this bounds the memory of the rebuilt table when a
-/// hostile file consists almost entirely of `N G obj` byte sequences.
+/// Cap on reconstructed cross-reference entries, bounding memory on hostile inputs.
 const MAX_RECONSTRUCTED_OBJECTS: usize = 1_000_000;
 
-/// Hard cap on how many trailing `trailer` dictionaries cross-reference
-/// reconstruction inspects while looking for one with a usable `/Root`.
+/// Cap on how many trailing `trailer` dictionaries are inspected for a `/Root`.
 const MAX_TRAILER_CANDIDATES: usize = 16;
 
 /// PDF metadata extracted without loading the entire document.
@@ -597,8 +593,6 @@ impl Reader<'_> {
 
         let version = parser::header(self.buffer, self.strict).ok_or(ParseError::InvalidFileHeader)?;
 
-        // Same resolution order as `read`, including the brute-force
-        // reconstruction fallback.
         let (xref, trailer) = match self.resolve_xref_and_trailer() {
             Ok(resolved) => resolved,
             Err(err) => match self.reconstruct_xref_and_trailer() {
@@ -802,11 +796,7 @@ impl Reader<'_> {
             self.document.binary_mark = binary_mark;
         }
 
-        // Resolve the cross-reference table/stream and trailer following the
-        // standard order: `startxref`, slight-offset correction, then the
-        // `/Prev` and `/XRefStm` chain. Only if every step of that pipeline
-        // fails, fall back to reconstructing the table from object markers
-        // scanned in the raw bytes.
+        // Fall back to reconstruction only after all standard resolution fails.
         let (xref, trailer) = match self.resolve_xref_and_trailer() {
             Ok(resolved) => resolved,
             Err(err) => match self.reconstruct_xref_and_trailer() {
@@ -1358,9 +1348,8 @@ impl Reader<'_> {
         parser::xref_and_trailer(&self.buffer[offset..], self)
     }
 
-    /// Resolve the cross-reference table/stream and trailer dictionary,
-    /// including the `/Prev` chain of linearized or incrementally updated
-    /// documents, and record the resolved start offset on the document.
+    /// Resolve the cross-reference table/stream and trailer, including the
+    /// `/Prev` chain, and record the resolved start offset on the document.
     fn resolve_xref_and_trailer(&mut self) -> Result<(Xref, Dictionary)> {
         let xref_start = Self::get_xref_start(self.buffer)?;
         if xref_start > self.buffer.len() {
@@ -1411,25 +1400,14 @@ impl Reader<'_> {
         Ok((xref, trailer))
     }
 
-    /// Last-resort recovery: rebuild a cross-reference table by scanning the
-    /// raw bytes for indirect-object headers (`N G obj`) and locating the
-    /// newest parsable `trailer` dictionary with a usable `/Root`. This mirrors
-    /// the reconstruction mode of pdf.js, qpdf, poppler and pypdf for files
-    /// whose `startxref`, cross-reference table or cross-reference stream
-    /// cannot be resolved at all.
-    ///
-    /// Object streams need no special treatment: their container objects are
-    /// ordinary top-level markers, so the regular loading pass decompresses
-    /// them once the rebuilt table points at the containers.
-    ///
-    /// Returns `None` when strict mode forbids recovery or nothing usable was
-    /// found; the caller then surfaces the original resolution error.
+    /// Last-resort recovery: rebuild the cross-reference table by scanning the
+    /// raw bytes for indirect-object headers and locating a trailer with a
+    /// usable `/Root`. Returns `None` (caller keeps the original error) when
+    /// strict mode forbids recovery or nothing usable was found.
     fn reconstruct_xref_and_trailer(&mut self) -> Option<(Xref, Dictionary)> {
         if self.strict {
             return None;
         }
-        // `XrefEntry::Normal` offsets are u32; refuse inputs whose byte offsets
-        // cannot be represented instead of wrapping them.
         u32::try_from(self.buffer.len()).ok()?;
 
         let markers = Self::scan_object_markers(self.buffer);
@@ -1439,16 +1417,13 @@ impl Reader<'_> {
 
         let mut xref = Xref::new(markers.len() as u32, XrefType::CrossReferenceTable);
         for (offset, (number, generation)) in markers {
-            // Later revisions of an object win because incremental updates
-            // append, so the scan meets their headers last.
+            // Incremental updates append, so later revisions win.
             xref.insert(number, XrefEntry::Normal { offset, generation });
         }
 
         let (_trailer_pos, trailer) = self.find_latest_trailer(&xref)?;
-        // deliberate: record end-of-file rather than the trailer position.
-        // Every scanned marker provides its own boundary through the sorted
-        // offset index, so no object read must stop early, and no misleading
-        // `/Prev` target exists for a table that was never on disk.
+        // deliberate: end-of-file, since each scanned offset carries its own
+        // read boundary and there is no real on-disk table to point at.
         self.document.xref_start = self.buffer.len();
 
         warn!(
@@ -1458,16 +1433,11 @@ impl Reader<'_> {
         Some((xref, trailer))
     }
 
-    /// Collect byte offsets and IDs of every indirect-object header
-    /// (`N G obj`) in the buffer with one left-to-right pass. Offsets come
-    /// from scan positions, never from numbers read out of the file, so the
-    /// result cannot be inflated by attacker-controlled values beyond the
-    /// [`MAX_RECONSTRUCTED_OBJECTS`] cap.
+    /// Collect `(offset, id)` of every indirect-object header in one pass.
     fn scan_object_markers(buffer: &[u8]) -> Vec<(u32, ObjectId)> {
         let mut markers = Vec::new();
         for pos in 0..buffer.len() {
-            // Anchor at digit-run starts so overlapping headers inside longer
-            // digit runs ("12 0 obj" vs "2 0 obj") match only once.
+            // Anchor at digit-run starts to avoid overlapping matches.
             if !buffer[pos].is_ascii_digit() || pos > 0 && buffer[pos - 1].is_ascii_digit() {
                 continue;
             }
@@ -1484,13 +1454,9 @@ impl Reader<'_> {
         markers
     }
 
-    /// Parse an indirect-object header (`N G obj`) at the start of `input`.
-    /// The byte following `obj` must be whitespace, a delimiter, or
-    /// end-of-input so tokens such as `objects` never match.
+    /// Parse an `N G obj` header; the byte after `obj` must end the token.
     fn parse_object_header(input: &[u8]) -> Option<ObjectId> {
-        // deliberate: digit runs are capped at the widths of u32/u16; longer
-        // runs cannot be conforming object numbers but could be pathological
-        // padding whose per-position rescans would waste time.
+        // deliberate: caps at u32/u16 width bound work on pathological padding.
         fn digits(input: &[u8], cap: usize) -> Option<(&[u8], &[u8])> {
             let n = input.iter().take_while(|b| b.is_ascii_digit()).count();
             (0 < n && n <= cap).then(|| input.split_at(n))
@@ -1518,10 +1484,7 @@ impl Reader<'_> {
         Some((number, generation))
     }
 
-    /// Scan backwards for the newest parsable `trailer` dictionary whose
-    /// `/Root` entry references an object found by the marker scan; later
-    /// revisions win because incremental updates append their trailers.
-    /// Returns the keyword's byte position alongside the dictionary.
+    /// Newest backwards-scanned `trailer` whose `/Root` references a scanned object.
     fn find_latest_trailer(&self, xref: &Xref) -> Option<(usize, Dictionary)> {
         let mut bound = self.buffer.len();
         for _ in 0..MAX_TRAILER_CANDIDATES {
@@ -1537,13 +1500,11 @@ impl Reader<'_> {
             let Ok((_, dict)) = parser::dictionary(&after_keyword[dict_start..]) else {
                 continue;
             };
-            // A trailer is only usable when its catalog is among the scanned
-            // objects; otherwise keep looking in older revisions.
-            let root_is_present = dict
+            if dict
                 .get(b"Root")
                 .and_then(Object::as_reference)
-                .is_ok_and(|root| xref.entries.contains_key(&root.0));
-            if root_is_present {
+                .is_ok_and(|root| xref.entries.contains_key(&root.0))
+            {
                 return Some((pos, dict));
             }
         }
@@ -1896,11 +1857,8 @@ fn object_marker_parsing_accepts_only_real_headers() {
     assert_eq!(Reader::parse_object_header(b"007 0 obj\n"), Some((7, 0)));
     assert_eq!(Reader::parse_object_header(b"5 2 obj>>"), Some((5, 2)));
     assert_eq!(Reader::parse_object_header(b"12\t3\r\nobj["), Some((12, 3)));
-
-    // The token after `obj` must not run into further letters or digits.
     assert_eq!(Reader::parse_object_header(b"2 0 objects"), None);
     assert_eq!(Reader::parse_object_header(b"99 88 objx"), None);
-    // Numbers beyond u32/u16 and malformed separators are rejected.
     assert_eq!(Reader::parse_object_header(b"12345678901 0 obj"), None);
     assert_eq!(Reader::parse_object_header(b"1 70000 obj"), None);
     assert_eq!(Reader::parse_object_header(b"1 0obj"), None);

--- a/tests/xref_reconstruction.rs
+++ b/tests/xref_reconstruction.rs
@@ -252,10 +252,7 @@ fn reconstructed_max_id_covers_object_stream_members() {
     let pages = b"<< /Type /Pages /Kids [6 0 R] /Count 1 >>";
     let page = b"<< /Type /Page /Parent 5 0 R /MediaBox [0 0 200 200] >>";
     let info = b"<< /Type /Info /Producer (x) >>";
-    let mut offsets = append_objects(
-        &mut pdf,
-        &[(1, 0, "<< /Type /Catalog /Pages 5 0 R >>".to_string())],
-    );
+    let mut offsets = append_objects(&mut pdf, &[(1, 0, "<< /Type /Catalog /Pages 5 0 R >>".to_string())]);
     let objstm_offset = pdf.len();
     append_objstm(&mut pdf, 2, &[(5, pages), (6, page), (7, info)]);
     offsets.push((2, objstm_offset));
@@ -305,9 +302,7 @@ fn reconstruction_bounds_unterminated_stream_by_its_length_hint() {
     let mut offsets = append_objects(&mut pdf, &page_tree_bodies());
     let payload = b"1 0 obj\n<< /Bogus true >>\nendobj\n";
     let fourth_offset = pdf.len();
-    pdf.extend_from_slice(
-        format!("4 0 obj\n<< /Length {} >>\nstream\n", payload.len()).as_bytes(),
-    );
+    pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", payload.len()).as_bytes());
     pdf.extend_from_slice(payload);
     pdf.extend_from_slice(b"endstrXXm\nendobj\n");
     offsets.push((4, fourth_offset));
@@ -349,14 +344,8 @@ fn reconstruction_accepts_indented_object_headers() {
     let second_offset = pdf.len();
     pdf.extend_from_slice(b" 2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
     let third_offset = pdf.len();
-    pdf.extend_from_slice(
-        b"\t3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>\nendobj\n",
-    );
-    let offsets = vec![
-        (1, first_offset),
-        (2, second_offset),
-        (3, third_offset),
-    ];
+    pdf.extend_from_slice(b"\t3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>\nendobj\n");
+    let offsets = vec![(1, first_offset), (2, second_offset), (3, third_offset)];
     let broken_startxref = pdf.len() + 4096;
     append_xref_trailer(&mut pdf, &offsets, "<< /Size 4 /Root 1 0 R >>", broken_startxref);
 

--- a/tests/xref_reconstruction.rs
+++ b/tests/xref_reconstruction.rs
@@ -1,0 +1,164 @@
+use lopdf::{Document, LoadOptions, Object};
+
+/// Append `bodies` as consecutive top-level objects, returning each object's
+/// `(number, physical offset)` including the file header's width.
+fn append_objects(pdf: &mut Vec<u8>, bodies: &[(u32, u16, String)]) -> Vec<(u32, usize)> {
+    let mut offsets = Vec::new();
+    for (number, generation, body) in bodies {
+        offsets.push((*number, pdf.len()));
+        pdf.extend_from_slice(format!("{number} {generation} obj\n{body}\nendobj\n").as_bytes());
+    }
+    offsets
+}
+
+/// Append a classic cross-reference table, trailer, and `startxref` line that
+/// records `startxref_value` — tests pass deliberately broken values to force
+/// the reconstruction fallback.
+fn append_xref_trailer(pdf: &mut Vec<u8>, offsets: &[(u32, usize)], trailer: &str, startxref_value: usize) {
+    pdf.extend_from_slice(b"xref\n");
+    pdf.extend_from_slice(format!("0 {}\n0000000000 65535 f \n", offsets.len() + 1).as_bytes());
+    for (_, offset) in offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(format!("trailer\n{trailer}\nstartxref\n{startxref_value}\n%%EOF\n").as_bytes());
+}
+
+/// A one-page document whose content stream embeds two object-like decoy
+/// tokens (`99 88 objx`, `1 2 objects`) that must never become markers.
+fn sample_bodies() -> Vec<(u32, u16, String)> {
+    let contents = b"BT /F1 12 Tf 20 100 Td (Hello World) Tj (99 88 objx) Tj (1 2 objects) Tj ET";
+    vec![
+        (1, 0, "<< /Type /Catalog /Pages 2 0 R >>".to_string()),
+        (2, 0, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string()),
+        (
+            3,
+            0,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>".to_string(),
+        ),
+        (
+            4,
+            0,
+            format!(
+                "<< /Length {} >>\nstream\n{}\nendstream",
+                contents.len(),
+                std::str::from_utf8(contents).unwrap()
+            ),
+        ),
+    ]
+}
+
+fn new_pdf() -> Vec<u8> {
+    b"%PDF-1.4\n".to_vec()
+}
+
+#[test]
+fn startxref_past_eof_is_reconstructed_from_object_markers() {
+    let mut pdf = new_pdf();
+    let offsets = append_objects(&mut pdf, &sample_bodies());
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 5 /Root 1 0 R >>", broken_startxref);
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert_eq!(document.get_pages().len(), 1);
+    assert!(document.trailer.get(b"Root").is_ok());
+
+    // The object-like tokens inside the content stream must not have become
+    // markers shadowing or inventing objects.
+    assert!(document.get_object((99, 0)).is_err());
+
+    // The metadata-only loader shares the same fallback.
+    let metadata = Document::load_metadata_mem(&pdf).unwrap();
+    assert_eq!(metadata.page_count, 1);
+}
+
+#[test]
+fn strict_mode_does_not_reconstruct() {
+    let mut pdf = new_pdf();
+    let offsets = append_objects(&mut pdf, &sample_bodies());
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 5 /Root 1 0 R >>", broken_startxref);
+    let strict = LoadOptions {
+        strict: true,
+        ..Default::default()
+    };
+
+    assert!(Document::load_mem_with_options(&pdf, strict).is_err());
+}
+
+#[test]
+fn startxref_pointing_into_a_stream_falls_back_to_reconstruction() {
+    // The pointer lands mid-payload of object 4's content stream, more than a
+    // recovery window away from any xref keyword, so neither the standard
+    // resolution nor the slight-offset correction can succeed.
+    let mut pdf = new_pdf();
+    let offsets = append_objects(&mut pdf, &sample_bodies());
+    let payload = pdf.windows(7).position(|window| window == b"stream\n").unwrap() + 7;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 5 /Root 1 0 R >>", payload + 30);
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert_eq!(document.get_pages().len(), 1);
+    let Object::Stream(stream) = document.get_object((4, 0)).unwrap() else {
+        panic!("reconstructed object must remain a stream");
+    };
+    assert!(stream.content.starts_with(b"BT"));
+}
+
+#[test]
+fn reconstruction_prefers_newer_revisions_of_duplicated_objects() {
+    // Two revisions appended like an incremental update; the second redefines
+    // object 2 and its `startxref` is corrupted. The scan meets both headers
+    // and must keep the later one, along with the later trailer.
+    let mut pdf = new_pdf();
+    let mut offsets = append_objects(&mut pdf, &sample_bodies());
+    let first_startxref = pdf.len();
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 5 /Root 1 0 R >>", first_startxref);
+
+    let revised_pages = "<< /Type /Pages /Kids [3 0 R] /Count 42 >>";
+    let revision_offset = pdf.len();
+    pdf.extend_from_slice(format!("2 0 obj\n{revised_pages}\nendobj\n").as_bytes());
+    offsets.retain(|(number, _)| *number != 2);
+    offsets.push((2, revision_offset));
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 5 /Root 1 0 R >>", broken_startxref);
+
+    let document = Document::load_mem(&pdf).unwrap();
+    let count = document
+        .get_object((2, 0))
+        .unwrap()
+        .as_dict()
+        .unwrap()
+        .get(b"Count")
+        .unwrap()
+        .as_i64()
+        .unwrap();
+    assert_eq!(count, 42);
+    assert_eq!(document.get_pages().len(), 1);
+}
+
+#[test]
+fn reconstruction_skips_trailers_whose_root_was_not_found() {
+    // A trailing bogus revision references catalog object 77, which does not
+    // exist; reconstruction must walk back to the trailer with a usable Root.
+    let mut pdf = new_pdf();
+    let offsets = append_objects(&mut pdf, &sample_bodies());
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 5 /Root 1 0 R >>", broken_startxref);
+    pdf.extend_from_slice(b"trailer\n<< /Size 12 /Root 77 0 R >>\n%%EOF\n");
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert_eq!(document.get_pages().len(), 1);
+    assert!(document.get_object((77, 0)).is_err());
+}
+
+#[test]
+fn reconstruction_fails_when_no_trailer_has_a_usable_root() {
+    // Without any parsable `/Root` there is nothing to recover to; the
+    // original resolution error must surface instead.
+    let mut pdf = new_pdf();
+    append_objects(&mut pdf, &sample_bodies());
+    pdf.extend_from_slice(b"trailer\n<< /Size 5 >>\n");
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &[], "", broken_startxref);
+
+    assert!(Document::load_mem(&pdf).is_err());
+}

--- a/tests/xref_reconstruction.rs
+++ b/tests/xref_reconstruction.rs
@@ -1,7 +1,6 @@
 use lopdf::{Document, LoadOptions, Object};
 
-/// Append `bodies` as consecutive top-level objects, returning each object's
-/// `(number, physical offset)` including the file header's width.
+/// Append objects, returning each one's `(number, physical offset)`.
 fn append_objects(pdf: &mut Vec<u8>, bodies: &[(u32, u16, String)]) -> Vec<(u32, usize)> {
     let mut offsets = Vec::new();
     for (number, generation, body) in bodies {
@@ -11,9 +10,8 @@ fn append_objects(pdf: &mut Vec<u8>, bodies: &[(u32, u16, String)]) -> Vec<(u32,
     offsets
 }
 
-/// Append a classic cross-reference table, trailer, and `startxref` line that
-/// records `startxref_value` — tests pass deliberately broken values to force
-/// the reconstruction fallback.
+/// Append a cross-reference table and trailer whose `startxref` records
+/// `startxref_value` (tests pass broken values to force the fallback).
 fn append_xref_trailer(pdf: &mut Vec<u8>, offsets: &[(u32, usize)], trailer: &str, startxref_value: usize) {
     pdf.extend_from_slice(b"xref\n");
     pdf.extend_from_slice(format!("0 {}\n0000000000 65535 f \n", offsets.len() + 1).as_bytes());
@@ -23,8 +21,8 @@ fn append_xref_trailer(pdf: &mut Vec<u8>, offsets: &[(u32, usize)], trailer: &st
     pdf.extend_from_slice(format!("trailer\n{trailer}\nstartxref\n{startxref_value}\n%%EOF\n").as_bytes());
 }
 
-/// A one-page document whose content stream embeds two object-like decoy
-/// tokens (`99 88 objx`, `1 2 objects`) that must never become markers.
+/// One-page document whose content stream embeds object-like decoy tokens
+/// (`99 88 objx`, `1 2 objects`) that must never become markers.
 fn sample_bodies() -> Vec<(u32, u16, String)> {
     let contents = b"BT /F1 12 Tf 20 100 Td (Hello World) Tj (99 88 objx) Tj (1 2 objects) Tj ET";
     vec![
@@ -62,11 +60,8 @@ fn startxref_past_eof_is_reconstructed_from_object_markers() {
     assert_eq!(document.get_pages().len(), 1);
     assert!(document.trailer.get(b"Root").is_ok());
 
-    // The object-like tokens inside the content stream must not have become
-    // markers shadowing or inventing objects.
     assert!(document.get_object((99, 0)).is_err());
 
-    // The metadata-only loader shares the same fallback.
     let metadata = Document::load_metadata_mem(&pdf).unwrap();
     assert_eq!(metadata.page_count, 1);
 }
@@ -87,9 +82,7 @@ fn strict_mode_does_not_reconstruct() {
 
 #[test]
 fn startxref_pointing_into_a_stream_falls_back_to_reconstruction() {
-    // The pointer lands mid-payload of object 4's content stream, more than a
-    // recovery window away from any xref keyword, so neither the standard
-    // resolution nor the slight-offset correction can succeed.
+    // Pointer lands mid-payload, beyond the correction window.
     let mut pdf = new_pdf();
     let offsets = append_objects(&mut pdf, &sample_bodies());
     let payload = pdf.windows(7).position(|window| window == b"stream\n").unwrap() + 7;
@@ -105,9 +98,7 @@ fn startxref_pointing_into_a_stream_falls_back_to_reconstruction() {
 
 #[test]
 fn reconstruction_prefers_newer_revisions_of_duplicated_objects() {
-    // Two revisions appended like an incremental update; the second redefines
-    // object 2 and its `startxref` is corrupted. The scan meets both headers
-    // and must keep the later one, along with the later trailer.
+    // A second revision redefines object 2; its startxref is corrupted.
     let mut pdf = new_pdf();
     let mut offsets = append_objects(&mut pdf, &sample_bodies());
     let first_startxref = pdf.len();
@@ -137,8 +128,7 @@ fn reconstruction_prefers_newer_revisions_of_duplicated_objects() {
 
 #[test]
 fn reconstruction_skips_trailers_whose_root_was_not_found() {
-    // A trailing bogus revision references catalog object 77, which does not
-    // exist; reconstruction must walk back to the trailer with a usable Root.
+    // A trailing bogus trailer references absent catalog object 77.
     let mut pdf = new_pdf();
     let offsets = append_objects(&mut pdf, &sample_bodies());
     let broken_startxref = pdf.len() + 4096;
@@ -152,8 +142,6 @@ fn reconstruction_skips_trailers_whose_root_was_not_found() {
 
 #[test]
 fn reconstruction_fails_when_no_trailer_has_a_usable_root() {
-    // Without any parsable `/Root` there is nothing to recover to; the
-    // original resolution error must surface instead.
     let mut pdf = new_pdf();
     append_objects(&mut pdf, &sample_bodies());
     pdf.extend_from_slice(b"trailer\n<< /Size 5 >>\n");

--- a/tests/xref_reconstruction.rs
+++ b/tests/xref_reconstruction.rs
@@ -150,3 +150,244 @@ fn reconstruction_fails_when_no_trailer_has_a_usable_root() {
 
     assert!(Document::load_mem(&pdf).is_err());
 }
+
+/// A one-page document whose uncompressed content stream embeds whole
+/// object-header lines that must never be scanned as markers.
+fn sample_bodies_with_decoy_stream() -> Vec<(u32, u16, String)> {
+    let contents = b"(1 0 obj)\nBT ET\n5 0 obj";
+    let mut bodies = sample_bodies();
+    bodies[3] = (
+        4,
+        0,
+        format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            contents.len(),
+            std::str::from_utf8(contents).unwrap()
+        ),
+    );
+    bodies
+}
+
+#[test]
+fn reconstruction_ignores_object_headers_inside_streams() {
+    // The decoys sit at line starts inside the payload; the `(1 0 obj)` one
+    // must not overwrite the genuine catalog entry for object 1.
+    let mut pdf = new_pdf();
+    let offsets = append_objects(&mut pdf, &sample_bodies_with_decoy_stream());
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 6 /Root 1 0 R >>", broken_startxref);
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert_eq!(document.get_pages().len(), 1);
+    assert!(document.get_object((1, 0)).unwrap().as_dict().unwrap().has(b"Type"));
+    assert!(document.get_object((5, 0)).is_err());
+}
+
+#[test]
+fn reconstruction_rejects_absurd_object_numbers() {
+    // A comment forging a huge object header would inflate size/max_id via
+    // Xref::insert and eventually overflow new_object_id().
+    let mut pdf = new_pdf();
+    let offsets = append_objects(&mut pdf, &sample_bodies());
+    pdf.extend_from_slice(b"%4294967290 0 obj\n");
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 5 /Root 1 0 R >>", broken_startxref);
+
+    let mut document = Document::load_mem(&pdf).unwrap();
+    assert_eq!(document.max_id, 4);
+    assert_eq!(document.new_object_id(), (5, 0));
+}
+
+#[test]
+fn reconstructed_size_counts_object_numbers_not_physical_copies() {
+    // Two revisions of every object: 8 markers, but the highest number is 4.
+    let mut pdf = new_pdf();
+    let mut offsets = append_objects(&mut pdf, &sample_bodies());
+    offsets.extend(append_objects(&mut pdf, &sample_bodies()));
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 9 /Root 1 0 R >>", broken_startxref);
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert_eq!(document.max_id, 4);
+    assert_eq!(document.reference_table.size, 5);
+    assert_eq!(document.get_pages().len(), 1);
+}
+
+/// Append an `/ObjStm` container holding `members` (object number + body).
+fn append_objstm(pdf: &mut Vec<u8>, number: u32, members: &[(u32, &[u8])]) {
+    use std::io::Write as _;
+
+    use flate2::Compression;
+    use flate2::write::ZlibEncoder;
+
+    let mut index = String::new();
+    let mut body: Vec<u8> = Vec::new();
+    for (id, data) in members {
+        index.push_str(&format!("{id} {}\n", body.len()));
+        body.extend_from_slice(data);
+    }
+    let first = index.len();
+    let content = [index.as_bytes(), body.as_slice()].concat();
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&content).unwrap();
+    let compressed = encoder.finish().unwrap();
+
+    pdf.extend_from_slice(
+        format!(
+            "{number} 0 obj\n<< /Type /ObjStm /N {} /First {first} /Length {} /Filter /FlateDecode >>\nstream\n",
+            members.len(),
+            compressed.len()
+        )
+        .as_bytes(),
+    );
+    pdf.extend_from_slice(&compressed);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+}
+
+#[test]
+fn reconstructed_max_id_covers_object_stream_members() {
+    // Objects 5-7 live inside the ObjStm container 2; only objects 1 and 2
+    // are scanned as markers, so max_id must still reach 7 after loading.
+    let mut pdf = new_pdf();
+    let pages = b"<< /Type /Pages /Kids [6 0 R] /Count 1 >>";
+    let page = b"<< /Type /Page /Parent 5 0 R /MediaBox [0 0 200 200] >>";
+    let info = b"<< /Type /Info /Producer (x) >>";
+    let mut offsets = append_objects(
+        &mut pdf,
+        &[(1, 0, "<< /Type /Catalog /Pages 5 0 R >>".to_string())],
+    );
+    let objstm_offset = pdf.len();
+    append_objstm(&mut pdf, 2, &[(5, pages), (6, page), (7, info)]);
+    offsets.push((2, objstm_offset));
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 8 /Root 1 0 R >>", broken_startxref);
+
+    let mut document = Document::load_mem(&pdf).unwrap();
+    assert_eq!(document.get_pages().len(), 1);
+    assert!(document.get_object((7, 0)).is_ok());
+    assert_eq!(document.max_id, 7);
+    assert_eq!(document.new_object_id(), (8, 0));
+}
+
+/// Catalog, pages, and page bodies without the content stream object.
+fn page_tree_bodies() -> Vec<(u32, u16, String)> {
+    vec![
+        (1, 0, "<< /Type /Catalog /Pages 2 0 R >>".to_string()),
+        (2, 0, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string()),
+        (
+            3,
+            0,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>".to_string(),
+        ),
+    ]
+}
+
+#[test]
+fn reconstruction_recovers_objects_after_a_stream_without_endstream() {
+    // The damaged stream cannot bound its payload; objects written after it
+    // must still be scanned instead of dropping the whole fallback.
+    let mut pdf = new_pdf();
+    pdf.extend_from_slice(b"4 0 obj\n<< /Length 5 >>\nstream\nBT ET\nendstrXXm\nendobj\n");
+    let offsets = append_objects(&mut pdf, &page_tree_bodies());
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 5 /Root 1 0 R >>", broken_startxref);
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert_eq!(document.get_pages().len(), 1);
+    assert!(document.get_object((1, 0)).is_ok());
+}
+
+#[test]
+fn reconstruction_bounds_unterminated_stream_by_its_length_hint() {
+    // Without `endstream` the payload is unbounded; honouring the direct
+    // /Length keeps its line-start decoy from shadowing the catalog.
+    let mut pdf = new_pdf();
+    let mut offsets = append_objects(&mut pdf, &page_tree_bodies());
+    let payload = b"1 0 obj\n<< /Bogus true >>\nendobj\n";
+    let fourth_offset = pdf.len();
+    pdf.extend_from_slice(
+        format!("4 0 obj\n<< /Length {} >>\nstream\n", payload.len()).as_bytes(),
+    );
+    pdf.extend_from_slice(payload);
+    pdf.extend_from_slice(b"endstrXXm\nendobj\n");
+    offsets.push((4, fourth_offset));
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 5 /Root 1 0 R >>", broken_startxref);
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert_eq!(document.get_pages().len(), 1);
+    assert!(document.get_object((1, 0)).unwrap().as_dict().unwrap().has(b"Type"));
+}
+
+#[test]
+fn reconstruction_does_not_use_a_previous_objects_length_hint() {
+    // Object 4's damaged stream carries no /Length; the stale `/Length 300`
+    // from object 5's dictionary must not skip past objects 1-3.
+    let mut pdf = new_pdf();
+    let fifth_offset = pdf.len();
+    pdf.extend_from_slice(b"5 0 obj\n<< /Length 300 >>\nstream\nBT ET\nendstream\nendobj\n");
+    let fourth_offset = pdf.len();
+    pdf.extend_from_slice(b"4 0 obj\n<< /Type /XObject >>\nstream\nPAYLOAD\nendstrXXm\nendobj\n");
+    let mut offsets = append_objects(&mut pdf, &page_tree_bodies());
+    offsets.push((4, fourth_offset));
+    offsets.push((5, fifth_offset));
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 6 /Root 1 0 R >>", broken_startxref);
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert_eq!(document.get_pages().len(), 1);
+    assert!(document.get_object((1, 0)).unwrap().as_dict().unwrap().has(b"Type"));
+}
+
+#[test]
+fn reconstruction_accepts_indented_object_headers() {
+    // Real generators indent object headers; blanks between the line start
+    // and the digits must not hide the marker.
+    let mut pdf = new_pdf();
+    let first_offset = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    let second_offset = pdf.len();
+    pdf.extend_from_slice(b" 2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    let third_offset = pdf.len();
+    pdf.extend_from_slice(
+        b"\t3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>\nendobj\n",
+    );
+    let offsets = vec![
+        (1, first_offset),
+        (2, second_offset),
+        (3, third_offset),
+    ];
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 4 /Root 1 0 R >>", broken_startxref);
+
+    let document = Document::load_mem(&pdf).unwrap();
+    assert_eq!(document.get_pages().len(), 1);
+    assert_eq!(document.max_id, 3);
+}
+
+#[test]
+fn incremental_update_omits_prev_without_a_real_xref_location() {
+    // Reconstructed document: no on-disk xref exists, so no /Prev may point
+    // at end-of-file.
+    let mut pdf = new_pdf();
+    let offsets = append_objects(&mut pdf, &sample_bodies());
+    let broken_startxref = pdf.len() + 4096;
+    append_xref_trailer(&mut pdf, &offsets, "<< /Size 5 /Root 1 0 R >>", broken_startxref);
+    let document = Document::load_mem(&pdf).unwrap();
+
+    let update = Document::new_from_prev(&document);
+    assert!(update.trailer.get(b"Prev").is_err());
+
+    // Contrast: a normally loaded document keeps its /Prev chain intact.
+    let mut valid = new_pdf();
+    let valid_offsets = append_objects(&mut valid, &sample_bodies());
+    let xref_pos = valid.len();
+    append_xref_trailer(&mut valid, &valid_offsets, "<< /Size 5 /Root 1 0 R >>", xref_pos);
+    let valid_document = Document::load_mem(&valid).unwrap();
+
+    let valid_update = Document::new_from_prev(&valid_document);
+    assert_eq!(
+        valid_update.trailer.get(b"Prev").unwrap().as_i64().unwrap(),
+        xref_pos as i64
+    );
+}


### PR DESCRIPTION
## Summary

- Adds a last-resort, bounded brute-force cross-reference reconstruction to lenient loading: when `startxref` / xref-table / xref-stream resolution fails entirely, lopdf now scans the raw bytes for indirect-object headers (`N G obj`), rebuilds an xref table from the scan offsets, and loads the document using the newest parsable `trailer` dictionary whose `/Root` references a scanned object.
- The fallback runs only after every existing recovery step fails (`startxref` lookup, slight-offset correction, then the `/Prev` and `/XRefStm` chain). Strict mode keeps rejecting such files.
- Object streams need no special handling: their containers are ordinary top-level markers, so the regular loading pass decompresses them once the rebuilt table points at them.
- `Document::read` and the metadata-only loaders share one new `resolve_xref_and_trailer` helper plus the same fallback; downstream behavior after reconstruction equals a normally loaded document.

## Bounds & safety

Input is untrusted, so the scan is deliberately conservative:

- Single O(n) left-to-right pass over the buffer. Marker offsets come from scan positions, never from numbers parsed out of the file, so no allocation can be inflated by attacker-controlled integers.
- Fixed caps: `MAX_RECONSTRUCTED_OBJECTS = 1_000_000` entries and `MAX_TRAILER_CANDIDATES = 16` trailer dictionaries.
- Files larger than `u32::MAX` bytes are not reconstructed (`XrefEntry::Normal::offset` is u32); digit runs are capped at 10/5 digits (u32/u16 width).
- A marker only counts when the byte after `obj` is whitespace, a delimiter, or EOF; markers are anchored at digit-run starts so overlapping headers match once.
- Duplicate object numbers resolve to the latest revision, because incremental updates append.
- Trailer candidates must parse as dictionaries and their `/Root` must reference an object found by the scan; otherwise older revisions are tried, and if none qualifies the original resolution error surfaces unchanged.
- Reconstruction records `document.xref_start = buffer.len()` (deliberate: each scanned offset carries its own read boundary, and there is no real on-disk table to point `/Prev` at).

## Validation

- `cargo fmt --all -- --check` → pass
- `cargo clippy --all-targets -- -D warnings` → pass
- `cargo clippy --all-targets --all-features -- -D warnings` → pass
- `cargo test` → 225 passed, 3 ignored (pre-existing), 0 failed — includes 6 new integration tests in `tests/xref_reconstruction.rs` (past-EOF startxref, pointer into stream payload, strict-mode rejection, newest-revision preference, unusable-trailer skip, no-usable-root failure) and unit tests for object-header parsing
- `cargo test --features async` → all suites pass